### PR TITLE
fix incorrect cursor position

### DIFF
--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -3,16 +3,13 @@ var _ = require('lodash');
 var util = require('./readline');
 var cliWidth = require('cli-width');
 var stripAnsi = require('strip-ansi');
+var stringWidth = require('string-width');
 
 // Prevent crashes on environments where the width can't be properly detected
 cliWidth.defaultWidth = 80;
 
 function height(content) {
   return content.split('\n').length;
-}
-
-function width(content) {
-  return stripAnsi(content).length;
 }
 
 function lastLine(content) {
@@ -35,8 +32,6 @@ var ScreenManager = module.exports = function (rl) {
 };
 
 ScreenManager.prototype.render = function (content, bottomContent) {
-  var cursorPos = this.rl._getCursorPos();
-
   this.rl.output.unmute();
   this.clean(this.extraLinesUnderPrompt);
 
@@ -55,6 +50,9 @@ ScreenManager.prototype.render = function (content, bottomContent) {
     prompt = prompt.slice(0, -this.rl.line.length);
   }
   this.rl.setPrompt(prompt);
+
+  // setPrompt will change cursor position, now we can get correct value
+  var cursorPos = this.rl._getCursorPos();
 
   content = forceLineReturn(content);
   if (bottomContent) {
@@ -82,14 +80,10 @@ ScreenManager.prototype.render = function (content, bottomContent) {
   }
 
   // Reset cursor at the beginning of the line
-  util.left(this.rl, width(lastLine(fullContent)));
+  util.left(this.rl, stringWidth(lastLine(fullContent)));
 
   // Adjust cursor on the right
-  var rightPos = cursorPos.cols;
-  if (cursorPos.rows === 0) {
-    rightPos = Math.max(rightPos, width(lastLine(content)));
-  }
-  util.right(this.rl, rightPos);
+  util.right(this.rl, cursorPos.cols);
 
   /**
    * Set up state for next re-rendering

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "readline2": "^1.0.1",
     "run-async": "^0.1.0",
     "rx-lite": "^3.1.2",
+    "string-width": "^1.0.1",
     "strip-ansi": "^3.0.0",
     "through": "^2.3.6"
   },


### PR DESCRIPTION
I found two bugs when use input prompt.

## First One

When prompt message contains multibyte characters (e.g. Chinese/Japanese), the input cursor position will move away:

![qq20160116-0](https://cloud.githubusercontent.com/assets/4136679/12372543/1514024e-bc97-11e5-88dd-16c225c01332.png)

The reason is result of `width()` function in screen-manager.js doesn't match with display length.

## The Second

When I moved LEFT key after typed some text in answer area, the cursor does't move; but when I type again, the characters will come out from the front of cursor.

![qq20160116-1](https://cloud.githubusercontent.com/assets/4136679/12372669/c2ca7d02-bc9a-11e5-8d52-40177d92acc4.png)

When re-adjust cursor one the right in ScreenManager.render, the column size does't match with real cursor in mute stream