### PR TITLE
nicer question mark prefix

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -11,6 +11,7 @@ var utils = require("../utils/utils");
 var Choices = require("../objects/choices");
 var tty = require("../utils/tty");
 var rx = require("rx");
+var figures = require("figures");
 
 /**
  * Module exports
@@ -188,7 +189,7 @@ Prompt.prototype.filter = function( input, cb ) {
 
 Prompt.prototype.prefix = function( str ) {
   str || (str = "");
-  return "[" + chalk.green("?") + "] " + str;
+  return chalk.green(figures.questionMarkPrefix) + " " + str;
 };
 
 


### PR DESCRIPTION
### OS X

![screen shot 2014-08-15 at 21 55 48](https://cloud.githubusercontent.com/assets/170270/3938106/38976988-24b6-11e4-9804-79879f90a0ee.png)

![screen shot 2014-08-15 at 23 30 11](https://cloud.githubusercontent.com/assets/170270/3939171/6830191c-24c3-11e4-875e-095004273584.png)
### Windows

![screen shot 2014-08-15 at 19 18 23](https://cloud.githubusercontent.com/assets/170270/3936500/59e8c550-24a2-11e4-9606-b4d485c29def.png)
### Linux

![screen shot 2014-08-15 at 19 19 57](https://cloud.githubusercontent.com/assets/170270/3936499/59e6ec80-24a2-11e4-99bd-a6e543b1d17c.png)

---

Existing prefix (OS X):

![screen shot 2014-08-15 at 19 35 20](https://cloud.githubusercontent.com/assets/170270/3936519/92cb1774-24a2-11e4-9568-b98830096e7c.png)

---

@addyosmani @passy @stephenplusplus 
