### PR TITLE
Updates cli-width dependency

### DIFF
--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -5,23 +5,12 @@ var cliWidth = require('cli-width');
 var stripAnsi = require('strip-ansi');
 var stringWidth = require('string-width');
 
-// Prevent crashes on environments where the width can't be properly detected
-cliWidth.defaultWidth = 80;
-
 function height(content) {
   return content.split('\n').length;
 }
 
 function lastLine(content) {
   return _.last(content.split('\n'));
-}
-
-function normalizedCliWidth() {
-  var width = cliWidth() || cliWidth.defaultWidth;
-  if (process.platform === 'win32') {
-    return width - 1;
-  }
-  return width;
 }
 
 var ScreenManager = module.exports = function (rl) {
@@ -54,15 +43,16 @@ ScreenManager.prototype.render = function (content, bottomContent) {
 
   // setPrompt will change cursor position, now we can get correct value
   var cursorPos = this.rl._getCursorPos();
+  var width = this.normalizedCliWidth();
 
-  content = forceLineReturn(content);
+  content = forceLineReturn(content, width);
   if (bottomContent) {
-    bottomContent = forceLineReturn(bottomContent);
+    bottomContent = forceLineReturn(bottomContent, width);
   }
   // Manually insert an extra line if we're at the end of the line.
   // This prevent the cursor from appearing at the beginning of the
   // current line.
-  if (rawPromptLine.length % normalizedCliWidth() === 0) {
+  if (rawPromptLine.length % width === 0) {
     content = content + '\n';
   }
   var fullContent = content + (bottomContent ? '\n' + bottomContent : '');
@@ -74,7 +64,7 @@ ScreenManager.prototype.render = function (content, bottomContent) {
 
   // We need to consider parts of the prompt under the cursor as part of the bottom
   // content in order to correctly cleanup and re-render.
-  var promptLineUpDiff = Math.floor(rawPromptLine.length / normalizedCliWidth()) - cursorPos.rows;
+  var promptLineUpDiff = Math.floor(rawPromptLine.length / width) - cursorPos.rows;
   var bottomContentHeight = promptLineUpDiff + (bottomContent ? height(bottomContent) : 0);
   if (bottomContentHeight > 0) {
     util.up(this.rl, bottomContentHeight);
@@ -108,10 +98,20 @@ ScreenManager.prototype.done = function () {
   this.rl.output.write('\n');
 };
 
-function breakLines(lines) {
+ScreenManager.prototype.normalizedCliWidth = function () {
+  var width = cliWidth({
+    defaultWidth: 80,
+    output: this.rl.output
+  });
+  if (process.platform === 'win32') {
+    return width - 1;
+  }
+  return width;
+};
+
+function breakLines(lines, width) {
   // Break lines who're longuer than the cli width so we can normalize the natural line
   // returns behavior accross terminals.
-  var width = normalizedCliWidth();
   var regex = new RegExp(
     '(?:(?:\\033\[[0-9;]*m)*.?){1,' + width + '}',
     'g'
@@ -124,6 +124,6 @@ function breakLines(lines) {
   });
 }
 
-function forceLineReturn(content) {
-  return _.flatten(breakLines(content.split('\n'))).join('\n');
+function forceLineReturn(content, width) {
+  return _.flatten(breakLines(content.split('\n'), width)).join('\n');
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ansi-regex": "^2.0.0",
     "chalk": "^1.0.0",
     "cli-cursor": "^1.0.1",
-    "cli-width": "^1.0.1",
+    "cli-width": "^2.0.0",
     "figures": "^1.3.5",
     "lodash": "^3.3.1",
     "readline2": "^1.0.1",


### PR DESCRIPTION
Greetings my friend @SBoudrias,

**cli-width** finally got a major release with a nicer API to define `defaultWidth` AND the possibility of configure an option **stdout** as described on #285 

This PR updates the dependency to its latest version `v2.0.0` - it's also worth noting that this version also contains a fix to the annoying issue where the default value wouldn't be used, reported and patched on #326

Unfortunately, I had to do a bit of moving around to be able to get the value of `this.rl.output` - please let me know if that's good enough.

Thanks :zap: 