### PR TITLE
#223 Separator as a plain object

### DIFF
--- a/lib/objects/choices.js
+++ b/lib/objects/choices.js
@@ -25,6 +25,9 @@ module.exports = Choices;
 function Choices( choices, answers ) {
   this.choices = _.map( choices, function( val ) {
     if ( val.type === "separator" ) {
+      if(!(val instanceof Separator)){
+        val = new Separator(val.line);
+      }
       return val;
     }
     return new Choice( val, answers );


### PR DESCRIPTION
Issue #223
`Separator.prototype.toString` works great when we use `new inquirer.Separator() `, but when we use inquirer.js in Yeoman and try to pass plain object:
```javascript
{
     type: "separator",
     line: ">>>>>>>>"
}
``` 
we get `[object Object]`