### PR TITLE
No longer run `question.filter` of prompts.input twice (Fix #125)

### DIFF
--- a/lib/prompts/input.js
+++ b/lib/prompts/input.js
@@ -73,18 +73,16 @@ Prompt.prototype.onSubmit = function( input ) {
   
   this.validate( value, function( isValid ) {
     if ( isValid === true ) {
-      this.filter( value, function( value ) {
-        this.status = "answered";
+      this.status = "answered";
 
-        // Re-render prompt
-        this.clean(1).render();
+      // Re-render prompt
+      this.clean(1).render();
 
-        // Render answer
-        this.write( chalk.cyan(value) + "\n" );
+      // Render answer
+      this.write( chalk.cyan(value) + "\n" );
 
-        this.rl.removeAllListeners("line");
-        this.done( value );
-      }.bind(this));
+      this.rl.removeAllListeners("line");
+      this.done( value );
     } else {
       this.error( isValid ).clean().render();
     }

--- a/test/specs/prompts/input.js
+++ b/test/specs/prompts/input.js
@@ -39,18 +39,48 @@ describe("`input` prompt", function() {
     this.rl.emit( "line", "Inquirer" );
   });
 
-  it("should output filtered value", function( done ) {
+  it("should not output filtered value", function( done ) {
     this.fixture.filter = function() {
       return "pass";
     };
 
     var prompt = new Input( this.fixture, this.rl );
     prompt.run(function( answer ) {
-      expect(this.output).to.contain("pass");
+      expect(this.output).not.to.contain("pass");
       done();
     }.bind(this));
 
     this.rl.emit("line", "");
   });
 
+  it("should filter the answer", function(done){
+    this.fixture.filter = function() {
+      return "pass";
+    };
+
+    var prompt = new Input( this.fixture, this.rl );
+    prompt.run(function( answer ) {
+      expect(answer).to.equal("pass");
+      done();
+    }.bind(this));
+
+    this.rl.emit("line", "");
+  });
+
+  it("should not execute filter function more than once", function(done){
+    var counter = 0;
+
+    this.fixture.filter = function() {
+      ++ counter;
+      return "pass";
+    };
+
+    var prompt = new Input( this.fixture, this.rl );
+    prompt.run(function( answer ) {
+      expect(counter).to.equal(1);
+      done();
+    }.bind(this));
+
+    this.rl.emit("line", "");
+  });
 });


### PR DESCRIPTION
- will not output filtered answer
- run `question.filter` only once
