### PR TITLE
Correct typo on line 164

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Take `type`, `name`, `message`, `choices`[, `filter`, `validate`, `default`] pro
 
 Choices marked as `{ checked: true }` will be checked by default.
 
-Choices who're property `disabled` is truthy will be unselectable. If `disabled` is a string, then the string will be outputed next to the disabled choice, otherwise it'll default to `"Disabled"`. The `disabled` property can also be a synchronous function receiving the current answers as argument and returning a boolean or a string.
+Choices whose property `disabled` is truthy will be unselectable. If `disabled` is a string, then the string will be outputed next to the disabled choice, otherwise it'll default to `"Disabled"`. The `disabled` property can also be a synchronous function receiving the current answers as argument and returning a boolean or a string.
 
 ![Checkbox prompt](https://dl.dropboxusercontent.com/u/59696254/inquirer/checkbox-prompt.png)
 


### PR DESCRIPTION
"Choices who're property" edited to "Choices whose property."

Before:
![screen shot 2014-11-11 at 11 09 16 am](https://cloud.githubusercontent.com/assets/3811225/4999065/62842610-6993-11e4-8c24-b1f93d981ee0.png)

After:
![screen shot 2014-11-11 at 11 09 47 am](https://cloud.githubusercontent.com/assets/3811225/4999068/6ae6ddfc-6993-11e4-8701-ef1240c84ae5.png)
