### PR TITLE
Fix multi-line error rendering for input type prompts (#167)

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -103,9 +103,10 @@ Prompt.prototype.error = function( error ) {
   var lines = (error || "Please enter a valid value")
     .split(/(?:\r\n|\n|\r)/)
     .map(function(line) { return chalk.red(">> ") + line; });
+  var len = this.errorHeight = lines.length;
   this.write( lines.join(os.EOL) );
 
-  return this.up( lines.length );
+  return this.up( len + this.height - 1 );
 };
 
 

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -7,6 +7,7 @@ var _ = require("lodash");
 var clc = require("cli-color");
 var chalk = require("chalk");
 var ansiRegex = require("ansi-regex");
+var os = require("os");
 var readline = require("readline");
 var utils = require("../utils/utils");
 var Choices = require("../objects/choices");
@@ -99,11 +100,12 @@ Prompt.prototype.error = function( error ) {
   readline.moveCursor( this.rl.output, -clc.width, 0 );
   readline.clearLine( this.rl.output, 0 );
 
-  var errMsg = chalk.red(">> ") +
-      (error || "Please enter a valid value");
-  this.write( errMsg );
+  var lines = (error || "Please enter a valid value")
+    .split(/(?:\r\n|\n|\r)/)
+    .map(function(line) { return chalk.red(">> ") + line; });
+  this.write( lines.join(os.EOL) );
 
-  return this.up(errMsg.split(/(?:\r\n|\n|\r)/).length);
+  return this.up( lines.length );
 };
 
 

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -103,7 +103,7 @@ Prompt.prototype.error = function( error ) {
       (error || "Please enter a valid value");
   this.write( errMsg );
 
-  return this.up();
+  return this.up(errMsg.split(/(?:\r\n|\n|\r)/).length);
 };
 
 

--- a/lib/prompts/input.js
+++ b/lib/prompts/input.js
@@ -83,7 +83,9 @@ Prompt.prototype.onEnd = function( state ) {
     this.status = "answered";
 
     // Re-render prompt
-    this.clean(1).render();
+    var move = this.errorHeight || 0;
+    this.down(move);
+    this.clean(move + 1).render();
 
     // Render answer
     this.write( chalk.cyan(filteredValue) + "\n" );


### PR DESCRIPTION
There was a relatively shallow, but present, rabbit-hole when addressing this issue. For ease of evaluation, I broke the commits associated with this PR into 3 distinct pieces, which I'll explain below.

#### fix rendering on multi-line errors (2976045)

This resolved the direct issue. It simply moves the cursor up based on the number of individual lines in the erorr message. Pretty simple.

#### prefix each error line with red >> (f110f1a)

When multi-line errors were printed, only the first line was prefixed with the red ">>" symbol. This commit prefixes each line in the resulting error message with that symbol for a more uniform output.

#### add errorHeight for appropriate next render (3368940)

This was the slightly tricky one. Once a multi-line error is rendered correctly, subsequent prompts, or the final result, would be rendered over it, rather than it being cleaned before moving on. For example, using the code in issue #167, the output might look something like this before this commit:

```
≫ node index.js 
? name: test
{ name: 'test' }
>> error message that is going to
(~/development/inq)how inquirer.js
≫  re-renders the prompts.
```

With this commit I added the `this.errorHeight` property that keeps track of the height of the rendered error message, which will then be subsequently be used in the `Prompt.prototype.onEnd()` function to reposition and clear the message upon successful validation. This was the best, most lightweight way I could come up with to both solve the problem and keep the `error()` and `onEnd()` functions loosely coupled.  Now it looks like this:

```
≫ node index.js 
? name: test
{ name: 'test' }
```