### PR TITLE
Change the separator color

### DIFF
--- a/lib/objects/separator.js
+++ b/lib/objects/separator.js
@@ -22,7 +22,7 @@ module.exports = Separator;
 
 function Separator( line ) {
   this.type = "separator";
-  this.line = chalk.dim(line || new Array(15).join(figures.line));
+  this.line = chalk.green(line || new Array(15).join(figures.line));
 }
 
 


### PR DESCRIPTION
Just to make it more obvious its a separator.

Before: 
![screen shot 2015-06-22 at 4 29 03 pm](https://cloud.githubusercontent.com/assets/6316590/8276646/4b5a702a-18fc-11e5-9b4b-b6835f85a0c5.png)

After:
![screen shot 2015-06-22 at 4 28 29 pm](https://cloud.githubusercontent.com/assets/6316590/8276650/5012022c-18fc-11e5-94a5-5d8fa421e243.png)

My instinct always told me that "Run a generator" was selectable and I ended up selecting "Get me out of here!" :cry: 
This change makes it very clear that "Run a generator" is not selectable and it's obviously a part of the separator.