### PR TITLE
Ensure provided options aren't overwritten on successive prompt calls

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -54,14 +54,16 @@ function setupReadlineOptions(opt) {
   opt = opt || {};
 
   // Default `input` to stdin
-  opt.input = opt.input || process.stdin;
+  var input = opt.input || process.stdin;
 
   // Add mute capabilities to the output
   var ms = new MuteStream();
   ms.pipe(opt.output || process.stdout);
-  opt.output = ms;
+  var output = ms;
 
   return _.extend({
-    terminal: true
-  }, opt);
+    terminal: true,
+    input: input,
+    output: output
+  }, _.omit(opt, ['input', 'output']));
 }


### PR DESCRIPTION
closes #414
- fix issue with custom prompt modules on successive calls