### PR TITLE
Fix for #442 (editor comes up again if it's not the last question / ObjectDisposedError)

### DIFF
--- a/lib/prompts/editor.js
+++ b/lib/prompts/editor.js
@@ -37,7 +37,7 @@ Prompt.prototype._run = function (cb) {
 
   // Open Editor on "line" (Enter Key)
   var events = observe(this.rl);
-  events.line.forEach(this.startExternalEditor.bind(this));
+  this.lineSubscription = events.line.forEach(this.startExternalEditor.bind(this));
 
   // Trigger Validation when editor closes
   var validation = this.handleSubmitEvents(this.editorResult);
@@ -97,6 +97,7 @@ Prompt.prototype.endExternalEditor = function (error, result) {
 
 Prompt.prototype.onEnd = function (state) {
   this.editorResult.dispose();
+  this.lineSubscription.dispose();
   this.answer = state.value;
   this.status = 'answered';
   // Re-render prompt


### PR DESCRIPTION
The editor result object was properly disposed (which then causes the error message), but the editor stayed subscribed to line events (which causes it to come up again after the next question).  
That subscription is now disposed properly, too, so editor questions can be used again if they are not the last question. So, this fixes issue #442 (editor issues).