### PR TITLE
Adds customizable checkbox formatting.

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -24,8 +24,6 @@ module.exports = Prompt;
 function Prompt() {
   Base.apply(this, arguments);
 
-  console.log(this.opt);
-
   if (!this.opt.choices) {
     this.throwParamError('choices');
   }

--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -24,6 +24,8 @@ module.exports = Prompt;
 function Prompt() {
   Base.apply(this, arguments);
 
+  console.log(this.opt);
+
   if (!this.opt.choices) {
     this.throwParamError('choices');
   }
@@ -92,7 +94,7 @@ Prompt.prototype.render = function (error) {
   if (this.status === 'answered') {
     message += chalk.cyan(this.selection.join(', '));
   } else {
-    var choicesStr = renderChoices(this.opt.choices, this.pointer);
+    var choicesStr = renderChoices(this.opt, this.pointer);
     var indexPosition = this.opt.choices.indexOf(this.opt.choices.getChoice(this.pointer));
     message += '\n' + this.paginator.paginate(choicesStr, indexPosition, this.opt.pageSize);
   }
@@ -169,7 +171,8 @@ Prompt.prototype.toggleChoice = function (index) {
  * @return {String}         Rendered content
  */
 
-function renderChoices(choices, pointer) {
+function renderChoices(opt, pointer) {
+  var choices = opt.choices;
   var output = '';
   var separatorOffset = 0;
 
@@ -187,7 +190,7 @@ function renderChoices(choices, pointer) {
     } else {
       var isSelected = (i - separatorOffset === pointer);
       output += isSelected ? chalk.cyan(figures.pointer) : ' ';
-      output += getCheckbox(choice.checked) + ' ' + choice.name;
+      output += getCheckbox(choice.checked, opt) + ' ' + choice.name;
     }
 
     output += '\n';
@@ -202,6 +205,8 @@ function renderChoices(choices, pointer) {
  * @return {String} Composited checkbox string
  */
 
-function getCheckbox(checked) {
-  return checked ? chalk.green(figures.radioOn) : figures.radioOff;
+function getCheckbox(checked, opt) {
+  return checked ?
+    _.get(opt, 'format.checked', chalk.green(figures.radioOn)) :
+    _.get(opt, 'format.unchecked', figures.radioOff);
 }


### PR DESCRIPTION
I like Inquirer, but I'm not a fan of the radio button format for checkboxes. This PR adds a configurable `format` option to checkbox types that lets you specify your own formats.

I'd be happy to write a test for this but I couldn't figure out how to get it to print the prompt and then read the output.