### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ inquirer.prompt(prompts);
 And using the `process` property, you have access to more fine grained callbacks:
 
 ```js
-inquirer.prompts(prompts).process.subscribe(
+inquirer.prompt(prompts).process.subscribe(
   onEachAnswer,
   onError,
   onComplete


### PR DESCRIPTION
I'm considering the `inquirer.prompts(prompts).process.subscribe(...)` is a typo because it doesn't work.
The right one should be `inquirer.prompt(prompts).process.subscribe(...)` which without the 's' for `inquirer.prompt`.
