### PR TITLE
Fix `subscribe` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ prompts.onCompleted();
 And using the return value `process` property, you can access more fine grained callbacks:
 
 ```js
-inquirer.prompt(prompts).process.subscribe(
+inquirer.prompt(prompts).ui.process.subscribe(
   onEachAnswer,
   onError,
   onComplete


### PR DESCRIPTION
After some debugging, found that the `process` attribute is nested under `ui`