### PR TITLE
make the current answers available within validate fn

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -29,6 +29,7 @@ function Prompt( question, rl, answers ) {
   // Setup instance defaults property
   _.assign( this, {
     height : 0,
+    answers: answers,
     status : "pending"
   });
 
@@ -146,12 +147,13 @@ Prompt.prototype.validate = function( input, cb ) {
 Prompt.prototype.handleSubmitEvents = function( submit ) {
   var self = this;
   var opt = this.opt;
+  var answers = this.answers;
   var validation = submit.flatMap(function( value ) {
     return rx.Observable.create(function( observer ) {
       utils.runAsync( opt.validate, function( isValid ) {
         observer.onNext({ isValid: isValid, value: self.getCurrentValue(value) });
         observer.onCompleted();
-      }, self.getCurrentValue(value) );
+      }, self.getCurrentValue(value), answers );
     });
   }).share();
 

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -220,6 +220,33 @@ var tests = {
         this.rl.emit( "line" );
       });
 
+      it("should pass previous answers to the prompt validation function", function( done ) {
+        var prompt = inquirer.createPromptModule();
+        var questions = [{
+          type: "confirm",
+          name: "q1",
+          message: "message"
+        }, {
+          type: "confirm",
+          name: "q2",
+          message: "message",
+          validate: function(input, answers) {
+            expect(answers.q1).to.be.true;
+            return true;
+          },
+          default: false
+        }];
+
+        var ui = prompt( questions, function( answers ) {
+          expect(answers.q1).to.be.true;
+          expect(answers.q2).to.be.false;
+          done();
+        });
+
+        ui.rl.emit("line");
+        ui.rl.emit("line");
+      });
+
     });
   },
 


### PR DESCRIPTION
fix #198 

This was the simplest fix I could see. If you don't like making the answers available on the prompt itself, I'm open to suggestions about how else it could be done.