### PR TITLE
Add trimming of choice input

### DIFF
--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -134,7 +134,7 @@ Prompt.prototype.onSubmit = function( input ) {
     input = this.rawDefault;
   }
 
-  var selected = this.opt.choices.where({ key : input.toLowerCase() })[0];
+  var selected = this.opt.choices.where({ key : input.toLowerCase().trim() })[0];
 
   if ( selected != null && selected.key === "h" ) {
     this.selectedKey = "";

--- a/test/specs/prompts/expand.js
+++ b/test/specs/prompts/expand.js
@@ -74,6 +74,14 @@ describe("`expand` prompt", function() {
     this.rl.emit("line", "b");
   });
 
+  it("should strip the user input", function( done ) {
+    this.expand.run(function( answer ) {
+      expect(answer).to.equal("bar");
+      done();
+    });
+    this.rl.emit("line", " b ");
+  });
+
   it("should have help option", function( done ) {
     var run = 0;
     this.expand.run(function( answer ) {


### PR DESCRIPTION
Hey, thanks for your work on this! I interact with it as a user of Ember CLI’s update process.

A surprising number of times, I get the `Please enter a valid command` error because I’ve typed a space before my letter choice. It’s user error and easily remedied by entering the command again without whitespace, but maybe other people make this same mistake and this little tweak would help!

I did see this in the contribution guidelines:

> Send _fixes_ PR on the `master` branch. Any new features should be send on the `wip`branch.

I’m not sure whether this constitutes a bug fix or a new feature, so let me know if I should resubmit to `wip`. Or if there are any other changes I should make.