### PR TITLE
Fix input prompt repeating value when value is longer than terminal width. Closes #214

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -8,7 +8,6 @@ var _ = require("lodash");
 var chalk = require("chalk");
 var ansiRegex = require("ansi-regex");
 var readline = require("readline");
-var cliWidth = require("cli-width");
 var utils = require("../utils/utils");
 var Choices = require("../objects/choices");
 var tty = require("../utils/tty");
@@ -96,7 +95,7 @@ Prompt.prototype.throwParamError = function( name ) {
  */
 
 Prompt.prototype.error = function( error ) {
-  readline.moveCursor( this.rl.output, -cliWidth(), 0 );
+  readline.moveCursor( this.rl.output, -utils.cliWidth(), 0 );
   readline.clearLine( this.rl.output, 0 );
 
   var errMsg = chalk.red(">> ") +
@@ -114,7 +113,7 @@ Prompt.prototype.error = function( error ) {
  */
 
 Prompt.prototype.hint = function( hint ) {
-  readline.moveCursor( this.rl.output, -cliWidth(), 0 );
+  readline.moveCursor( this.rl.output, -utils.cliWidth(), 0 );
   readline.clearLine( this.rl.output, 0 );
 
   if ( hint.length ) {

--- a/lib/prompts/input.js
+++ b/lib/prompts/input.js
@@ -2,6 +2,7 @@
  * `input` type prompt
  */
 
+var os = require("os");
 var _ = require("lodash");
 var util = require("util");
 var chalk = require("chalk");
@@ -82,7 +83,7 @@ Prompt.prototype.onEnd = function( state ) {
     this.status = "answered";
 
     // Re-render prompt
-    this.clean(1).render();
+    this.clean( this.lines() ).render();
 
     // Render answer
     this.write( chalk.cyan(filteredValue) + "\n" );
@@ -100,5 +101,14 @@ Prompt.prototype.onError = function( state ) {
  */
 
 Prompt.prototype.onKeypress = function() {
-  this.clean().render().write( this.rl.line );
+  var lines = this.lines();
+
+  // Windows duplicates the line only when the
+  // first character wraps to another line
+  if ( os.platform() === "win32" && this.previousLines === lines + 1 ) {
+    this.clean( 1 ).render();
+  }
+
+  this.previousLines = lines;
+  this.clean( this.previousLines - 1 ).render().write( this.rl.line );
 };

--- a/lib/utils/tty.js
+++ b/lib/utils/tty.js
@@ -2,11 +2,54 @@
  * TTY mixin helpers
  */
 
+var os = require("os");
 var _ = require("lodash");
 var readline = require("readline");
-var cliWidth = require("cli-width");
+var unicodeLength = require("unicode-length");
+var utils = require("./utils");
 
 var tty = module.exports;
+
+/**
+ * Get the number of lines the current line occupies
+ * @return {Number}  The number of lines
+ */
+
+tty.lines = function() {
+  var terminalWidth = utils.cliWidth();
+
+  if ( terminalWidth === 0 ) {
+
+    // Preserve original behaviour
+    return 1;
+  }
+
+  var value = this.rl.line;
+
+  if ( !value ) {
+    if ( this.rl.history ) {
+      value = this.rl.history[0];
+    } else {
+      value = this.opt.default;
+    }
+  }
+
+  var lineLength = unicodeLength.get( this.rl._prompt + value );
+
+  // Windows seems to wraps the line one character
+  // before the window width for some reason
+  if ( os.platform() === "win32" ) {
+    lineLength += 1;
+  }
+
+  var result = lineLength / terminalWidth;
+
+  if ( result % 1 === 0 ) {
+    return result;
+  } else {
+    return Math.floor( result ) + 1;
+  }
+};
 
 
 /**
@@ -21,7 +64,7 @@ tty.clean = function( extra ) {
   var len = this.height + extra;
 
   while ( len-- ) {
-    readline.moveCursor(this.rl.output, -cliWidth(), 0);
+    readline.moveCursor(this.rl.output, -utils.cliWidth(), 0);
     readline.clearLine(this.rl.output, 0);
     if ( len ) readline.moveCursor(this.rl.output, 0, -1);
   }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -7,6 +7,7 @@ var _ = require("lodash");
 var chalk = require("chalk");
 var rx = require("rx");
 var figures = require("figures");
+var cliWidth = require("cli-width");
 
 
 /**
@@ -120,4 +121,15 @@ utils.writeMessage = function ( prompt, message ) {
     prompt.left( message.length + prompt.rl.line.length );
   }
   prompt.write( message );
+};
+
+
+/**
+ * Helper for getting the terminal width
+ * Wraps cli-width for stub purposes
+ * @return {Number} - The terminal width
+ */
+
+utils.cliWidth = function() {
+  return cliWidth();
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lodash": "^3.3.1",
     "readline2": "^0.1.1",
     "rx": "^2.4.3",
-    "through": "^2.3.6"
+    "through": "^2.3.6",
+    "unicode-length": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^2.1.2",

--- a/test/helpers/readline.js
+++ b/test/helpers/readline.js
@@ -11,6 +11,7 @@ var stub = {
   pause         : sinon.stub().returns(stub),
   resume        : sinon.stub().returns(stub),
   _getCursorPos : sinon.stub().returns(stub),
+  _prompt       : sinon.stub().returns(stub),
   output        : {
     end    : sinon.stub().returns(stub),
     mute   : sinon.stub().returns(stub),

--- a/test/specs/prompts/input.js
+++ b/test/specs/prompts/input.js
@@ -4,6 +4,7 @@ var _ = require("lodash");
 var ReadlineStub = require("../../helpers/readline");
 var fixtures = require("../../helpers/fixtures");
 
+var utils = require("../../../lib/utils/utils");
 var Input = require("../../../lib/prompts/input");
 
 
@@ -51,6 +52,73 @@ describe("`input` prompt", function() {
     }.bind(this));
 
     this.rl.emit("line", "");
+  });
+
+  describe("given a terminal width", function() {
+
+    beforeEach(function() {
+      this.cliWidthStub = sinon.stub( utils, "cliWidth" );
+      this.cliWidthStub.returns(20);
+    });
+
+    afterEach(function() {
+      this.cliWidthStub.restore();
+    });
+
+    it("should clean short lines appropriately", function( done ) {
+      var prompt = new Input( this.fixture, this.rl );
+      var cleanSpy = sinon.spy( prompt, "clean" );
+      prompt.run(function() {
+        expect( cleanSpy.callCount ).to.equal(1);
+        expect( cleanSpy.calledWith(1) ).to.be.true;
+        done();
+      }.bind(this));
+
+      this.rl.line = "hello";
+      this.rl.emit( "line", this.rl.line );
+    });
+
+    it("should clean wrapped long lines", function( done ) {
+      var prompt = new Input( this.fixture, this.rl );
+      var cleanSpy = sinon.spy( prompt, "clean" );
+      prompt.run(function() {
+        expect( cleanSpy.callCount ).to.equal(1);
+        expect( cleanSpy.calledWith(3) ).to.be.true;
+        done();
+      }.bind(this));
+
+      this.rl.line = "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdf";
+      this.rl.emit( "line", this.rl.line );
+    });
+
+  });
+
+  describe("given no terminal width", function() {
+
+    beforeEach(function() {
+      this.cliWidthStub = sinon.stub( utils, "cliWidth" );
+
+      // Return the default value
+      this.cliWidthStub.returns(0);
+    });
+
+    afterEach(function() {
+      this.cliWidthStub.restore();
+    });
+
+    it("should clean one line even if the input line is long", function( done ) {
+      var prompt = new Input( this.fixture, this.rl );
+      var cleanSpy = sinon.spy( prompt, "clean" );
+      prompt.run(function() {
+        expect( cleanSpy.callCount ).to.equal(1);
+        expect( cleanSpy.calledWith(1) ).to.be.true;
+        done();
+      }.bind(this));
+
+      this.rl.line = "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdf";
+      this.rl.emit( "line", this.rl.line );
+    });
+
   });
 
 });


### PR DESCRIPTION
The problem happens because inquirer cleans only the current line on
each key stroke, without paying attention to the actual length of the
value, which might be longer than one line.

This PR was only tested on OS X. Help from people with other OSes would be appreciated.