### PR TITLE
Only interpret arrays of strings as object paths in question names

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A question object is a `hash` containing question related values:
 
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
 `list`, `rawlist`, `expand`, `checkbox`, `password`, `editor`
-- **name**: (String) The name to use when storing the answer in the answers hash. If the name contains periods, it will define a path in the answers hash.
+- **name**: (String|Array) The name to use when storing the answer in the answers hash. If the name is an array of strings, it will define a path in the answers hash.
 - **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers.
 - **default**: (String|Number|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.
 - **choices**: (Array|Function) Choices array or a function returning a choices array. If defined as a function, the first parameter will be the current inquirer session answers.

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -40,7 +40,12 @@ PromptUI.prototype.run = function (questions) {
 
   return this.process
     .reduce(function (answers, answer) {
-      _.set(this.answers, answer.name, answer.answer);
+      if (_.isArray(answer.name)) {
+        _.set(this.answers, answer.name, answer.answer);
+      } else {
+        this.answers[answer.name] = answer.answer;
+      }
+
       return this.answers;
     }.bind(this), {})
     .toPromise(Promise)

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -71,7 +71,34 @@ describe('inquirer.prompt', function () {
     });
   });
 
-  it('should take a prompts array with nested names', function () {
+  it('should take a prompts array with array names', function () {
+    var prompts = [{
+      type: 'confirm',
+      name: ['foo', 'bar', 'q1'],
+      message: 'message'
+    }, {
+      type: 'confirm',
+      name: ['foo', 'q2'],
+      message: 'message',
+      default: false
+    }];
+
+    var promise = this.prompt(prompts);
+    autosubmit(promise.ui);
+
+    return promise.then(function (answers) {
+      expect(answers).to.deep.equal({
+        foo: {
+          bar: {
+            q1: true
+          },
+          q2: false
+        }
+      });
+    });
+  });
+
+  it('should not nest answers if prompts names are string containing periods', function () {
     var prompts = [{
       type: 'confirm',
       name: 'foo.bar.q1',
@@ -88,12 +115,8 @@ describe('inquirer.prompt', function () {
 
     return promise.then(function (answers) {
       expect(answers).to.deep.equal({
-        foo: {
-          bar: {
-            q1: true
-          },
-          q2: false
-        }
+        'foo.bar.q1': true,
+        'foo.q2': false
       });
     });
   });


### PR DESCRIPTION
The following pull-request: https://github.com/SBoudrias/Inquirer.js/pull/425 introduced a change
where we would use `_.set` to set a value in the answers object, since
that Lodash function has the nice property that it will interpret
strings as object paths, and will create nested objects if the question
name contains periods.

As raised in a comment after the pull-request was merged, this causes
problems when the question names represent file names containing
extensions, since `_.set` will incorrectly interpret the extension
period as a path delimiter.

In order to solve this regression, while still preserving this
functionality, this commit makes use of `_.set` only of the question
name consists of an array of strings.

In summary, a question name such as `[ foo, bar, baz ]` will be
interpreted as an object path, while `foo.bar.baz` will be interpreted
literally.

See: https://github.com/SBoudrias/Inquirer.js/pull/425
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>