### PR TITLE
Adds more robust testing for up/down navigation

### DIFF
--- a/test/specs/prompts/checkbox.js
+++ b/test/specs/prompts/checkbox.js
@@ -81,6 +81,19 @@ describe("`checkbox` prompt", function() {
     this.rl.emit("line");
   });
 
+  it("should allow for arrow navigation", function( done ) {
+    this.checkbox.run(function( answer ) {
+      expect(answer.length).to.equal(1);
+      expect(answer[0]).to.equal("choice 2");
+      done();
+    });
+    this.rl.emit("keypress", null, { name: "down" });
+    this.rl.emit("keypress", null, { name: "down" });
+    this.rl.emit("keypress", null, { name: "up" });
+    this.rl.emit("keypress", " ", { name: "space" });
+    this.rl.emit("line");
+  });
+
   it("should allow 1-9 shortcut key", function( done ) {
 
     this.checkbox.run(function( answer ) {

--- a/test/specs/prompts/list.js
+++ b/test/specs/prompts/list.js
@@ -45,10 +45,11 @@ describe("`list` prompt", function() {
   it("should move selected cursor up and down on keypress", function( done ) {
 
     this.list.run(function( answer ) {
-      expect(answer).to.equal("foo");
+      expect(answer).to.equal("bar");
       done();
     });
 
+    this.rl.emit("keypress", "", { name : "down" });
     this.rl.emit("keypress", "", { name : "down" });
     this.rl.emit("keypress", "", { name : "up" });
     this.rl.emit("line");


### PR DESCRIPTION
I've updated one test and added another to fix a couple potential gaps in the up/down navigation testing.

I updated the test in `test/specs/prompts/list.js` to be a little more thorough. The original tests simulate pressing down and then up, which brings you back to the original position. This would catch the case where one of the directions was not implemented correctly, but not if both were implemented incorrectly (as the start and end conditions are the same). Granted, without up and down navigation many other tests would fail. However, this small change allows for this test to stand alone should it ever need to.

`test/specs/prompts/checkbox.js` tests down arrow navigation indirectly. However, I was able to disable up arrow navigation in the checkbox prompt and still have all the tests pass. This pull requests adds explicit arrow navigation testing to cover both up and down arrow navigation.
