### PR TITLE
Fix cli width issue for `node debug`, fixes #207

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -3,14 +3,15 @@
  * Should be extended by prompt types.
  */
 
+var rx = require("rx");
 var _ = require("lodash");
 var chalk = require("chalk");
 var ansiRegex = require("ansi-regex");
 var readline = require("readline");
+var cliWidth = require("cli-width");
 var utils = require("../utils/utils");
 var Choices = require("../objects/choices");
 var tty = require("../utils/tty");
-var rx = require("rx");
 
 /**
  * Module exports
@@ -95,7 +96,7 @@ Prompt.prototype.throwParamError = function( name ) {
  */
 
 Prompt.prototype.error = function( error ) {
-  readline.moveCursor( this.rl.output, -process.stdout.getWindowSize()[0], 0 );
+  readline.moveCursor( this.rl.output, -cliWidth(), 0 );
   readline.clearLine( this.rl.output, 0 );
 
   var errMsg = chalk.red(">> ") +
@@ -113,7 +114,7 @@ Prompt.prototype.error = function( error ) {
  */
 
 Prompt.prototype.hint = function( hint ) {
-  readline.moveCursor( this.rl.output, -process.stdout.getWindowSize()[0], 0 );
+  readline.moveCursor( this.rl.output, -cliWidth(), 0 );
   readline.clearLine( this.rl.output, 0 );
 
   if ( hint.length ) {

--- a/lib/utils/tty.js
+++ b/lib/utils/tty.js
@@ -4,6 +4,7 @@
 
 var _ = require("lodash");
 var readline = require("readline");
+var cliWidth = require("cli-width");
 
 var tty = module.exports;
 
@@ -20,7 +21,7 @@ tty.clean = function( extra ) {
   var len = this.height + extra;
 
   while ( len-- ) {
-    readline.moveCursor(this.rl.output, -process.stdout.getWindowSize()[0], 0);
+    readline.moveCursor(this.rl.output, -cliWidth(), 0);
     readline.clearLine(this.rl.output, 0);
     if ( len ) readline.moveCursor(this.rl.output, 0, -1);
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "ansi-regex": "^1.1.0",
     "chalk": "^0.5.0",
-    "cli-width": "^1.0.0",
+    "cli-width": "^1.0.1",
     "figures": "^1.3.2",
     "lodash": "~2.4.1",
     "readline2": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "ansi-regex": "^1.1.0",
     "chalk": "^0.5.0",
+    "cli-width": "^1.0.0",
     "figures": "^1.3.2",
     "lodash": "~2.4.1",
     "readline2": "~0.1.0",


### PR DESCRIPTION
Prevents scripts from crashing if using a `debugger` with `node debug my-script.js` while accepting feedback from user.