### PR TITLE
Add a space for padding.

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -198,7 +198,7 @@ Prompt.prototype.prefix = function( str ) {
 
 Prompt.prototype.suffix = function( str ) {
   str || (str = "");
-  return (str.length < 1 || /([a-z])$/i.test(str)) ? str + ": " : str;
+  return (str.length < 1 || /([a-z])$/i.test(str) ? str + ":" : str).trim() + " ";
 };
 
 

--- a/test/specs/prompts/base.js
+++ b/test/specs/prompts/base.js
@@ -18,8 +18,8 @@ describe("`base` prompt (e.g. prompt helpers)", function() {
   });
 
   it("`suffix` method should only add ':' if last char is a letter", function() {
-    expect(this.base.suffix("m:")).to.equal("m:");
-    expect(this.base.suffix("m?")).to.equal("m?");
+    expect(this.base.suffix("m:")).to.equal("m: ");
+    expect(this.base.suffix("m?")).to.equal("m? ");
     expect(this.base.suffix("m")).to.equal("m: ");
     expect(this.base.suffix("m ")).to.equal("m ");
     expect(this.base.suffix()).to.equal(": ");


### PR DESCRIPTION
Hello! I was running into scenarios like:

```
Would you like to include Twitter Bootstrap for Sass?(Y/n)
.. and ..
Select something from the list below:(Use arrow keys)
  [ ] hi
  [ ] what
  [X] oh
```

You may have a better way of accomplishing this, but this commit just adds in a space at the end of a print, so above turns into:

```
Would you like to include Twitter Bootstrap for Sass? (Y/n)
.. and ..
Select something from the list below: (Use arrow keys)
  [ ] hi
  [ ] what
  [X] oh
```

That's all I've got! Thanks for working so hard on this :)
