### PR TITLE
Readline should emit the keypress event if its not null

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -122,7 +122,9 @@ cli.onKeypress = function( s, key ) {
   // Ignore `enter` key (readline `line` event is the only one we care for)
   if ( key && (key.name === "enter" || key.name === "return") ) return;
 
-  this.rl.emit( "keypress", s, key );
+  if ( this.rl ) {
+    this.rl.emit( "keypress", s, key );
+  }
 }.bind(cli);
 
 


### PR DESCRIPTION
SIGINT event is handled before the CTRL+C's keypress. Inquirer breaks force closes by trying to emit an event to a null readline object. Reproducible on `yeoman`, stack trace is below:

```
TypeError: Cannot call method 'emit' of null
    at Object.<anonymous> (/Users/burcu/yo/node_modules/yeoman-generator/node_modules/inquirer/lib/inquirer.js:119:11)
    at ReadStream.EventEmitter.emit (events.js:117:20)
    at emitKey (readline.js:1089:12)
    at ReadStream.onData (readline.js:834:14)
    at ReadStream.EventEmitter.emit (events.js:95:17)
    at ReadStream.<anonymous> (_stream_readable.js:720:14)
    at ReadStream.EventEmitter.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:392:10)
    at emitReadable (_stream_readable.js:388:5)
    at readableAddChunk (_stream_readable.js:150:9)
```
