### PR TITLE
Adds support for vi-style navigation.

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -139,9 +139,10 @@ Prompt.prototype.onSubmit = function() {
  */
 
 Prompt.prototype.onKeypress = function( s, key ) {
-  // Only process up, down, space and 1-9 key
-  if ( key && (key.name !== "up" && key.name !== "down" && key.name !== "space") ) return;
-  if ( key && key.name === "space" ) s = undefined;
+  // Only process up, down, space, j, k and 1-9 keys
+  var keyWhitelist = [ "up", "down", "space", "j", "k" ];
+  if ( key && !_.contains(keyWhitelist, key.name) ) return;
+  if ( key && (key.name === "space" || key.name === "j" || key.name === "k") ) s = undefined;
   if ( s && "123456789".indexOf(s) < 0 ) return;
 
   var len = this.opt.choices.realLength;
@@ -156,9 +157,9 @@ Prompt.prototype.onKeypress = function( s, key ) {
   if ( key && key.name === "space" ) {
     var checked = this.opt.choices.getChoice(this.pointer).checked;
     this.opt.choices.getChoice(this.pointer).checked = !checked;
-  } else if ( key && key.name === "up" ) {
+  } else if ( key && (key.name === "up" || key.name === "k") ) {
     (this.pointer > 0) ? this.pointer-- : (this.pointer = len - 1);
-  } else if ( key && key.name === "down" ) {
+  } else if ( key && (key.name === "down" || key.name === "j") ) {
     (this.pointer < len - 1) ? this.pointer++ : (this.pointer = 0);
   }
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -131,16 +131,18 @@ Prompt.prototype.onSubmit = function() {
  */
 
 Prompt.prototype.onKeypress = function( s, key ) {
-  // Only process up, down and 1-9 key
-  if ( key && (key.name !== "up" && key.name !== "down") ) return;
+  // Only process up, down, j, k and 1-9 keys
+  var keyWhitelist = [ "up", "down", "j", "k" ];
+  if ( key && !_.contains(keyWhitelist, key.name) ) return;
+  if ( key && (key.name === "j" || key.name === "k") ) s = undefined;
   if ( s && "123456789".indexOf(s) < 0 ) return;
 
   this.rl.output.unmute();
 
   var len = this.opt.choices.realLength;
-  if ( key && key.name === "up" ) {
+  if ( key && (key.name === "up" || key.name === "k") ) {
     (this.selected > 0) ? this.selected-- : (this.selected = len - 1);
-  } else if ( key && key.name === "down" ) {
+  } else if ( key && (key.name === "down" || key.name === "j") ) {
     (this.selected < len - 1) ? this.selected++ : (this.selected = 0);
   } else if ( Number(s) <= len ) {
     this.selected = Number(s) - 1;

--- a/test/specs/prompts/checkbox.js
+++ b/test/specs/prompts/checkbox.js
@@ -81,6 +81,19 @@ describe("`checkbox` prompt", function() {
     this.rl.emit("line");
   });
 
+  it("should allow for vi-style navigation", function( done ) {
+    this.checkbox.run(function( answer ) {
+      expect(answer.length).to.equal(1);
+      expect(answer[0]).to.equal("choice 2");
+      done();
+    });
+    this.rl.emit("keypress", "j", { name: "j" });
+    this.rl.emit("keypress", "j", { name: "j" });
+    this.rl.emit("keypress", "k", { name: "k" });
+    this.rl.emit("keypress", " ", { name: "space" });
+    this.rl.emit("line");
+  });
+
   it("should allow 1-9 shortcut key", function( done ) {
 
     this.checkbox.run(function( answer ) {

--- a/test/specs/prompts/list.js
+++ b/test/specs/prompts/list.js
@@ -42,7 +42,7 @@ describe("`list` prompt", function() {
     this.rl.emit("line");
   });
 
-  it("should move selected cursor up and down on keypress", function( done ) {
+  it("should allow for arrow navigation", function( done ) {
 
     this.list.run(function( answer ) {
       expect(answer).to.equal("foo");
@@ -51,6 +51,19 @@ describe("`list` prompt", function() {
 
     this.rl.emit("keypress", "", { name : "down" });
     this.rl.emit("keypress", "", { name : "up" });
+    this.rl.emit("line");
+  });
+
+  it("should allow for vi-style navigation", function( done ) {
+
+    this.list.run(function( answer ) {
+      expect(answer).to.equal("bar");
+      done();
+    });
+
+    this.rl.emit("keypress", "j", { name : "j" });
+    this.rl.emit("keypress", "j", { name : "j" });
+    this.rl.emit("keypress", "k", { name : "k" });
     this.rl.emit("line");
   });
 


### PR DESCRIPTION
I decided I'd add this feature while using Yeoman, which includes Inquirer.js as a dependency of a dependency. I think this feature is really nice as it allows you to navigate through Inquirer.js lists and checkboxes without having to move your hands from the home row. I think this would be a really nice feature, especially for Vi(m) users to whom this style of navigation is familiar. I added this functionality to the checkbox and list JavaScript as they seem to be the only prompts that allow for arrow navigation.

Adding new conditions to the if statements resulted in some very long lines. Rather than messing with strange line breaks for the sake of formatting, I decided to use Lodash and a whitelist array approach. I've added tests to support this new functionality. I also renamed one of the previous tests just to keep the navigation test names consistent.

If you prefer a different approach I'd be happy to refactor this. I didn't feel the need to mess with the "Use arrow keys" text. Users who are familiar with this type of navigation will likely try to navigate with `j` and `k` anyway and hopefully be pleasantly surprised.
