### PR TITLE
Allow ESCAPE in list prompt

### DIFF
--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -147,7 +147,6 @@ Prompt.prototype.onCancel = function () {
   this.done(null);
 };
 
-
 /**
  * When user press a key
  */

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -66,6 +66,7 @@ Prompt.prototype._run = function (cb) {
   events.normalizedUpKey.takeUntil(events.line).forEach(this.onUpKey.bind(this));
   events.normalizedDownKey.takeUntil(events.line).forEach(this.onDownKey.bind(this));
   events.numberKey.takeUntil(events.line).forEach(this.onNumberKey.bind(this));
+  events.normalizedEscapeKey.take(1).forEach(this.onCancel.bind(this));
   events.line
     .take(1)
     .map(this.getCurrentValue.bind(this))
@@ -93,12 +94,14 @@ Prompt.prototype.render = function () {
   var message = this.getQuestion();
 
   if (this.firstRender) {
-    message += chalk.dim('(Use arrow keys)');
+    message += chalk.dim('(Use arrow keys, ESC to cancel)');
   }
 
   // Render choices or answer depending on the state
   if (this.status === 'answered') {
     message += chalk.cyan(this.opt.choices.getChoice(this.selected).short);
+  } else if (this.status === 'canceled') {
+    message += chalk.cyan('Canceled');
   } else {
     var choicesStr = listRender(this.opt.choices, this.selected);
     var indexPosition = this.opt.choices.indexOf(this.opt.choices.getChoice(this.selected));
@@ -128,6 +131,22 @@ Prompt.prototype.onSubmit = function (value) {
 Prompt.prototype.getCurrentValue = function () {
   return this.opt.choices.getChoice(this.selected).value;
 };
+
+/**
+ * When user press `escape` key
+ */
+
+Prompt.prototype.onCancel = function () {
+  this.status = 'canceled';
+
+  // Rerender prompt
+  this.render();
+
+  this.screen.done();
+  cliCursor.show();
+  this.done(null);
+};
+
 
 /**
  * When user press a key

--- a/lib/utils/events.js
+++ b/lib/utils/events.js
@@ -24,6 +24,10 @@ module.exports = function (rl) {
       return e.key.name === 'down' || e.key.name === 'j' || (e.key.name === 'n' && e.key.ctrl);
     }).share(),
 
+    normalizedEscapeKey: keypress.filter(function (e) {
+      return e.key.name === 'esc' || e.key.name === 'escape';
+    }).share(),
+
     numberKey: keypress.filter(function (e) {
       return e.value && '123456789'.indexOf(e.value) >= 0;
     }).map(function (e) {

--- a/test/specs/prompts/list.js
+++ b/test/specs/prompts/list.js
@@ -31,6 +31,16 @@ describe('`list` prompt', function () {
     this.rl.emit('line');
   });
 
+  it('should abort when user presses escape', function (done) {
+    this.list.run().then(function (answer) {
+      expect(answer).to.equal(null);
+      done();
+    });
+
+    this.rl.input.emit('keypress', '', {name: 'escape'});
+    this.rl.emit('line');
+  });
+
   it('should allow for arrow navigation', function (done) {
     this.list.run().then(function (answer) {
       expect(answer).to.equal('bar');


### PR DESCRIPTION
This (small) PR allows pressing ESC while in the list prompt. When this happens, the prompt is closed exactly in the same way as when it is normally answered, but a `null` value is returned.

I've included a unit test to validate the new functionality.
