### PR TITLE
Adds an option to configure input/output streams, fixes #279

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -22,9 +22,9 @@ inquirer.ui = {
 /**
  * Create a new self-contained prompt module.
  */
-inquirer.createPromptModule = function () {
+inquirer.createPromptModule = function (opt) {
   var promptModule = function (questions, allDone) {
-    var ui = new inquirer.ui.Prompt(promptModule.prompts);
+    var ui = new inquirer.ui.Prompt(promptModule.prompts, opt);
     ui.run(questions, allDone);
     return ui;
   };

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -10,7 +10,9 @@ var readlineFacade = require('readline2');
 var UI = module.exports = function (opt) {
   // Instantiate the Readline interface
   // @Note: Don't reassign if already present (allow test to override the Stream)
-  this.rl || (this.rl = readlineFacade.createInterface());
+  if (!this.rl) {
+    this.rl = readlineFacade.createInterface(opt);
+  }
   this.rl.resume();
 
   this.onForceClose = this.onForceClose.bind(this);
@@ -21,7 +23,7 @@ var UI = module.exports = function (opt) {
   process.on('exit', this.onForceClose);
 
   // Propagate keypress events directly on the readline
-  process.stdin.addListener('keypress', this.onKeypress);
+  this.rl.input.addListener('keypress', this.onKeypress);
 };
 
 
@@ -43,12 +45,12 @@ UI.prototype.onForceClose = function () {
 UI.prototype.close = function () {
   // Remove events listeners
   this.rl.removeListener('SIGINT', this.onForceClose);
-  process.stdin.removeListener('keypress', this.onKeypress);
+  this.rl.input.removeListener('keypress', this.onKeypress);
   process.removeListener('exit', this.onForceClose);
 
   // Restore prompt functionnalities
   this.rl.output.unmute();
-  process.stdout.write('\x1B[?25h'); // show cursor
+  this.rl.output.write('\x1B[?25h'); // show cursor
 
   // Close the readline
   this.rl.output.end();

--- a/lib/ui/bottom-bar.js
+++ b/lib/ui/bottom-bar.js
@@ -89,7 +89,7 @@ Prompt.prototype.write = function (message) {
   // Write message to screen and setPrompt to control backspace
   this.rl.setPrompt( _.last(msgLines) );
 
-  if ( process.stdout.rows === 0 && process.stdout.columns === 0 ) {
+  if ( this.rl.output.rows === 0 && this.rl.output.columns === 0 ) {
     /* When it's a tty through serial port there's no terminal info and the render will malfunction,
        so we need enforce the cursor to locate to the leftmost position for rendering. */
     rlUtils.left( this.rl, message.length + this.rl.line.length );

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -11,8 +11,8 @@ var Base = require('./baseUI');
  * Base interface class other can inherits from
  */
 
-var PromptUI = module.exports = function (prompts) {
-  Base.call(this);
+var PromptUI = module.exports = function (prompts, opt) {
+  Base.call(this, opt);
   this.prompts = prompts;
 };
 util.inherits(PromptUI, Base);

--- a/test/helpers/readline.js
+++ b/test/helpers/readline.js
@@ -19,6 +19,10 @@ var stub = {
     write  : function (str) {
       this.__raw__ += str;
     }
+  },
+  input: {
+    addListener   : sinon.stub(),
+    removeListener: sinon.stub()
   }
 };
 


### PR DESCRIPTION
Adds a third option to the `inquirer.prompt` method to allow for configurable input/output streams.

When no value is supplied defaults to `process.stdin`/`process.stdout`.

@SBoudrias 