### PR TITLE
add sanity check for screen width

### DIFF
--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -17,10 +17,11 @@ function lastLine(content) {
 }
 
 function normalizedCliWidth() {
+  var width = cliWidth() || cliWidth.defaultWidth;
   if (process.platform === 'win32') {
-    return cliWidth() - 1;
+    return width - 1;
   }
-  return cliWidth();
+  return width;
 }
 
 var ScreenManager = module.exports = function (rl) {


### PR DESCRIPTION
string-width can return a 0 width screen, which causes inquirer to blow up:

https://gist.github.com/bcoe/6bc16d0dbe5190b8d302

I'm submitted a [pull request](https://github.com/knownasilya/cli-width/pull/6) to `cli-width`, but I felt it might be worthwhile to defend against this in inquirer as well.