### PR TITLE
Fix cursor position on the input prompt (Fix #68)

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -270,3 +270,30 @@ Prompt.prototype.hideCursor = function() {
 Prompt.prototype.showCursor = function() {
   return this.write("\033[?25h");
 };
+
+
+/**
+ * Remember the cursor position
+ * @return {Prompt} Self
+ */
+
+Prompt.prototype.cacheCursorPos = function() {
+  this.cursorPos = this.rl._getCursorPos();
+  return this;
+};
+
+
+/**
+ * Restore the cursor position to where it has been previously stored.
+ * @return {Prompt} Self
+ */
+
+Prompt.prototype.restoreCursorPos = function() {
+  if ( !this.cursorPos ) return;
+  var line = this.rl._prompt + this.rl.line;
+  readline.moveCursor(this.rl.output, -line.length, 0);
+  readline.moveCursor(this.rl.output, this.cursorPos.cols, 0);
+  this.cursorPos = null;
+  return this;
+};
+

--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -173,7 +173,7 @@ Prompt.prototype.onSubmit = function( input ) {
 Prompt.prototype.onKeypress = function( s, key ) {
   this.selectedKey = this.rl.line.toLowerCase();
   var selected = this.opt.choices.where({ key : this.selectedKey })[0];
-
+  this.cacheCursorPos();
   if ( this.status === "expanded" )  {
     this.clean().render();
   } else {
@@ -184,7 +184,7 @@ Prompt.prototype.onKeypress = function( s, key ) {
       .render();
   }
 
-  this.write( this.rl.line );
+  this.write( this.rl.line ).restoreCursorPos();
 };
 
 

--- a/lib/prompts/password.js
+++ b/lib/prompts/password.js
@@ -106,8 +106,8 @@ Prompt.prototype.onSubmit = function( input ) {
 
 Prompt.prototype.onKeypress = function() {
   this.rl.output.unmute();
-  this.clean().render();
+  this.cacheCursorPos().clean().render();
   var mask = new Array( this.rl.line.length + 1 ).join("*");
-  this.write(mask);
+  this.write(mask).restoreCursorPos();
   this.rl.output.mute();
 };

--- a/lib/prompts/rawlist.js
+++ b/lib/prompts/rawlist.js
@@ -143,7 +143,7 @@ Prompt.prototype.onKeypress = function( s, key ) {
     this.selected = undefined;
   }
 
-  this.down().clean(1).render().write( this.rl.line );
+  this.cacheCursorPos().down().clean(1).render().write( this.rl.line ).restoreCursorPos();
 };
 
 

--- a/lib/utils/readline.js
+++ b/lib/utils/readline.js
@@ -42,13 +42,54 @@ Interface.createInterface = function( opt ) {
   rl._refreshLine = _.wrap(rl._refreshLine, function( func ) {
     func.call(rl);
     var line = this._prompt + this.line;
-    var visualLength = ansiTrim(line).length;
-    var diff = line.length - visualLength;
     var cursorPos = this._getCursorPos();
 
     readline.moveCursor(this.output, -line.length, 0);
-    readline.moveCursor(this.output, cursorPos.cols - diff, 0);
+    readline.moveCursor(this.output, cursorPos.cols, 0);
   });
+
+  // Returns current cursor's position and line
+  rl._getCursorPos = function() {
+    var columns = this.columns;
+    var strBeforeCursor = this._prompt + this.line.substring(0, this.cursor);
+    var dispPos = this._getDisplayPos(ansiTrim(strBeforeCursor));
+    var cols = dispPos.cols;
+    var rows = dispPos.rows;
+    // If the cursor is on a full-width character which steps over the line,
+    // move the cursor to the beginning of the next line.
+    if (cols + 1 === columns &&
+        this.cursor < this.line.length &&
+        isFullWidthCodePoint(codePointAt(this.line, this.cursor))) {
+      rows++;
+      cols = 0;
+    }
+    return {cols: cols, rows: rows};
+  };
+
+  // Returns the last character's display position of the given string
+  rl._getDisplayPos = function(str) {
+    var offset = 0;
+    var col = this.columns;
+    var code;
+    str = ansiTrim(str);
+    for (var i = 0, len = str.length; i < len; i++) {
+      code = codePointAt(str, i);
+      if (code >= 0x10000) { // surrogates
+        i++;
+      }
+      if (isFullWidthCodePoint(code)) {
+        if ((offset + 1) % col === 0) {
+          offset++;
+        }
+        offset += 2;
+      } else {
+        offset++;
+      }
+    }
+    var cols = offset % col;
+    var rows = (offset - cols) / col;
+    return {cols: cols, rows: rows};
+  };
 
   // Prevent arrows from breaking the question line
   var origWrite = rl._ttyWrite;
@@ -63,3 +104,67 @@ Interface.createInterface = function( opt ) {
 
   return rl;
 };
+
+/**
+ * Returns the Unicode code point for the character at the
+ * given index in the given string. Similar to String.charCodeAt(),
+ * but this function handles surrogates (code point >= 0x10000).
+ */
+
+function codePointAt(str, index) {
+  var code = str.charCodeAt(index);
+  var low;
+  if (0xd800 <= code && code <= 0xdbff) { // High surrogate
+    low = str.charCodeAt(index + 1);
+    if (!isNaN(low)) {
+      code = 0x10000 + (code - 0xd800) * 0x400 + (low - 0xdc00);
+    }
+  }
+  return code;
+}
+
+/**
+ * Returns true if the character represented by a given
+ * Unicode code point is full-width. Otherwise returns false.
+ */
+
+function isFullWidthCodePoint(code) {
+  if (isNaN(code)) {
+    return false;
+  }
+
+  // Code points are derived from:
+  // http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
+  if (code >= 0x1100 && (
+      code <= 0x115f ||  // Hangul Jamo
+      0x2329 === code || // LEFT-POINTING ANGLE BRACKET
+      0x232a === code || // RIGHT-POINTING ANGLE BRACKET
+      // CJK Radicals Supplement .. Enclosed CJK Letters and Months
+      (0x2e80 <= code && code <= 0x3247 && code !== 0x303f) ||
+      // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
+      0x3250 <= code && code <= 0x4dbf ||
+      // CJK Unified Ideographs .. Yi Radicals
+      0x4e00 <= code && code <= 0xa4c6 ||
+      // Hangul Jamo Extended-A
+      0xa960 <= code && code <= 0xa97c ||
+      // Hangul Syllables
+      0xac00 <= code && code <= 0xd7a3 ||
+      // CJK Compatibility Ideographs
+      0xf900 <= code && code <= 0xfaff ||
+      // Vertical Forms
+      0xfe10 <= code && code <= 0xfe19 ||
+      // CJK Compatibility Forms .. Small Form Variants
+      0xfe30 <= code && code <= 0xfe6b ||
+      // Halfwidth and Fullwidth Forms
+      0xff01 <= code && code <= 0xff60 ||
+      0xffe0 <= code && code <= 0xffe6 ||
+      // Kana Supplement
+      0x1b000 <= code && code <= 0x1b001 ||
+      // Enclosed Ideographic Supplement
+      0x1f200 <= code && code <= 0x1f251 ||
+      // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
+      0x20000 <= code && code <= 0x3fffd)) {
+    return true;
+  }
+  return false;
+}

--- a/test/helpers/readline.js
+++ b/test/helpers/readline.js
@@ -4,13 +4,14 @@ var util = require("util");
 var _ = require("lodash");
 
 var stub = {
-  write      : sinon.stub().returns(stub),
-  moveCursor : sinon.stub().returns(stub),
-  setPrompt  : sinon.stub().returns(stub),
-  close      : sinon.stub().returns(stub),
-  pause      : sinon.stub().returns(stub),
-  resume     : sinon.stub().returns(stub),
-  output     : {
+  write         : sinon.stub().returns(stub),
+  moveCursor    : sinon.stub().returns(stub),
+  setPrompt     : sinon.stub().returns(stub),
+  close         : sinon.stub().returns(stub),
+  pause         : sinon.stub().returns(stub),
+  resume        : sinon.stub().returns(stub),
+  _getCursorPos : sinon.stub().returns(stub),
+  output        : {
     end    : sinon.stub().returns(stub),
     mute   : sinon.stub().returns(stub),
     unmute : sinon.stub().returns(stub),


### PR DESCRIPTION
First part of cursor position fix.

This will fix the basic behavior. But more elaborate prompt (password, expand, etc) directly write some output and by doing this, the cursor is moved around the page and the initial position is lost. That'll require more work.
