### PR TITLE
Scroller fixed to middle of list

### DIFF
--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -23,7 +23,7 @@ Paginator.prototype.paginate = function (output, active, pageSize) {
     return output;
   }
 
-  // Move the pointer only when the user go down and limit it to 3
+  // Move the pointer only when the user go down and limit it to the middle of the list
   if (this.pointer < middleOfList && this.lastIndex < active && active - this.lastIndex < 9) {
     this.pointer = Math.min(middleOfList, this.pointer + active - this.lastIndex);
   }

--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -15,6 +15,7 @@ var Paginator = module.exports = function () {
 
 Paginator.prototype.paginate = function (output, active, pageSize) {
   pageSize = pageSize || 7;
+  var middleOfList = Math.floor(pageSize/2);
   var lines = output.split('\n');
 
   // Make sure there's enough lines to paginate
@@ -23,8 +24,8 @@ Paginator.prototype.paginate = function (output, active, pageSize) {
   }
 
   // Move the pointer only when the user go down and limit it to 3
-  if (this.pointer < 3 && this.lastIndex < active && active - this.lastIndex < 9) {
-    this.pointer = Math.min(3, this.pointer + active - this.lastIndex);
+  if (this.pointer < middleOfList && this.lastIndex < active && active - this.lastIndex < 9) {
+    this.pointer = Math.min(middleOfList, this.pointer + active - this.lastIndex);
   }
   this.lastIndex = active;
 

--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -15,7 +15,7 @@ var Paginator = module.exports = function () {
 
 Paginator.prototype.paginate = function (output, active, pageSize) {
   pageSize = pageSize || 7;
-  var middleOfList = Math.floor(pageSize/2);
+  var middleOfList = Math.floor(pageSize / 2);
   var lines = output.split('\n');
 
   // Make sure there's enough lines to paginate


### PR DESCRIPTION
This fixes a somewhat broken implementation of pageSize. It always fixed the list at position 4. So any pageSize below that caused the currently selected item to be out of the visible area.

Now we fix it to the middle of the list.