### PR TITLE
Set a default cli width of 80 characters

### DIFF
--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -5,6 +5,8 @@ var readline = require('readline');
 var cliWidth = require('cli-width');
 var stripAnsi = require('strip-ansi');
 
+// Prevent crashes on environments where the width can't be properly detected
+cliWidth.defaultWidth = 80;
 
 var ScreenManager = module.exports = function (rl) {
   // These variables are keeping information to allow correct prompt re-rendering


### PR DESCRIPTION
In some environment, `cli-width` is known to return a default value of
`0`, which causes inquirer to crash in such a context.

Fixes: https://github.com/SBoudrias/Inquirer.js/issues/290