### PR TITLE
Add support for object paths in question names

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A question object is a `hash` containing question related values:
 
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
 `list`, `rawlist`, `expand`, `checkbox`, `password`, `editor`
-- **name**: (String) The name to use when storing the answer in the answers hash.
+- **name**: (String) The name to use when storing the answer in the answers hash. If the name contains periods, it will define a path in the answers hash.
 - **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers.
 - **default**: (String|Number|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.
 - **choices**: (Array|Function) Choices array or a function returning a choices array. If defined as a function, the first parameter will be the current inquirer session answers.

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -40,7 +40,7 @@ PromptUI.prototype.run = function (questions) {
 
   return this.process
     .reduce(function (answers, answer) {
-      this.answers[answer.name] = answer.answer;
+      _.set(this.answers, answer.name, answer.answer);
       return this.answers;
     }.bind(this), {})
     .toPromise(Promise)

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -72,6 +72,33 @@ describe('inquirer.prompt', function () {
     });
   });
 
+  it('should take a prompts array with nested names', function () {
+    var prompts = [{
+      type: 'confirm',
+      name: 'foo.bar.q1',
+      message: 'message'
+    }, {
+      type: 'confirm',
+      name: 'foo.q2',
+      message: 'message',
+      default: false
+    }];
+
+    var promise = this.prompt(prompts);
+    autosubmit(promise.ui);
+
+    return promise.then(function (answers) {
+      expect(answers).to.deep.equal({
+        foo: {
+          bar: {
+            q1: true
+          },
+          q2: false
+        }
+      });
+    });
+  });
+
   it('should take a single prompt and return answer', function () {
     var prompt = {
       type: 'input',


### PR DESCRIPTION
Consider the following set of questions:

``` js
{
  type: 'input',
  name: 'name.first',
  message: 'What\'s your first name?'
},
{
  type: 'input',
  name: 'name.last',
  message: 'What\'s your last name?'
}
```

The resulting answer object will look something like this:

``` js
{
  'name.first': 'John',
  'name.last': 'Doe'
}
```

If the `name` properties contains periods, it makes sense that Inquirer
will interpret them as paths in the final answers object, resulting in
something like this instead:

``` js
{
  name: {
    first: 'John',
    last: 'Doe'
  }
}
```

This change is implemented by making use of `_.set` when assigning the
value to the answers hash.

Signed-off-by: Juan Cruz Viotti jviotti@openmailbox.org
