### PR TITLE
Fixed spelling and grammatical errors in examples and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A collection of common interactive command line user interfaces.
 - *validating* answers
 - managing *hierarchical prompts*
 
-> **Note:** **`Inquirer.js`** provides the user interface, and the inquiry session flow. If you're searching for a full blown command line program utility, then check out [Commander.js](https://github.com/visionmedia/commander.js) or [Vorpal.js](https://github.com/dthree/vorpal).
+> **Note:** **`Inquirer.js`** provides the user interface and the inquiry session flow. If you're searching for a full blown command line program utility, then check out [Commander.js](https://github.com/visionmedia/commander.js) or [Vorpal.js](https://github.com/dthree/vorpal).
 
 
 ## Documentation
@@ -39,7 +39,7 @@ inquirer.prompt([/* Pass your questions in here */], function( answers ) {
 
 
 ### Examples (Run it and see it)
-Checkout the `examples/` folder for code and interface examples.
+Check out the `examples/` folder for code and interface examples.
 
 ``` shell
 node examples/pizza.js

--- a/examples/checkbox.js
+++ b/examples/checkbox.js
@@ -13,7 +13,7 @@ inquirer.prompt([
     choices: [
       new inquirer.Separator(" = The Meats = "),
       {
-        name: "Peperonni"
+        name: "Pepperonni"
       },
       {
         name: "Ham"

--- a/examples/pizza.js
+++ b/examples/pizza.js
@@ -52,8 +52,8 @@ var questions = [
     choices: [
       {
         key: "p",
-        name: "Peperonni and chesse",
-        value: "PeperonniChesse"
+        name: "Pepperonni and Chesse",
+        value: "PepperonniChesse"
       },
       {
         key: "a",
@@ -62,8 +62,8 @@ var questions = [
       },
       {
         key: "w",
-        name: "Hawaïan",
-        value: "hawaian"
+        name: "Hawaiian",
+        value: "hawaiian"
       }
     ]
   },


### PR DESCRIPTION
In the examples, I fixed misspelling of the words "Pepperoni" and "Hawaiian". In the readme, I removed a comma that didn't make much sense and separated the words "check" and "out".