### PR TITLE
added pageSize option for prompts that use paginator

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -96,7 +96,7 @@ Prompt.prototype.render = function (error) {
     message += chalk.cyan( this.selection.join(", ") );
   } else {
     var choicesStr = renderChoices(this.opt.choices, this.pointer);
-    message += "\n" + this.paginator.paginate(choicesStr, this.pointer);
+    message += "\n" + this.paginator.paginate(choicesStr, this.pointer, this.opt.pageSize);
   }
 
   if (error) {

--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -80,7 +80,7 @@ Prompt.prototype.render = function (error, hint) {
     message += chalk.cyan( this.selected.name );
   } else if ( this.status === "expanded" ) {
     var choicesStr = renderChoices(this.opt.choices, this.selectedKey);
-    message += this.paginator.paginate(choicesStr, this.selectedKey);
+    message += this.paginator.paginate(choicesStr, this.selectedKey, this.opt.pageSize);
     message += "\n  Answer: ";
   }
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -94,7 +94,7 @@ Prompt.prototype.render = function() {
     message += chalk.cyan( this.opt.choices.getChoice(this.selected).short );
   } else {
     var choicesStr = listRender(this.opt.choices, this.selected );
-    message += "\n" + this.paginator.paginate(choicesStr, this.selected);
+    message += "\n" + this.paginator.paginate(choicesStr, this.selected, this.opt.pageSize);
   }
 
   this.firstRender = false;

--- a/lib/prompts/rawlist.js
+++ b/lib/prompts/rawlist.js
@@ -93,7 +93,7 @@ Prompt.prototype.render = function (error) {
     message += chalk.cyan(this.opt.choices.getChoice(this.selected).name);
   } else {
     var choicesStr = renderChoices(this.opt.choices, this.selected);
-    message += this.paginator.paginate(choicesStr, this.selected);
+    message += this.paginator.paginate(choicesStr, this.selected, this.opt.pageSize);
     message += "\n  Answer: ";
   }
 

--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -14,8 +14,8 @@ var Paginator = module.exports = function () {
   this.lastIndex = 0;
 };
 
-Paginator.prototype.paginate = function (output, active) {
-  var pageSize = 7;
+Paginator.prototype.paginate = function (output, active, pageSize) {
+  var pageSize = pageSize || 7;
   var lines = output.split('\n');
 
   // Make sure there's enough lines to paginate


### PR DESCRIPTION
Prompts that use the paginator (checkbox, expand, list, and rawList) can now be passed an optional pageSize parameter. Defaults to 7.