### PR TITLE
Fix wrapping bug on lists

### DIFF
--- a/examples/long-list.js
+++ b/examples/long-list.js
@@ -9,6 +9,7 @@ var choices = Array.apply(0, new Array(26)).map(function(x,y) {
   return String.fromCharCode(y + 65);
 });
 choices.push("Multiline option \n  super cool feature");
+choices.push("Super long option that should force the terminal to wrap the characters and Inquirer should not break because it's awesome.");
 
 inquirer.prompt([
   {

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -23,8 +23,13 @@ ScreenManager.prototype.render = function (content, opt) {
   this.rl.output.unmute();
   this.clean(this.prevCursor);
 
-  var lines = content.split(/\n/);
-  this.height = lines.length;
+  var lines = content.split(/\n/),
+    width = cliWidth();
+
+  this.height = lines.reduce(function(count, line) {
+    count += Math.ceil(line.length / width);
+    return count;
+  }, 0);
 
   // Write message to screen and setPrompt to control backspace
   var prompt = lines[lines.length - 1 - opt.cursor];

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -23,8 +23,8 @@ ScreenManager.prototype.render = function (content, opt) {
   this.rl.output.unmute();
   this.clean(this.prevCursor);
 
-  var lines = content.split(/\n/),
-    width = cliWidth();
+  var lines = content.split(/\n/);
+  var width = cliWidth();
 
   this.height = lines.reduce(function(count, line) {
     count += Math.ceil(line.length / width);


### PR DESCRIPTION
This should fix the issue #214 where wrapping lines caused extra lines to be added to the prompt. The problem was where the lines wrapped and it caused the screens count of lines to clear to fall out of sync. I'm not exactly sure how to unit test this but from manual tests, it seems to work fine. Another potential bug is when the terminal resizes, it will go out of sync because it only updates the line count on render so that will need to be accounted for in future.

#### Behaviour differences
Here is a demonstration of the behaviour differences introduced by this PR:
* Current (`master`): https://asciinema.org/a/c11odt2jpxncuz7jmdaymefch
* PR changes (`wrapping-bug`): https://asciinema.org/a/bsaszkvz3skkixpgtuzoy40re