### PR TITLE
Call streams end to trigger cleanup (fix #62)

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -72,6 +72,7 @@ inquirer.prompt = function( questions, allDone ) {
     process.stdin.removeListener( "keypress", this.onKeypress );
 
     // Close the readline
+    this.rl.output.end();
     this.rl.pause();
     this.rl.close();
     this.rl = null;

--- a/test/helpers/readline.js
+++ b/test/helpers/readline.js
@@ -11,6 +11,7 @@ var stub = {
   pause      : sinon.stub().returns(stub),
   resume     : sinon.stub().returns(stub),
   output     : {
+    end    : sinon.stub().returns(stub),
     mute   : sinon.stub().returns(stub),
     unmute : sinon.stub().returns(stub),
     write  : sinon.stub().returns(stub)

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -29,6 +29,7 @@ describe("inquirer.prompt", function() {
       var rl2;
 
       expect(rl1.close.called).to.be.true;
+      expect(rl1.output.end.called).to.be.true;
       expect(inquirer.rl).to.not.exist;
 
       inquirer.prompt({
@@ -37,6 +38,7 @@ describe("inquirer.prompt", function() {
         message: "message"
       }, function( answers ) {
         expect(rl2.close.called).to.be.true;
+        expect(rl2.output.end.called).to.be.true;
         expect(inquirer.rl).to.not.exist;
 
         expect( rl1 ).to.not.equal( rl2 );


### PR DESCRIPTION
From #62

> [`cleanup`](https://github.com/joyent/node/blob/v0.11.6-release/lib/stream.js#L102) isn't being called. It is called automatically when:
> - the `end` event is emitted on the `source`
>   - the `close` event is emitted on the `source`
>   - the `close` event is emitted on the `destination`
> 
> Since the `destination` is `process.stdout` we can't close that. We close the `readline` interface but this does not close the input or the output streams so `cleanup` is never fired.
> 
> To fix this leak we need to call mute-stream's `end` method.
> 
> By adding `this.rl.output.end();` the above test doesn't fail (but it currently causes other tests to fail). I'm investigating the other tests now (at least one of them I can see is because we overwrite the output stream with something that doesn't have an `end` method).

Patch includes a change to the test to prevent a regression, ideally I'd want to add a separate test that catches any sort of memory leak but currently the node warning is just a `console.error` call so I can't see a way of "catching" it to fail the test.

// cc: @SBoudrias
