### PR TITLE
Add inquirer.createPromptModule (Fix #161)

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -19,6 +19,47 @@ inquirer.ui = {
   Prompt: require("./ui/prompt")
 };
 
+/**
+ * Create a new self-contained prompt module.
+ */
+inquirer.createPromptModule = function () {
+  var promptModule = function( questions, allDone ) {
+    var ui = new inquirer.ui.Prompt( promptModule.prompts );
+    ui.run( questions, allDone );
+    return ui;
+  };
+  promptModule.prompts = {};
+
+  /**
+   * Register a prompt type
+   * @param {String} name     Prompt type name
+   * @param {Function} prompt Prompt constructor
+   * @return {inquirer}
+   */
+
+  promptModule.registerPrompt = function( name, prompt ) {
+    promptModule.prompts[ name ] = prompt;
+    return this;
+  };
+
+  /**
+   * Register the defaults provider prompts
+   */
+
+  promptModule.restoreDefaultPrompts = function () {
+    this.registerPrompt( "list", require("./prompts/list"));
+    this.registerPrompt( "input", require("./prompts/input"));
+    this.registerPrompt( "confirm", require("./prompts/confirm"));
+    this.registerPrompt( "rawlist", require("./prompts/rawlist"));
+    this.registerPrompt( "expand", require("./prompts/expand"));
+    this.registerPrompt( "checkbox", require("./prompts/checkbox"));
+    this.registerPrompt( "password", require("./prompts/password"));
+  };
+
+  promptModule.restoreDefaultPrompts();
+
+  return promptModule;
+};
 
 /**
  * Public CLI helper interface
@@ -27,36 +68,12 @@ inquirer.ui = {
  * @return {inquirer.ui.Prompt}
  */
 
-inquirer.prompt = function( questions, allDone ) {
-  var prompt = new inquirer.ui.Prompt();
-  prompt.run( questions, allDone );
-  return prompt;
-};
+inquirer.prompt = inquirer.createPromptModule();
 
-/**
- * Register a prompt type
- * @param {String} name     Prompt type name
- * @param {Function} prompt Prompt constructor
- * @return {inquirer}
- */
-
+// Expose helper functions on the top level for easiest usage by common users
 inquirer.registerPrompt = function( name, prompt ) {
-  this.prompts[ name ] = prompt;
-  return this;
+  inquirer.prompt.registerPrompt( name, prompt );
 };
-
-/**
- * Register the defaults provider prompts
- */
-
-inquirer.restoreDefaultPrompts = function () {
-  this.registerPrompt( "list", require("./prompts/list"));
-  this.registerPrompt( "input", require("./prompts/input"));
-  this.registerPrompt( "confirm", require("./prompts/confirm"));
-  this.registerPrompt( "rawlist", require("./prompts/rawlist"));
-  this.registerPrompt( "expand", require("./prompts/expand"));
-  this.registerPrompt( "checkbox", require("./prompts/checkbox"));
-  this.registerPrompt( "password", require("./prompts/password"));
+inquirer.restoreDefaultPrompts = function() {
+  inquirer.prompt.restoreDefaultPrompts();
 };
-
-inquirer.restoreDefaultPrompts();

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -22,8 +22,9 @@ module.exports = PromptUI;
  * Constructor
  */
 
-function PromptUI() {
+function PromptUI( prompts ) {
   Base.call(this);
+  this.prompts = prompts;
 }
 util.inherits( PromptUI, Base );
 
@@ -77,7 +78,7 @@ PromptUI.prototype.processQuestion = function( question ) {
     });
 
     return obs
-      .concatMap( this.setDefaultType )
+      .concatMap( this.setDefaultType.bind(this) )
       .concatMap( this.filterIfRunnable.bind(this) )
       .concatMap( utils.fetchAsyncQuestionProperty.bind( null, question, "message", this.answers ) )
       .concatMap( utils.fetchAsyncQuestionProperty.bind( null, question, "default", this.answers ) )
@@ -87,7 +88,8 @@ PromptUI.prototype.processQuestion = function( question ) {
 };
 
 PromptUI.prototype.fetchAnswer = function( question ) {
-  var prompt = new inquirer.prompts[question.type]( question, this.rl, this.answers );
+  var Prompt = this.prompts[question.type];
+  var prompt = new Prompt( question, this.rl, this.answers );
   var answers = this.answers;
   return utils.createObservableFromAsync(function() {
     var done = this.async();
@@ -100,7 +102,7 @@ PromptUI.prototype.fetchAnswer = function( question ) {
 
 PromptUI.prototype.setDefaultType = function( question ) {
   // Default type to input
-  if ( !inquirer.prompts[question.type] ) {
+  if ( !this.prompts[question.type] ) {
     question.type = "input";
   }
   return rx.Observable.defer(function() {

--- a/test/before.js
+++ b/test/before.js
@@ -3,7 +3,7 @@ var ReadlineStub = require("./helpers/readline");
 
 mockery.enable();
 mockery.warnOnUnregistered(false);
-mockery.registerMock("../utils/readline", {
+mockery.registerMock("readline2", {
   createInterface: function() {
     return new ReadlineStub();
   }

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -331,7 +331,7 @@ describe("Prompt public APIs", function() {
       beforeEach(function() {
         var self = this;
         this.fixture = _.clone(fixtures[ detail.name ]);
-        this.Prompt = inquirer.prompts[ detail.name ];
+        this.Prompt = inquirer.prompt.prompts[ detail.name ];
         this.rl = new ReadlineStub();
 
         this.output = "";

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -11,21 +11,25 @@ var inquirer = require("../../lib/inquirer");
 
 describe("inquirer.prompt", function() {
 
+  beforeEach(function () {
+    this.prompt = inquirer.createPromptModule();
+  });
+
   it("should close and create a new readline instances each time it's called", function( done ) {
+    var ctx = this;
     var rl1;
 
-    var prompt = inquirer.prompt({
+    var prompt = this.prompt({
       type: "confirm",
       name: "q1",
       message: "message"
     }, function( answers ) {
-      var rl2;
-
       expect(rl1.close.called).to.be.true;
       expect(rl1.output.end.called).to.be.true;
       expect(prompt.rl).to.not.exist;
 
-      var prompt2 = inquirer.prompt({
+      var rl2;
+      var prompt2 = ctx.prompt({
         type: "confirm",
         name: "q1",
         message: "message"
@@ -39,17 +43,11 @@ describe("inquirer.prompt", function() {
       });
 
       rl2 = prompt2.rl;
-      sinon.spy( rl2, "close" );
-      sinon.spy( rl2.output, "end" );
       prompt2.rl.emit("line");
     });
 
-
     rl1 = prompt.rl;
-    sinon.spy( rl1, "close" );
-    sinon.spy( rl1.output, "end" );
     prompt.rl.emit("line");
-
   });
 
   it("should take a prompts array and return answers", function( done ) {
@@ -64,7 +62,7 @@ describe("inquirer.prompt", function() {
       default: false
     }];
 
-    var ui = inquirer.prompt( prompts, function( answers ) {
+    var ui = this.prompt( prompts, function( answers ) {
       expect(answers.q1).to.be.true;
       expect(answers.q2).to.be.false;
       done();
@@ -82,7 +80,7 @@ describe("inquirer.prompt", function() {
       default: "bar"
     };
 
-    var ui = inquirer.prompt( prompt, function( answers ) {
+    var ui = this.prompt( prompt, function( answers ) {
       expect(answers.q1).to.equal("bar");
       done();
     });
@@ -92,14 +90,14 @@ describe("inquirer.prompt", function() {
 
   it("should parse `message` if passed as a function", function( done ) {
     var stubMessage = "foo";
-    inquirer.prompts.stub = function( params ) {
+    this.prompt.registerPrompt("stub", function( params ) {
       this.opt = {
         when: function() { return true; }
       };
+      this.run = _.noop;
       expect(params.message).to.equal(stubMessage);
       done();
-    };
-    inquirer.prompts.stub.prototype.run = function() {};
+    });
 
     var prompts = [{
       type: "input",
@@ -115,20 +113,20 @@ describe("inquirer.prompt", function() {
       }
     }];
 
-    var ui = inquirer.prompt(prompts, function() {});
+    var ui = this.prompt(prompts, function() {});
     ui.rl.emit("line");
   });
 
   it("should run asynchronous `message`", function( done ) {
     var stubMessage = "foo";
-    inquirer.prompts.stub = function( params ) {
+    this.prompt.registerPrompt("stub", function( params ) {
       this.opt = {
         when: function() { return true; }
       };
+      this.run = _.noop;
       expect(params.message).to.equal(stubMessage);
       done();
-    };
-    inquirer.prompts.stub.prototype.run = function() {};
+    });
 
     var prompts = [{
       type: "input",
@@ -147,20 +145,20 @@ describe("inquirer.prompt", function() {
       }
     }];
 
-    var ui = inquirer.prompt(prompts, function() {});
+    var ui = this.prompt(prompts, function() {});
     ui.rl.emit("line");
   });
 
   it("should parse `default` if passed as a function", function( done ) {
     var stubDefault = "foo";
-    inquirer.prompts.stub = function( params ) {
+    this.prompt.registerPrompt("stub", function( params ) {
       this.opt = {
         when: function() { return true; }
       };
+      this.run = _.noop;
       expect(params.default).to.equal(stubDefault);
       done();
-    };
-    inquirer.prompts.stub.prototype.run = function() {};
+    });
 
     var prompts = [{
       type: "input",
@@ -177,7 +175,7 @@ describe("inquirer.prompt", function() {
       }
     }];
 
-    var ui = inquirer.prompt(prompts, function() {});
+    var ui = this.prompt(prompts, function() {});
     ui.rl.emit("line");
   });
 
@@ -204,7 +202,7 @@ describe("inquirer.prompt", function() {
       }
     }];
 
-    var ui = inquirer.prompt( prompts, function( answers ) {
+    var ui = this.prompt( prompts, function( answers ) {
       expect(goesInDefault).to.be.true;
       expect(answers.q2).to.equal(input2Default);
       done();
@@ -214,12 +212,11 @@ describe("inquirer.prompt", function() {
   });
 
   it("should pass previous answers to the prompt constructor", function( done ) {
-    inquirer.prompts.stub = function( params, rl, answers ) {
+    this.prompt.registerPrompt("stub", function( params, rl, answers ) {
+      this.run = _.noop;
       expect(answers.name1).to.equal("bar");
       done();
-      return new inquirer.prompts.input( params, rl, answers );
-    };
-    inquirer.prompts.stub.prototype.run = function() {};
+    });
 
     var prompts = [{
       type: "input",
@@ -232,20 +229,20 @@ describe("inquirer.prompt", function() {
       message: "message"
     }];
 
-    var ui = inquirer.prompt(prompts, function() {});
+    var ui = this.prompt(prompts, function() {});
     ui.rl.emit("line");
   });
 
   it("should parse `choices` if passed as a function", function( done ) {
     var stubChoices = [ "foo", "bar" ];
-    inquirer.prompts.stub = function( params ) {
+    this.prompt.registerPrompt("stub", function( params ) {
+      this.run = _.noop;
       this.opt = {
         when: function() { return true; }
       };
       expect(params.choices).to.equal(stubChoices);
       done();
-    };
-    inquirer.prompts.stub.prototype.run = function() {};
+    });
 
     var prompts = [{
       type: "input",
@@ -262,7 +259,7 @@ describe("inquirer.prompt", function() {
       }
     }];
 
-    var ui = inquirer.prompt(prompts, function() {});
+    var ui = this.prompt(prompts, function() {});
     ui.rl.emit("line");
   });
 
@@ -279,7 +276,7 @@ describe("inquirer.prompt", function() {
       default: "doe"
     }];
 
-    var ui = inquirer.prompt(prompts, function() {});
+    var ui = this.prompt(prompts, function() {});
     var spy = sinon.spy();
     ui.process.subscribe( spy, function() {}, function() {
       sinon.assert.calledWith( spy, { name: "name1", answer: "bar" });
@@ -309,7 +306,7 @@ describe("inquirer.prompt", function() {
       }, 30 );
     });
 
-    var ui = inquirer.prompt( prompts, function( answers ) {
+    var ui = this.prompt( prompts, function( answers ) {
       expect(answers.q1).to.be.true;
       expect(answers.q2).to.be.false;
       done();
@@ -318,8 +315,7 @@ describe("inquirer.prompt", function() {
     ui.rl.emit("line");
   });
 
-  // Hierarchical prompts (`when`)
-  describe("hierarchical mode", function() {
+  describe("hierarchical mode (`when`)", function() {
 
     it("should pass current answers to `when`", function( done ) {
       var prompts = [{
@@ -332,11 +328,12 @@ describe("inquirer.prompt", function() {
         when: function( answers ) {
           expect(answers).to.be.an("object");
           expect(answers.q1).to.be.true;
-          done();
         }
       }];
 
-      var ui = inquirer.prompt( prompts, function( answers ) {});
+      var ui = this.prompt( prompts, function( answers ) {
+        done();
+      });
 
       ui.rl.emit("line");
     });
@@ -358,7 +355,7 @@ describe("inquirer.prompt", function() {
         }
       }];
 
-      var ui = inquirer.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( answers ) {
         expect(goesInWhen).to.be.true;
         expect(answers.q2).to.equal("bar-var");
         done();
@@ -389,7 +386,7 @@ describe("inquirer.prompt", function() {
         default: "foo"
       }];
 
-      var ui = inquirer.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( answers ) {
         expect(goesInWhen).to.be.true;
         expect(answers.q2).to.not.exist;
         expect(answers.q3).to.equal("foo");
@@ -399,7 +396,6 @@ describe("inquirer.prompt", function() {
 
       ui.rl.emit("line");
       ui.rl.emit("line");
-
     });
 
     it("should run asynchronous `when`", function( done ) {
@@ -423,7 +419,7 @@ describe("inquirer.prompt", function() {
         }
       }];
 
-      var ui = inquirer.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( answers ) {
         expect(goesInWhen).to.be.true;
         expect(answers.q2).to.equal("foo-bar");
         done();
@@ -461,10 +457,10 @@ describe("inquirer.prompt", function() {
 
   describe("#restoreDefaultPrompts()", function() {
     it("restore default prompts", function() {
-      var ConfirmPrompt = inquirer.prompts["confirm"];
+      var ConfirmPrompt = inquirer.prompt.prompts["confirm"];
       inquirer.registerPrompt("confirm", _.noop);
       inquirer.restoreDefaultPrompts();
-      expect(ConfirmPrompt).to.equal(inquirer.prompts["confirm"]);
+      expect(ConfirmPrompt).to.equal(inquirer.prompt.prompts["confirm"]);
     });
   });
 


### PR DESCRIPTION
This method allow the creation of self contained prompt function. This
mean prompts defined on each instances of a prompt module won't pollute
the scope of another.

I'm leaving here for code review from my estimate collaborators :)
