### PR TITLE
(Fix) Use promises in examples to log out answers

### DIFF
--- a/examples/checkbox.js
+++ b/examples/checkbox.js
@@ -61,6 +61,6 @@ inquirer.prompt([
       return true;
     }
   }
-], function (answers) {
+]).then(function (answers) {
   console.log(JSON.stringify(answers, null, '  '));
 });

--- a/examples/pizza.js
+++ b/examples/pizza.js
@@ -92,7 +92,7 @@ var questions = [
   }
 ];
 
-inquirer.prompt(questions, function (answers) {
+inquirer.prompt(questions).then(function (answers) {
   console.log('\nOrder receipt:');
   console.log(JSON.stringify(answers, null, '  '));
 });


### PR DESCRIPTION
Fixes #341 

Any ideas @SBoudrias


Now the stock examples log correctly:
<img width="774" alt="screen shot 2016-03-14 at 4 43 45 pm" src="https://cloud.githubusercontent.com/assets/1396559/13763737/cbab0c00-ea05-11e5-952d-1e3a7f0de976.png">
<img width="774" alt="screen shot 2016-03-14 at 4 47 16 pm" src="https://cloud.githubusercontent.com/assets/1396559/13763744/d33acfa0-ea05-11e5-8790-15735c765169.png">
