### PR TITLE
docs: Capitalize Array

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -36,7 +36,7 @@ inquirer.Separator = require("./objects/separator");
 
 /**
  * Public CLI helper interface
- * @param  {array}   questions  Questions settings array
+ * @param  {Array}   questions  Questions settings array
  * @param  {Function} cb        Callback being passed the user answers
  * @return {null}
  */


### PR DESCRIPTION
Webstorm displays a warning when I call this function, that my input "Array" does not match the specified input of "array".
