### PR TITLE
Fixes syntax error: octal literals are not allowed in strict mode

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -59,7 +59,7 @@ UI.prototype.close = function() {
 
   // Restore prompt functionnalities
   this.rl.output.unmute();
-  process.stdout.write("\033[?25h"); // show cursor
+  process.stdout.write("\x1B[?25h"); // show cursor
 
   // Close the readline
   this.rl.output.end();

--- a/lib/utils/tty.js
+++ b/lib/utils/tty.js
@@ -78,7 +78,7 @@ tty.write = function( str ) {
  */
 
 tty.hideCursor = function() {
-  return this.write("\033[?25l");
+  return this.write("\x1B[?25l");
 };
 
 
@@ -88,7 +88,7 @@ tty.hideCursor = function() {
  */
 
 tty.showCursor = function() {
-  return this.write("\033[?25h");
+  return this.write("\x1B[?25h");
 };
 
 


### PR DESCRIPTION
Converts octal literals to hexadecimal literals to prevent errors in strict mode (Fix #111)
