### PR TITLE
fixed syntax error in examples/checkbox.js

### DIFF
--- a/examples/checkbox.js
+++ b/examples/checkbox.js
@@ -16,14 +16,15 @@ inquirer.prompt([
         name: "Peperonni"
       },
       {
-        name: "Cheese"
+        name: "Cheese",
+        checked: true
       },
       {
         name: "Mushroom"
       },
       new inquirer.Separator("The extras:"),
       {
-        name: "Pineapple",c
+        name: "Pineapple",
       },
       {
         name: "Bacon"


### PR DESCRIPTION
fixed syntax error in examples/checkbox.js + selected one of the list items by default.
