### PR TITLE
Add error handling for errors produced in filter function

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -89,6 +89,8 @@ Prompt.prototype.handleSubmitEvents = function (submit) {
       return validate(filteredValue, self.answers).then(function (isValid) {
         return {isValid: isValid, value: filteredValue};
       });
+    }, function (err) {
+      return {isValid: err};
     });
   }).share();
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -60,6 +60,8 @@ util.inherits(Prompt, Base);
 Prompt.prototype._run = function (cb) {
   this.done = cb;
 
+  var self = this;
+
   var events = observe(this.rl);
   events.normalizedUpKey.takeUntil(events.line).forEach(this.onUpKey.bind(this));
   events.normalizedDownKey.takeUntil(events.line).forEach(this.onDownKey.bind(this));
@@ -67,7 +69,11 @@ Prompt.prototype._run = function (cb) {
   events.line
     .take(1)
     .map(this.getCurrentValue.bind(this))
-    .flatMap(runAsync(this.opt.filter))
+    .flatMap(function (value) {
+      return runAsync(self.opt.filter)(value).catch(function (err) {
+        return err;
+      });
+    })
     .forEach(this.onSubmit.bind(this));
 
   // Init the prompt

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -109,6 +109,29 @@ var tests = {
 
         this.rl.emit('line', '');
       });
+
+      it('should handle errors produced in async filters', function () {
+        var called = 0;
+        var rl = this.rl;
+
+        this.fixture.filter = function () {
+          called++;
+          var cb = this.async();
+
+          if (called === 2) {
+            return cb(null, 'pass');
+          }
+
+          rl.emit('line');
+          return cb(new Error('fail'));
+        };
+
+        var prompt = new this.Prompt(this.fixture, this.rl);
+        var promise = prompt.run();
+
+        this.rl.emit('line');
+        return promise;
+      });
     });
   },
 


### PR DESCRIPTION
Changes behavior of errors produced in async filter functions from
throwing to printing the error and reprompting the user for a
non-erroring input. Addresses #363

cc/ @rclark @SBoudrias @iongion