### PR TITLE
Fix offset separator

### DIFF
--- a/examples/checkbox.js
+++ b/examples/checkbox.js
@@ -11,23 +11,40 @@ inquirer.prompt([
     message: "Select toppings",
     name: "toppings",
     choices: [
-      new inquirer.Separator("The usual:"),
+      new inquirer.Separator(" = The Meats = "),
       {
         name: "Peperonni"
       },
       {
-        name: "Cheese",
-        checked: true
+        name: "Ham"
       },
       {
-        name: "Mushroom"
-      },
-      new inquirer.Separator("The extras:"),
-      {
-        name: "Pineapple",
+        name: "Ground Meat"
       },
       {
         name: "Bacon"
+      },
+      new inquirer.Separator(" = The Cheeses = "),
+      {
+        name: "Mozzarella",
+        checked: true
+      },
+      {
+        name: "Cheddar"
+      },
+      {
+        name: "Parmesan"
+      },
+      new inquirer.Separator(" = The usual ="),
+      {
+        name: "Mushroom"
+      },
+      {
+        name: "Tomato"
+      },
+      new inquirer.Separator(" = The extras = "),
+      {
+        name: "Pineapple",
       },
       {
         name: "Olives",

--- a/lib/objects/choices.js
+++ b/lib/objects/choices.js
@@ -96,6 +96,9 @@ Choices.prototype.pluck = function (propertyName) {
 
 
 // Expose usual Array methods
+Choices.prototype.indexOf = function () {
+  return this.choices.indexOf.apply(this.choices, arguments);
+};
 Choices.prototype.forEach = function () {
   return this.choices.forEach.apply(this.choices, arguments);
 };

--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -96,7 +96,8 @@ Prompt.prototype.render = function (error) {
     message += chalk.cyan( this.selection.join(", ") );
   } else {
     var choicesStr = renderChoices(this.opt.choices, this.pointer);
-    message += "\n" + this.paginator.paginate(choicesStr, this.pointer, this.opt.pageSize);
+    var indexPosition = this.opt.choices.indexOf(this.opt.choices.getChoice(this.pointer));
+    message += "\n" + this.paginator.paginate(choicesStr, indexPosition, this.opt.pageSize);
   }
 
   if (error) {
@@ -168,7 +169,6 @@ Prompt.prototype.toggleChoice = function( index ) {
   var checked = this.opt.choices.getChoice(index).checked;
   this.opt.choices.getChoice(index).checked = !checked;
 };
-
 
 /**
  * Function for rendering checkbox choices

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -94,7 +94,8 @@ Prompt.prototype.render = function() {
     message += chalk.cyan( this.opt.choices.getChoice(this.selected).short );
   } else {
     var choicesStr = listRender(this.opt.choices, this.selected );
-    message += "\n" + this.paginator.paginate(choicesStr, this.selected, this.opt.pageSize);
+    var indexPosition = this.opt.choices.indexOf(this.opt.choices.getChoice(this.selected));
+    message += "\n" + this.paginator.paginate(choicesStr, indexPosition, this.opt.pageSize);
   }
 
   this.firstRender = false;


### PR DESCRIPTION
Fix bug when a list prompt has separator and is longer than pageSize (using paginator)

The offset of the separator was added to the cursor position but the index of the first line to print was wrong.