### PR TITLE
Added password type to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Launch the prompt interface (inquiry session)
 A question object is a `hash` containing question related values:
 
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
-`list`, `rawlist`
+`list`, `rawlist`, `password`
 - **name**: (String) The name to use when storing the answer in the anwers hash.
 - **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers.
 - **default**: (String|Number|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.


### PR DESCRIPTION
Adding the `password` type because it is listed below types, but not here.
