### PR TITLE
new checkbox style

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -6,6 +6,7 @@
 var _ = require("lodash");
 var chalk = require("chalk");
 var rx = require("rx");
+var figures = require("figures");
 
 
 /**
@@ -85,9 +86,7 @@ utils.fetchAsyncQuestionProperty = function( question, prop, answers ) {
  */
 
 utils.getPointer = function() {
-  if ( process.platform === "win32" ) return ">";
-  if ( process.platform === "linux" ) return "‣";
-  return "❯";
+  return figures.pointer;
 };
 
 
@@ -99,13 +98,6 @@ utils.getPointer = function() {
  */
 
 utils.getCheckbox = function( checked, after ) {
-  var win32 = (process.platform === "win32");
-  var check = "";
-  after || (after = "");
-  if ( checked ) {
-    check =  chalk.green( win32 ? "[X]" : "⬢" );
-  } else {
-    check = win32 ? "[ ]" : "⬡";
-  }
-  return check + " " + after;
+  var checked = checked ? chalk.green( figures.checkboxCircleOn ) : figures.radioOff;
+  return checked + " " + ( after || "" );
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "chalk": "^0.5.0",
     "cli-color": "~0.3.2",
+    "figures": "^1.2.0",
     "lodash": "~2.4.1",
     "mute-stream": "0.0.4",
     "readline2": "~0.1.0",


### PR DESCRIPTION
![screen shot 2014-08-12 at 21 54 38](https://cloud.githubusercontent.com/assets/170270/3896924/e8ff15a2-225c-11e4-8c58-a3bfe93a2176.png) ![screen shot 2014-08-12 at 22 10 21](https://cloud.githubusercontent.com/assets/170270/3896925/e9077b0c-225c-11e4-80df-e9d9b22c8f26.png)

_OS X left and Windows right_

I think these characters are much clearer. Also switched to using the [`figures`](https://github.com/sindresorhus/figures) module.

_(I spent 2 hours today going through the Unicode character table to find this one. lol)_
## 

For reference, the current one is:

![screen shot 2014-08-12 at 22 18 19](https://cloud.githubusercontent.com/assets/170270/3897015/e12caee2-225d-11e4-8137-784c994b31d6.png)
## 

Alternatively

![screen shot 2014-08-12 at 21 54 24](https://cloud.githubusercontent.com/assets/170270/3896932/15d20e04-225d-11e4-8943-326af63a6099.png)

But I think that's more of a radio button. Maybe you should have a `radio` prompt type?
## 

@addyosmani @passy @stephenplusplus @eddiemonge @silvenon
## 

closes #72 
