### PR TITLE
utils: Checkbox with U+2612 and U+2610 instead of hexagons

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -70,9 +70,9 @@ utils.getCheckbox = function( checked, after ) {
   var check = "";
   after || (after = "");
   if ( checked ) {
-    check =  clc.green( win32 ? "[X]" : "⬢" );
+    check =  clc.green( win32 ? "[X]" : "☒" );
   } else {
-    check = win32 ? "[ ]" : "⬡";
+    check = win32 ? "[ ]" : "☐";
   }
   return check + " " + after;
 };


### PR DESCRIPTION
U+2612 BALLOT BOX WITH X and U+2610 BALLOT BOX are both Unicode since 1.1. 
They are closer to both the symbols used for win32 and the
"checked" and "checkbox" language in the getCheckbox comment.  Plus I didn't
have a monospaced font for Inquirer's previous U+2B22 BLACK HEXAGON or U+2B21
WHITE HEXAGON, which have only been in Unicode since 5.0.

The ballot box glyphs are in DejaVu Sans Mono [1](http://dejavu-fonts.org/).  I have the hexagon glyphs
in a number of fonts including Unifont [2](http://unifoundry.com/unifont.html), but not in a monospace font. 
Installed fonts are obviously subjective, but I expect the older v1.1 code
points will have better coverage than the newer 5.0 code points.
