### PR TITLE
Add support for `message` function, fixes #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A question object is a `hash` containing question related values:
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
 `list`, `rawlist`
 - **name**: (String) The name to use when storing the answer in the anwers hash.
-- **message**: (String) The question to print.
+- **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers.
 - **default**: (String|Number|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.
 - **choices**: (Array|Function) Choices array or a function returning a choices array. If defined as a function, the first parameter will be the current inquirer session answers.  
 Array values can be simple `strings`, or `objects` containing a `name` (to display) and a `value` properties (to save in the answers hash). Values can also be [a `Separator`](#separator).

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -79,6 +79,7 @@ PromptUI.prototype.processQuestion = function( question ) {
     return obs
       .concatMap( this.setDefaultType )
       .concatMap( this.filterIfRunnable.bind(this) )
+      .concatMap( utils.fetchAsyncQuestionProperty.bind( null, question, "message", this.answers ) )
       .concatMap( utils.fetchAsyncQuestionProperty.bind( null, question, "default", this.answers ) )
       .concatMap( utils.fetchAsyncQuestionProperty.bind( null, question, "choices", this.answers ) )
       .concatMap( this.fetchAnswer.bind(this) );

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -90,6 +90,67 @@ describe("inquirer.prompt", function() {
     ui.rl.emit("line");
   });
 
+  it("should parse `message` if passed as a function", function( done ) {
+    var stubMessage = "foo";
+    inquirer.prompts.stub = function( params ) {
+      this.opt = {
+        when: function() { return true; }
+      };
+      expect(params.message).to.equal(stubMessage);
+      done();
+    };
+    inquirer.prompts.stub.prototype.run = function() {};
+
+    var prompts = [{
+      type: "input",
+      name: "name1",
+      message: "message",
+      default: "bar"
+    }, {
+      type: "stub",
+      name: "name",
+      message: function( answers ) {
+        expect(answers.name1).to.equal("bar");
+        return stubMessage;
+      }
+    }];
+
+    var ui = inquirer.prompt(prompts, function() {});
+    ui.rl.emit("line");
+  });
+
+  it("should run asynchronous `message`", function( done ) {
+    var stubMessage = "foo";
+    inquirer.prompts.stub = function( params ) {
+      this.opt = {
+        when: function() { return true; }
+      };
+      expect(params.message).to.equal(stubMessage);
+      done();
+    };
+    inquirer.prompts.stub.prototype.run = function() {};
+
+    var prompts = [{
+      type: "input",
+      name: "name1",
+      message: "message",
+      default: "bar"
+    }, {
+      type: "stub",
+      name: "name",
+      message: function( answers ) {
+        expect(answers.name1).to.equal("bar");
+        var goOn = this.async();
+        setTimeout(function() {
+          goOn(stubMessage);
+        }, 0 );
+      }
+    }];
+
+    var ui = inquirer.prompt(prompts, function() {});
+    ui.rl.emit("line");
+  });
+
   it("should parse `default` if passed as a function", function( done ) {
     var stubDefault = "foo";
     inquirer.prompts.stub = function( params ) {


### PR DESCRIPTION
[WIP] tests are broken. Looks like the message function is not executed inside of the tests. I don't know how to fix it.
