### PR TITLE
Move pagination cursor progressively

### DIFF
--- a/lib/objects/choices.js
+++ b/lib/objects/choices.js
@@ -49,6 +49,10 @@ function Choices( choices ) {
       throw new Error("Cannot set `realLength` of a Choices collection");
     }
   });
+
+  // Set pagination state
+  this.pointer = 0;
+  this.lastIndex = 0;
 }
 
 
@@ -146,16 +150,22 @@ Choices.prototype.setRender = function( render ) {
 Choices.prototype.paginateOutput = function( render ) {
   var pageSize = 7;
 
-  return function( pointer ) {
+  return function( active ) {
     var output = render.apply( this, arguments );
     var lines = output.split("\n");
 
     // Make sure there's enough line to paginate
     if ( lines.length <= pageSize ) return output;
 
+    // Move the pointer only when the user go down and limit it to 3
+    if ( this.pointer < 3 && this.lastIndex < active && active - this.lastIndex < 9 ) {
+      this.pointer = Math.min( 3, this.pointer + active - this.lastIndex);
+    }
+    this.lastIndex = active;
+
     // Duplicate the lines so it give an infinite list look
     var infinite = _.flatten([ lines, lines, lines ]);
-    var topIndex = Math.max( 0, pointer + lines.length - 3 );
+    var topIndex = Math.max( 0, active + lines.length - this.pointer );
 
     var section = infinite.splice( topIndex, pageSize ).join("\n");
     return section + "\n" + clc.blackBright("(Move up and down to reveal more choices)");


### PR DESCRIPTION
Previous to this fix, when a list is paginated, the cursor start on the middle row so we see 3 options from the end of the list before.

This felt weird to me in many cases (notably the `yo` home prompt).

@danielchatfield Could you give a try to `examples/long-list.js` and let me know how it feels to you this way?
