### PR TITLE
Fix bug to properly close readline.

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -70,6 +70,7 @@ cli.prompt = function( questions, allDone ) {
     process.stdin.removeListener( "keypress", this.onKeypress );
 
     // Close the readline
+    this.rl.pause();
     this.rl.close();
     this.rl = null;
 


### PR DESCRIPTION
@SBoudrias I have found the bug causing https://github.com/SBoudrias/Inquirer.js/issues/49, turns out all the blocking code is already in place and working fine and it was this pesky code bug:

(Only showing problem code)

``` javascript
cli.prompt = function( questions, allDone ) {
  /* ... */
  this.rl || (this.rl = readlineFacade.createInterface());
  this.rl.resume();
 /* ... */
  var onCompletion = function() {
    /* ... */
    this.rl.close();
    this.rl = null;
    /* ... */
}
/* ... */
}
```

As you can see resume() is called on readline even though there is no pause implemented. In fact as it stands it is not possible for readline to be present since it always get's destroyed in onCompletion.

To fix this we should call `this.rl.pause();` and remove the line that destroys the readline Interface.
