### PR TITLE
Fixes bug where falsy choice values incorrectly take the choice name.

### DIFF
--- a/lib/objects/choice.js
+++ b/lib/objects/choice.js
@@ -33,7 +33,7 @@ function Choice( val ) {
   } else {
     _.extend( this, val, {
       name: val.name || val.value,
-      value: val.value || val.name
+      value: val.hasOwnProperty("value") ? val.value : val.name
     });
   }
 }


### PR DESCRIPTION
Choices with falsy values cause the value to take-on the name, which (IMHO) is not expected.
In my use-case, I would like to use numbers (including zero) as values.
I could imagine using null or undefined as values too, depending on the situation.

This patch makes such things possible.

This fix _might_ cause issues for existing users if they were relying on the existing behaviour.
