### PR TITLE
fix #373

### DIFF
--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -193,17 +193,11 @@ Prompt.prototype.onKeypress = function () {
 
 Prompt.prototype.validateChoices = function (choices) {
   var formatError;
-  var typeError;
   var errors = [];
   var keymap = {};
   choices.filter(Separator.exclude).forEach(function (choice) {
     if (!choice.key || choice.key.length !== 1) {
       formatError = true;
-    }
-    if (choice.value !== undefined) {
-      if (typeof choice.value !== 'string' && typeof choice.value !== 'boolean' && typeof choice.value !== 'number') {
-        typeError = true;
-      }
     }
     if (keymap[choice.key]) {
       errors.push(choice.key);
@@ -214,9 +208,6 @@ Prompt.prototype.validateChoices = function (choices) {
 
   if (formatError) {
     throw new Error('Format error: `key` param must be a single letter and is required.');
-  }
-  if (typeError) {
-    throw new Error('Type error: `value` param must be a string, a number or a boolean.');
   }
   if (keymap.h) {
     throw new Error('Reserved key error: `key` param cannot be `h` - this value is reserved.');

--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -190,11 +190,17 @@ Prompt.prototype.onKeypress = function () {
 
 Prompt.prototype.validateChoices = function (choices) {
   var formatError;
+  var typeError;
   var errors = [];
   var keymap = {};
   choices.filter(Separator.exclude).forEach(function (choice) {
     if (!choice.key || choice.key.length !== 1) {
       formatError = true;
+    }
+    if (choice.value !== undefined) {
+      if (typeof choice.value !== 'string') {
+        typeError = true;
+      }
     }
     if (keymap[choice.key]) {
       errors.push(choice.key);
@@ -205,6 +211,9 @@ Prompt.prototype.validateChoices = function (choices) {
 
   if (formatError) {
     throw new Error('Format error: `key` param must be a single letter and is required.');
+  }
+  if (typeError) {
+    throw new Error('Type error: `value` param must be a string.');
   }
   if (keymap.h) {
     throw new Error('Reserved key error: `key` param cannot be `h` - this value is reserved.');

--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -201,7 +201,7 @@ Prompt.prototype.validateChoices = function (choices) {
       formatError = true;
     }
     if (choice.value !== undefined) {
-      if (typeof choice.value !== 'string' || typeof choice.value !== 'boolean' || typeof choice.value !== 'number') {
+      if (typeof choice.value !== 'string' && typeof choice.value !== 'boolean' && typeof choice.value !== 'number') {
         typeError = true;
       }
     }

--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -115,7 +115,10 @@ Prompt.prototype.getCurrentValue = function (input) {
     return null;
   }
 
-  return selected.value || selected.name;
+  if (selected.value === undefined) {
+    return selected.name;
+  }
+  return selected.value;
 };
 
 /**
@@ -198,7 +201,7 @@ Prompt.prototype.validateChoices = function (choices) {
       formatError = true;
     }
     if (choice.value !== undefined) {
-      if (typeof choice.value !== 'string') {
+      if (typeof choice.value !== 'string' || typeof choice.value !== 'boolean' || typeof choice.value !== 'number') {
         typeError = true;
       }
     }
@@ -213,7 +216,7 @@ Prompt.prototype.validateChoices = function (choices) {
     throw new Error('Format error: `key` param must be a single letter and is required.');
   }
   if (typeError) {
-    throw new Error('Type error: `value` param must be a string.');
+    throw new Error('Type error: `value` param must be a string, a number or a boolean.');
   }
   if (keymap.h) {
     throw new Error('Reserved key error: `key` param cannot be `h` - this value is reserved.');

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -35,7 +35,9 @@ module.exports = {
       {key: 'a', name: 'acab'},
       new inquirer.Separator(),
       {key: 'b', name: 'bar'},
-      {key: 'c', name: 'chile'}
+      {key: 'c', name: 'chile'},
+      {key: 'd', name: 'david', value: false},
+      {key: 'e', name: 'ellias', value: 5}
     ]
   },
 

--- a/test/specs/prompts/expand.js
+++ b/test/specs/prompts/expand.js
@@ -21,6 +21,17 @@ describe('`expand` prompt', function () {
     expect(mkPrompt).to.throw(/Format error/);
   });
 
+  it('should throw if `value` has a wrong type', function () {
+    var mkPrompt = function () {
+      this.fixture.choices = [
+          {key: 'a', name: 'foo', value: null}
+      ];
+      return new Expand(this.fixture, this.rl);
+    }.bind(this);
+
+    expect(mkPrompt).to.throw(/Type error/);
+  });
+
   it('should throw if `key` is duplicate', function () {
     var mkPrompt = function () {
       this.fixture.choices = [
@@ -121,7 +132,7 @@ describe('`expand` prompt', function () {
     this.expand = new Expand(this.fixture, this.rl);
 
     this.expand.run();
-    expect(this.rl.output.__raw__).to.contain('(aBch)');
+    expect(this.rl.output.__raw__).to.contain('(aBcdeh)');
   });
 
   it('should \'autocomplete\' the user input', function (done) {

--- a/test/specs/prompts/expand.js
+++ b/test/specs/prompts/expand.js
@@ -21,17 +21,6 @@ describe('`expand` prompt', function () {
     expect(mkPrompt).to.throw(/Format error/);
   });
 
-  it('should throw if `value` has a wrong type', function () {
-    var mkPrompt = function () {
-      this.fixture.choices = [
-          {key: 'a', name: 'foo', value: null}
-      ];
-      return new Expand(this.fixture, this.rl);
-    }.bind(this);
-
-    expect(mkPrompt).to.throw(/Type error/);
-  });
-
   it('should throw if `key` is duplicate', function () {
     var mkPrompt = function () {
       this.fixture.choices = [


### PR DESCRIPTION
This patch aims to fix [#373](https://github.com/SBoudrias/Inquirer.js/issues/373).
It checks whether the attribute `value` is really a string, and throw an error if needed.

Updated : it now allows the value to be a String, a Boolean or a Integer. (Nb, it would probably be good to also support Objects)