### PR TITLE
Add support for passing a function as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A question object is a `hash` containing question related values:
 `list`, `rawlist`
 + **name**: (String) The name to use when storing the answer in the anwers hash.
 + **message**: (String) The question to print.
-+ **default**: (String) Default value to use if nothing is entered
++ **default**: (String|Function) Default value to use if nothing is entered, or a function that returns the default value. If defined as a function, the first parameter will be the current inquirer session answers. 
 + **choices**: (Array|Function) Choices array or a function returning a choices array. If defined as a function, the first parameter will be the current inquirer session answers.  
 Array values can be simple `strings`, or `objects` containing a `name` (to display) and a `value` properties (to save in the answers hash).
 + **validate**: (Function) Receive the user input and should return `true` if the value is valid, and an error message (`String`) otherwise. If `false` is returned, a default error message is provided.

--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -90,6 +90,10 @@ cli.prompt = function( questions, allDone ) {
       question.type = "input";
     }
 
+    if ( _.isFunction(question.default) ) {
+      question.default = question.default( this.answers );
+    }
+
     if ( _.isFunction(question.choices) ) {
       question.choices = question.choices( this.answers );
     }

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -90,6 +90,36 @@ describe("inquirer.prompt", function() {
     inquirer.rl.emit("line");
   });
 
+  it("should parse `default` if passed as a function", function( done ) {
+    var stubDefault = "foo";
+    inquirer.prompts.stub = function( params ) {
+      this.opt = {
+        when: function() { return true; }
+      };
+      expect(params.default).to.equal(stubDefault);
+      done();
+    };
+    inquirer.prompts.stub.prototype.run = function() {};
+
+    var prompts = [{
+      type: "input",
+      name: "name1",
+      message: "message",
+      default: "bar"
+    }, {
+      type: "stub",
+      name: "name",
+      message: "message",
+      default: function( answers ) {
+        expect(answers.name1).to.equal("bar");
+        return stubDefault;
+      }
+    }];
+
+    inquirer.prompt(prompts, function() {});
+    inquirer.rl.emit("line");
+  });
+
   it("should parse `choices` if passed as a function", function( done ) {
     var stubChoices = [ "foo", "bar" ];
     inquirer.prompts.stub = function( params ) {


### PR DESCRIPTION
It is not uncommon to want to set a default value based upon a previous answer, by adding the ability to define default as a function this can be achieved.

I've added the relevant test.
