### PR TITLE
Move cursor to end (of bottom content) on forced close

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -1,3 +1,7 @@
+/* global -Promise */
+var Promise = require('pinkie-promise');
+var _ = require('lodash');
+
 /**
  * Inquirer.js
  * A collection of common interactive command line user interfaces.
@@ -25,8 +29,21 @@ inquirer.ui = {
 inquirer.createPromptModule = function (opt) {
   var promptModule = function (questions, allDone) {
     var ui = new inquirer.ui.Prompt(promptModule.prompts, opt);
-    ui.run(questions, allDone);
-    return ui;
+    var promise = new Promise(function (resolve, reject) {
+      ui.run(questions, function (answers) {
+        if (_.isFunction(allDone)) {
+          allDone(answers);
+        }
+        resolve(answers);
+      });
+    });
+
+    // Monkey patch the readline and Observable `process` object on the
+    // promise object so they remain publicly accessible.
+    promise.rl = ui.rl;
+    promise.process = ui.process;
+
+    return promise;
   };
   promptModule.prompts = {};
 

--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -30,11 +30,16 @@ inquirer.createPromptModule = function (opt) {
   var promptModule = function (questions, allDone) {
     var ui = new inquirer.ui.Prompt(promptModule.prompts, opt);
     var promise = new Promise(function (resolve, reject) {
-      ui.run(questions, function (answers) {
+      ui.run(questions, function (err, answers) {
         if (_.isFunction(allDone)) {
-          allDone(answers);
+          allDone(err, answers);
         }
-        resolve(answers);
+
+        if (err) {
+          reject(err);
+        } else {
+          resolve(answers);
+        }
       });
     });
 

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -9,11 +9,8 @@ var chalk = require('chalk');
 var ansiRegex = require('ansi-regex');
 var runAsync = require('run-async');
 var Choices = require('../objects/choices');
-var ScreenManager = require('../utils/screen-manager');
 
-
-var Prompt = module.exports = function (question, rl, answers) {
-
+var Prompt = module.exports = function (question, screen, rl, answers) {
   // Setup instance defaults property
   _.assign(this, {
     answers: answers,
@@ -41,7 +38,7 @@ var Prompt = module.exports = function (question, rl, answers) {
   }
 
   this.rl = rl;
-  this.screen = new ScreenManager(this.rl);
+  this.screen = screen;
 };
 
 

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -1,6 +1,7 @@
 'use strict';
 var _ = require('lodash');
 var readlineFacade = require('readline2');
+var ScreenManager = require('../utils/screen-manager');
 
 
 /**
@@ -36,11 +37,12 @@ UI.prototype.onForceClose = function () {
 };
 
 /**
- * Set the currently active screen manager.
+ * Create a new Screen Manager and remember it for when there's a forced close
  */
 
-UI.prototype.setCurrentScreen = function (screen) {
-  this.currentScreen = screen;
+UI.prototype.createScreen = function () {
+  this.currentScreen = new ScreenManager(this.rl);
+  return this.currentScreen;
 };
 
 /**

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -35,6 +35,13 @@ UI.prototype.onForceClose = function () {
   console.log('\n'); // Line return
 };
 
+/**
+ * Set the currently active screen manager.
+ */
+
+UI.prototype.setActiveScreen = function (screen) {
+  this.activeScreen = screen;
+};
 
 /**
  * Close the interface and cleanup listeners

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -49,8 +49,8 @@ UI.prototype.close = function (force) {
   this.rl.output.unmute();
 
   // Move the cursor to the end of the active screen
-  if (force && this.rl.activeScreen) {
-    this.rl.activeScreen.releaseCursor();
+  if (force && this.activeScreen) {
+    this.activeScreen.releaseCursor();
   }
 
   // Close the readline

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -31,7 +31,7 @@ var UI = module.exports = function (opt) {
  */
 
 UI.prototype.onForceClose = function () {
-  this.close(true);
+  this.close();
   console.log('\n'); // Line return
 };
 
@@ -39,15 +39,15 @@ UI.prototype.onForceClose = function () {
  * Set the currently active screen manager.
  */
 
-UI.prototype.setActiveScreen = function (screen) {
-  this.activeScreen = screen;
+UI.prototype.setCurrentScreen = function (screen) {
+  this.currentScreen = screen;
 };
 
 /**
  * Close the interface and cleanup listeners
  */
 
-UI.prototype.close = function (force) {
+UI.prototype.close = function () {
   // Remove events listeners
   this.rl.removeListener('SIGINT', this.onForceClose);
   process.removeListener('exit', this.onForceClose);
@@ -55,9 +55,10 @@ UI.prototype.close = function (force) {
   // Restore prompt functionnalities
   this.rl.output.unmute();
 
-  // Move the cursor to the end of the active screen
-  if (force && this.activeScreen) {
-    this.activeScreen.releaseCursor();
+  // In case this is a forced close, move the cursor to
+  // the end of the last active screen
+  if (this.currentScreen) {
+    this.currentScreen.releaseCursor();
   }
 
   // Close the readline

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -31,7 +31,7 @@ var UI = module.exports = function (opt) {
  */
 
 UI.prototype.onForceClose = function () {
-  this.close();
+  this.close(true);
   console.log('\n'); // Line return
 };
 
@@ -40,13 +40,18 @@ UI.prototype.onForceClose = function () {
  * Close the interface and cleanup listeners
  */
 
-UI.prototype.close = function () {
+UI.prototype.close = function (force) {
   // Remove events listeners
   this.rl.removeListener('SIGINT', this.onForceClose);
   process.removeListener('exit', this.onForceClose);
 
   // Restore prompt functionnalities
   this.rl.output.unmute();
+
+  // Move the cursor to the end of the active screen
+  if (force && this.rl.activeScreen) {
+    this.rl.activeScreen.releaseCursor();
+  }
 
   // Close the readline
   this.rl.output.end();

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -76,12 +76,10 @@ PromptUI.prototype.processQuestion = function (question) {
 };
 
 PromptUI.prototype.fetchAnswer = function (question) {
+  var screen = this.createScreen();
   var Prompt = this.prompts[question.type];
-  var prompt = new Prompt(question, this.rl, this.answers);
+  var prompt = new Prompt(question, screen, this.rl, this.answers);
   var answers = this.answers;
-
-  // Remember the screen for when there's a forced close
-  this.setCurrentScreen(prompt.screen);
 
   return utils.createObservableFromAsync(function () {
     var done = this.async();

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -79,9 +79,14 @@ PromptUI.prototype.fetchAnswer = function (question) {
   var Prompt = this.prompts[question.type];
   var prompt = new Prompt(question, this.rl, this.answers);
   var answers = this.answers;
+  var self = this;
+
   return utils.createObservableFromAsync(function () {
     var done = this.async();
+    self.activeScreen = prompt.screen;
+
     prompt.run(function (answer) {
+      self.activeScreen = null;
       answers[question.name] = answer;
       done({ name: question.name, answer: answer });
     });

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -54,7 +54,7 @@ PromptUI.prototype.onCompletion = function () {
   this.close();
 
   if (_.isFunction(this.completed)) {
-    this.completed(this.answers);
+    this.completed(null, this.answers);
   }
 };
 

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -83,10 +83,10 @@ PromptUI.prototype.fetchAnswer = function (question) {
 
   return utils.createObservableFromAsync(function () {
     var done = this.async();
-    self.activeScreen = prompt.screen;
+    self.setActiveScreen(prompt.screen);
 
     prompt.run(function (answer) {
-      self.activeScreen = null;
+      self.setActiveScreen(null);
       answers[question.name] = answer;
       done({ name: question.name, answer: answer });
     });

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -79,14 +79,13 @@ PromptUI.prototype.fetchAnswer = function (question) {
   var Prompt = this.prompts[question.type];
   var prompt = new Prompt(question, this.rl, this.answers);
   var answers = this.answers;
-  var self = this;
+
+  // Remember the screen for when there's a forced close
+  this.setCurrentScreen(prompt.screen);
 
   return utils.createObservableFromAsync(function () {
     var done = this.async();
-    self.setActiveScreen(prompt.screen);
-
     prompt.run(function (answer) {
-      self.setActiveScreen(null);
       answers[question.name] = answer;
       done({ name: question.name, answer: answer });
     });

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -19,7 +19,6 @@ var ScreenManager = module.exports = function (rl) {
   this.extraLinesUnderPrompt = 0;
 
   this.rl = rl;
-  if (rl) rl.activeScreen = this;
 };
 
 ScreenManager.prototype.render = function (content, bottomContent) {
@@ -100,7 +99,6 @@ ScreenManager.prototype.releaseCursor = function () {
 };
 
 ScreenManager.prototype.done = function () {
-  this.rl.activeScreen = null;
   this.rl.setPrompt('');
   this.rl.output.unmute();
   this.rl.output.write('\n');

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -19,6 +19,7 @@ var ScreenManager = module.exports = function (rl) {
   this.extraLinesUnderPrompt = 0;
 
   this.rl = rl;
+  if (rl) rl.activeScreen = this;
 };
 
 ScreenManager.prototype.render = function (content, bottomContent) {
@@ -92,7 +93,14 @@ ScreenManager.prototype.clean = function (extraLines) {
   util.clearLine(this.rl, this.height);
 };
 
+ScreenManager.prototype.releaseCursor = function () {
+  if (this.extraLinesUnderPrompt > 0) {
+    util.down(this.rl, this.extraLinesUnderPrompt);
+  }
+};
+
 ScreenManager.prototype.done = function () {
+  this.rl.activeScreen = null;
   this.rl.setPrompt('');
   this.rl.output.unmute();
   this.rl.output.write('\n');

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -102,6 +102,10 @@ ScreenManager.prototype.done = function () {
   this.rl.setPrompt('');
   this.rl.output.unmute();
   this.rl.output.write('\n');
+
+  // Clear state
+  this.height = 0;
+  this.extraLinesUnderPrompt = 0;
 };
 
 ScreenManager.prototype.normalizedCliWidth = function () {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cli-width": "^2.0.0",
     "figures": "^1.3.5",
     "lodash": "^4.3.0",
+    "pinkie-promise": "^2.0.0",
     "readline2": "^1.0.1",
     "run-async": "^0.1.0",
     "rx-lite": "^3.1.2",

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -225,7 +225,7 @@ var tests = {
           default: false
         }];
 
-        var ui = prompt( questions, function( answers ) {
+        var ui = prompt( questions, function( err, answers ) {
           expect(answers.q1).to.be.true;
           expect(answers.q2).to.be.false;
           done();

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -23,7 +23,7 @@ describe("inquirer.prompt", function() {
       type: "confirm",
       name: "q1",
       message: "message"
-    }, function( answers ) {
+    }, function( err, answers ) {
       expect(rl1.close.called).to.be.true;
       expect(rl1.output.end.called).to.be.true;
 
@@ -32,7 +32,7 @@ describe("inquirer.prompt", function() {
         type: "confirm",
         name: "q1",
         message: "message"
-      }, function( answers ) {
+      }, function( err, answers ) {
         expect(rl2.close.called).to.be.true;
         expect(rl2.output.end.called).to.be.true;
 
@@ -60,7 +60,7 @@ describe("inquirer.prompt", function() {
       default: false
     }];
 
-    var ui = this.prompt( prompts, function( answers ) {
+    var ui = this.prompt( prompts, function( err, answers ) {
       expect(answers.q1).to.be.true;
       expect(answers.q2).to.be.false;
       done();
@@ -78,7 +78,7 @@ describe("inquirer.prompt", function() {
       default: "bar"
     };
 
-    var ui = this.prompt( prompt, function( answers ) {
+    var ui = this.prompt( prompt, function( err, answers ) {
       expect(answers.q1).to.equal("bar");
       done();
     });
@@ -200,7 +200,7 @@ describe("inquirer.prompt", function() {
       }
     }];
 
-    var ui = this.prompt( prompts, function( answers ) {
+    var ui = this.prompt( prompts, function( err, answers ) {
       expect(goesInDefault).to.be.true;
       expect(answers.q2).to.equal(input2Default);
       done();
@@ -321,7 +321,7 @@ describe("inquirer.prompt", function() {
       }, 30 );
     });
 
-    var ui = this.prompt( prompts, function( answers ) {
+    var ui = this.prompt( prompts, function( err, answers ) {
       expect(answers.q1).to.be.true;
       expect(answers.q2).to.be.false;
       done();
@@ -346,7 +346,7 @@ describe("inquirer.prompt", function() {
         }
       }];
 
-      var ui = this.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( err, answers ) {
         done();
       });
 
@@ -370,7 +370,7 @@ describe("inquirer.prompt", function() {
         }
       }];
 
-      var ui = this.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( err, answers ) {
         expect(goesInWhen).to.be.true;
         expect(answers.q2).to.equal("bar-var");
         done();
@@ -393,7 +393,7 @@ describe("inquirer.prompt", function() {
         when: true
       }];
 
-      var ui = this.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( err, answers ) {
         expect(answers.q2).to.equal("bar-var");
         done();
       });
@@ -423,7 +423,7 @@ describe("inquirer.prompt", function() {
         default: "foo"
       }];
 
-      var ui = this.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( err, answers ) {
         expect(goesInWhen).to.be.true;
         expect(answers.q2).to.not.exist;
         expect(answers.q3).to.equal("foo");
@@ -452,7 +452,7 @@ describe("inquirer.prompt", function() {
         default: "foo"
       }];
 
-      var ui = this.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( err, answers ) {
         expect(answers.q2).to.not.exist;
         expect(answers.q3).to.equal("foo");
         expect(answers.q1).to.be.true;
@@ -484,7 +484,7 @@ describe("inquirer.prompt", function() {
         }
       }];
 
-      var ui = this.prompt( prompts, function( answers ) {
+      var ui = this.prompt( prompts, function( err, answers ) {
         expect(goesInWhen).to.be.true;
         expect(answers.q2).to.equal("foo-bar");
         done();
@@ -543,7 +543,7 @@ describe("inquirer.prompt", function() {
       message: "message"
     }];
 
-    var ui = prompt( prompts, function( answers ) {
+    var ui = prompt( prompts, function( err, answers ) {
       process.stdout.getWindowSize = original;
       expect(answers.q1).to.equal(true);
       done();

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -26,7 +26,6 @@ describe("inquirer.prompt", function() {
     }, function( answers ) {
       expect(rl1.close.called).to.be.true;
       expect(rl1.output.end.called).to.be.true;
-      expect(prompt.rl).to.not.exist;
 
       var rl2;
       var prompt2 = ctx.prompt({
@@ -36,7 +35,6 @@ describe("inquirer.prompt", function() {
       }, function( answers ) {
         expect(rl2.close.called).to.be.true;
         expect(rl2.output.end.called).to.be.true;
-        expect(prompt.rl).to.not.exist;
 
         expect( rl1 ).to.not.equal( rl2 );
         done();
@@ -260,6 +258,23 @@ describe("inquirer.prompt", function() {
     }];
 
     var ui = this.prompt(prompts, function() {});
+    ui.rl.emit("line");
+  });
+
+  it("should returns a promise", function( done ) {
+    var prompt = {
+      type: "input",
+      name: "q1",
+      message: "message",
+      default: "bar"
+    };
+
+    var ui = this.prompt(prompt);
+    ui.then(function( answers ) {
+      expect(answers.q1).to.equal("bar");
+      done();
+    });
+
     ui.rl.emit("line");
   });
 


### PR DESCRIPTION
If a (custom) prompt renders some bottomContent (e.g. `this.screen.render(msg, 'bottom')`), but the user aborts, the cursor should be moved to the end of the last active screen.

A gif to show the problem and the fix (after `npm link inquirer`):

![inquirer-cursor-fix-cut](https://cloud.githubusercontent.com/assets/3055345/13534972/fdd51890-e237-11e5-8dc2-7dcada210eb8.gif)

(this is running [my fork](https://github.com/vweevers/inquirer-autocomplete-prompt/tree/inquirer-0.11) of [inquirer-autocomplete-prompt](https://github.com/mokkabonna/inquirer-autocomplete-prompt), which renders the autocomplete list as bottomContent so that the cursor stays at the normal text input above it. And in both instances, I'm pressing `a` to trigger the search, then `ctrl-c`.)