### PR TITLE
Add missing options to question type description

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ prompt(questions).then(/* ... */);
 A question object is a `hash` containing question related values:
 
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
-`list`, `rawlist`, `password`
+`list`, `rawlist`, `expand`, `checkbox`, `password`
 - **name**: (String) The name to use when storing the answer in the answers hash.
 - **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers.
 - **default**: (String|Number|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.


### PR DESCRIPTION
The description of possible question `type` did not include

* `expand`
* `checkbox`

Add these options (which are present in the `type` detail section).