### PR TITLE
Use "short" property in expanding prompts

### DIFF
--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -77,7 +77,7 @@ Prompt.prototype.render = function (error, hint) {
   var bottomContent = '';
 
   if ( this.status === "answered" ) {
-    message += chalk.cyan( this.selected.name );
+    message += chalk.cyan( this.selected.short || this.selected.name );
   } else if ( this.status === "expanded" ) {
     var choicesStr = renderChoices(this.opt.choices, this.selectedKey);
     message += this.paginator.paginate(choicesStr, this.selectedKey, this.opt.pageSize);


### PR DESCRIPTION
Choice objects may have a `"short"` property which is defined as a text displayed after selection. However, it doesn't work for all prompt types.

This patch makes `"expand"` work properly with `"short"` properties, that is, prefer it to `"name"` after selection.