### PR TITLE
Fix #214 by not redrawing the question on keypress

### DIFF
--- a/lib/prompts/input.js
+++ b/lib/prompts/input.js
@@ -100,5 +100,5 @@ Prompt.prototype.onError = function( state ) {
  */
 
 Prompt.prototype.onKeypress = function() {
-  this.clean().render().write( this.rl.line );
+  // do nothing
 };


### PR DESCRIPTION
I found out there was actually no good reason to do this. At least, I didn't find one, and removing this code make the input works for me again (I'm doing some sort of REPL so it's frequent to see my input wrapping).