### PR TITLE
add support for overriding the "?" prefix for questions

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -118,7 +118,7 @@ Prompt.prototype.handleSubmitEvents = function (submit) {
  */
 
 Prompt.prototype.getQuestion = function () {
-  var message = chalk.green('?') + ' ' + chalk.bold(this.opt.message) + ' ';
+  var message = (this.opt.hasOwnProperty('prefixMessage') ? this.opt.prefixMessage : chalk.green('?') + ' ') + chalk.bold(this.opt.message) + ' ';
 
   // Append the default if available, and if question isn't answered
   if (this.opt.default != null && this.status !== 'answered') {


### PR DESCRIPTION
This pull request adds support for clients overriding the "?" prefix that appears on question prompts, by specifying a prefixMessage property.
