### PR TITLE
Fix #154

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -60,10 +60,10 @@ Prompt.prototype._run = function( cb ) {
 
   var events = observe(this.rl);
   this.lineObs = events.line.forEach( this.onSubmit.bind(this) );
-  events.normalizedUpKey.takeUntil( events.line ).forEach( this.onUpKey.bind(this) );
-  events.normalizedDownKey.takeUntil( events.line ).forEach( this.onDownKey.bind(this) );
-  events.numberKey.takeUntil( events.line ).forEach( this.onNumberKey.bind(this) );
-  events.spaceKey.takeUntil( events.line ).forEach( this.onSpaceKey.bind(this) );
+  this.upObs = events.normalizedUpKey.forEach( this.onUpKey.bind(this) );
+  this.downObs = events.normalizedDownKey.forEach( this.onDownKey.bind(this) );
+  this.numberObs = events.numberKey.forEach( this.onNumberKey.bind(this) );
+  this.spaceObs = events.spaceKey.forEach( this.onSpaceKey.bind(this) );
 
   // Init the prompt
   this.render();
@@ -132,6 +132,10 @@ Prompt.prototype.onSubmit = function() {
       this.down().clean(1).render();
 
       this.lineObs.dispose();
+      this.upObs.dispose();
+      this.downObs.dispose();
+      this.numberObs.dispose();
+      this.spaceObs.dispose();
       this.done( answer );
     } else {
       this.down().error( isValid ).clean().render();


### PR DESCRIPTION
Remove takeUntil(events.line) from event stream as event.line does not
indicate success.

Not sure if this is the best way to fix this (code is certainly not as nice), I was originally thinking about refactoring the `handleSubmitEvents` function so that it could be used by the checkbox prompt but I'll leave it for you to decide.
