### PR TITLE
'checked' improperly handles truthy values

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -135,7 +135,9 @@ Prompt.prototype.onError = function ( state ) {
 };
 
 Prompt.prototype.getCurrentValue = function () {
-  var choices = this.opt.choices.where({ checked: true });
+  var choices = this.opt.choices.filter(function( choice ) {
+    return !!choice.checked && !choice.disabled;
+  });
 
   this.selection = _.pluck(choices, "name");
   return _.pluck(choices, "value");

--- a/test/specs/prompts/checkbox.js
+++ b/test/specs/prompts/checkbox.js
@@ -71,11 +71,11 @@ describe("`checkbox` prompt", function() {
   it("provide an array of checked choice to validate", function( done ) {
     this.fixture.choices = [
       { name: "1", checked: true  },
-      { name: "2", checked: false },
+      { name: "2", checked: 1 },
       { name: "3", checked: false }
     ];
     this.fixture.validate = function( answer ) {
-      expect(answer).to.eql([ "1" ]);
+      expect(answer).to.eql([ "1", "2" ]);
       return true;
     };
     this.checkbox = new Checkbox( this.fixture, this.rl );


### PR DESCRIPTION
Suppling a truthy value to 'checked' resulted in the list item
being selected visually, but it was missing from the selected
elements list.

'checked' is now coerced to a boolean when selected items are
queried.

This patch closes #242.