### PR TITLE
Add handle for active prompt.

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -1,7 +1,8 @@
 'use strict';
 var _ = require('lodash');
 var readlineFacade = require('readline2');
-
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
 
 /**
  * Base interface class other can inherits from
@@ -24,6 +25,7 @@ var UI = module.exports = function (opt) {
   process.on('exit', this.onForceClose);
 };
 
+util.inherits(UI, EventEmitter);
 
 /**
  * Handle the ^C exit

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -85,6 +85,7 @@ PromptUI.prototype.fetchAnswer = function (question) {
   var prompt = new Prompt(question, this.rl, this.answers);
   var answers = this.answers;
   this._activePrompt = prompt;
+  this.emit('new-prompt', prompt);
   return utils.createObservableFromAsync(function () {
     var done = this.async();
     prompt.run(function (answer) {

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -75,14 +75,21 @@ PromptUI.prototype.processQuestion = function (question) {
   }.bind(this));
 };
 
+PromptUI.prototype.activePrompt = function () {
+  return this._activePrompt;
+};
+
 PromptUI.prototype.fetchAnswer = function (question) {
+  var self = this;
   var Prompt = this.prompts[question.type];
   var prompt = new Prompt(question, this.rl, this.answers);
   var answers = this.answers;
+  this._activePrompt = prompt;
   return utils.createObservableFromAsync(function () {
     var done = this.async();
     prompt.run(function (answer) {
       answers[question.name] = answer;
+      delete self._activePrompt;
       done({ name: question.name, answer: answer });
     });
   });


### PR DESCRIPTION
When `inquirer.prompt` is called, the `UI` object is returned. However, in the course of cycling through prompts, the currently active prompt is never exposed to either the `UI` object nor `inquirer` itself. 

I added a simple handle that cleans itself up, and exposed a public function to the `UI` object returned in a prompt, so that one can programatically assess and handle the current prompt.

Usage example:

```js
var prompt = inquirer.prompt(options, function(result) {
  console.log(prompt.activePrompt()); // returns undefined - the prompt has terminated.
});
console.log(prompt.activePrompt()); // returns the prompt object
```

This would be tremendously helpful for programmatic use of Inquirer.js as I can then hook in keypress events and control the active prompt in a proper fashion. This is needed to finish this pjt:

https://github.com/vorpaljs/vorpal-less 

:)