### PR TITLE
handle ansi styled prefix

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -6,6 +6,7 @@
 var _ = require("lodash");
 var clc = require("cli-color");
 var chalk = require("chalk");
+var ansiRegex = require("ansi-regex");
 var readline = require("readline");
 var utils = require("../utils/utils");
 var Choices = require("../objects/choices");
@@ -202,9 +203,13 @@ Prompt.prototype.prefix = function( str ) {
  * @return {String} prompt suffix
  */
 
+var reStrEnd = new RegExp("(?:" + ansiRegex().source + ")$|$");
+
 Prompt.prototype.suffix = function( str ) {
   str || (str = "");
-  return (str.length < 1 || /([a-z1-9])$/i.test(str) ? str + ":" : str).trim() + " ";
+  return (str.length < 1 || /[a-z1-9]$/i.test(chalk.stripColor(str)) ?
+          // make sure we get the `:` inside the styles
+          str.replace(reStrEnd, ":$&") : str).trim() + " ";
 };
 
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
   "dependencies": {
+    "ansi-regex": "^1.1.0",
     "chalk": "^0.5.0",
     "cli-color": "~0.3.2",
     "figures": "^1.3.2",

--- a/test/specs/prompts/base.js
+++ b/test/specs/prompts/base.js
@@ -1,5 +1,6 @@
 var expect = require("chai").expect;
 var sinon = require("sinon");
+var chalk = require("chalk");
 var ReadlineStub = require("../../helpers/readline");
 
 var Base = require("../../../lib/prompts/base");
@@ -19,6 +20,8 @@ describe("`base` prompt (e.g. prompt helpers)", function() {
     expect(this.base.suffix("m:")).to.equal("m: ");
     expect(this.base.suffix("m?")).to.equal("m? ");
     expect(this.base.suffix("my question?")).to.equal("my question? ");
+    expect(this.base.suffix(chalk.bold("m"))).to.equal("\u001b[1mm:\u001b[22m ");
+    expect(chalk.stripColor(this.base.suffix(chalk.bold("m?")))).to.equal("m? ");
     expect(this.base.suffix("m")).to.equal("m: ");
     expect(this.base.suffix("M")).to.equal("M: ");
     expect(this.base.suffix("m ")).to.equal("m ");


### PR DESCRIPTION
followup to 0968122686180d01e1c9aca26527d7a465b28e05

before it didn't detect the end of the string correctly when it ended in an ansi escape.

also make sure the inserted `:` is inserted inside any ansi escape code.
## 

Noticed it when `yo` still showed `? 'Allo Sindre! What would you like to do?:` with the latest version of Inquirer.
