### PR TITLE
Clears screen at bottom of prompt - alternative

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -7,8 +7,9 @@ var _ = require('lodash');
 var chalk = require('chalk');
 var runAsync = require('run-async');
 var Choices = require('../objects/choices');
+var ScreenManager = require('../utils/screen-manager');
 
-var Prompt = module.exports = function (question, screen, rl, answers) {
+var Prompt = module.exports = function (question, rl, answers) {
   // Setup instance defaults property
   _.assign(this, {
     answers: answers,
@@ -42,7 +43,7 @@ var Prompt = module.exports = function (question, screen, rl, answers) {
   }
 
   this.rl = rl;
-  this.screen = screen;
+  this.screen = new ScreenManager(this.rl);
 };
 
 /**

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -6,6 +6,7 @@
 var _ = require('lodash');
 var chalk = require('chalk');
 var runAsync = require('run-async');
+var readline = require('../utils/readline');
 var Choices = require('../objects/choices');
 var ScreenManager = require('../utils/screen-manager');
 
@@ -72,6 +73,15 @@ Prompt.prototype._run = function (cb) {
 
 Prompt.prototype.throwParamError = function (name) {
   throw new Error('You must provide a `' + name + '` parameter');
+};
+
+/**
+ * Called when the UI closes. Override to do any specific cleanup necessary
+ */
+Prompt.prototype.close = function () {
+  if (this.screen.extraLinesUnderPrompt > 0) {
+    readline.down(this.rl, this.screen.extraLinesUnderPrompt);
+  }
 };
 
 /**

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -9,7 +9,7 @@ var runAsync = require('run-async');
 var Choices = require('../objects/choices');
 var ScreenManager = require('../utils/screen-manager');
 
-var Prompt = module.exports = function (question, rl, answers) {
+var Prompt = module.exports = function (question, screen, rl, answers) {
   // Setup instance defaults property
   _.assign(this, {
     answers: answers,
@@ -43,7 +43,7 @@ var Prompt = module.exports = function (question, rl, answers) {
   }
 
   this.rl = rl;
-  this.screen = new ScreenManager(this.rl);
+  this.screen = screen;
 };
 
 /**

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -7,7 +7,6 @@ var _ = require('lodash');
 var chalk = require('chalk');
 var runAsync = require('run-async');
 var Choices = require('../objects/choices');
-var ScreenManager = require('../utils/screen-manager');
 
 var Prompt = module.exports = function (question, screen, rl, answers) {
   // Setup instance defaults property

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -43,7 +43,8 @@ UI.prototype.close = function () {
 
   // Restore prompt functionnalities
   this.rl.output.unmute();
-  if (this.activePrompt && this.activePrompt.close) {
+
+  if (this.activePrompt && typeof this.activePrompt.close === 'function') {
     this.activePrompt.close();
   }
 

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -2,7 +2,6 @@
 var _ = require('lodash');
 var MuteStream = require('mute-stream');
 var readline = require('readline');
-var ScreenManager = require('../utils/screen-manager');
 
 /**
  * Base interface class other can inherits from
@@ -17,7 +16,6 @@ var UI = module.exports = function (opt) {
   this.rl.resume();
 
   this.onForceClose = this.onForceClose.bind(this);
-  this.currentScreen = new ScreenManager(this.rl);
 
   // Make sure new prompt start on a newline when closing
   this.rl.on('SIGINT', this.onForceClose);
@@ -45,11 +43,8 @@ UI.prototype.close = function () {
 
   // Restore prompt functionnalities
   this.rl.output.unmute();
-
-  // In case this is a forced close, move the cursor to
-  // the end of the last active screen
-  if (this.currentScreen) {
-    this.currentScreen.releaseCursor();
+  if (this.activePrompt && this.activePrompt.close) {
+    this.activePrompt.close();
   }
 
   // Close the readline

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -2,6 +2,7 @@
 var _ = require('lodash');
 var MuteStream = require('mute-stream');
 var readline = require('readline');
+var ScreenManager = require('../utils/screen-manager');
 
 /**
  * Base interface class other can inherits from
@@ -33,6 +34,15 @@ UI.prototype.onForceClose = function () {
 };
 
 /**
+ + * Create a new Screen Manager and remember it for when there's a forced close
+ + */
+
+UI.prototype.createScreen = function () {
+  this.currentScreen = new ScreenManager(this.rl);
+  return this.currentScreen;
+};
+
+/**
  * Close the interface and cleanup listeners
  */
 
@@ -43,6 +53,12 @@ UI.prototype.close = function () {
 
   // Restore prompt functionnalities
   this.rl.output.unmute();
+
+  // In case this is a forced close, move the cursor to
+  // the end of the last active screen
+  if (this.currentScreen) {
+    this.currentScreen.releaseCursor();
+  }
 
   // Close the readline
   this.rl.output.end();

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -17,6 +17,7 @@ var UI = module.exports = function (opt) {
   this.rl.resume();
 
   this.onForceClose = this.onForceClose.bind(this);
+  this.currentScreen = new ScreenManager(this.rl);
 
   // Make sure new prompt start on a newline when closing
   this.rl.on('SIGINT', this.onForceClose);
@@ -31,15 +32,6 @@ var UI = module.exports = function (opt) {
 UI.prototype.onForceClose = function () {
   this.close();
   console.log('\n'); // Line return
-};
-
-/**
- + * Create a new Screen Manager and remember it for when there's a forced close
- + */
-
-UI.prototype.createScreen = function () {
-  this.currentScreen = new ScreenManager(this.rl);
-  return this.currentScreen;
 };
 
 /**

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -72,9 +72,8 @@ PromptUI.prototype.processQuestion = function (question) {
 };
 
 PromptUI.prototype.fetchAnswer = function (question) {
-  var screen = this.createScreen();
   var Prompt = this.prompts[question.type];
-  var prompt = new Prompt(question, screen, this.rl, this.answers);
+  var prompt = new Prompt(question, this.currentScreen, this.rl, this.answers);
   return rx.Observable.defer(function () {
     return rx.Observable.fromPromise(prompt.run().then(function (answer) {
       return {name: question.name, answer: answer};

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -73,7 +73,8 @@ PromptUI.prototype.processQuestion = function (question) {
 
 PromptUI.prototype.fetchAnswer = function (question) {
   var Prompt = this.prompts[question.type];
-  var prompt = new Prompt(question, this.currentScreen, this.rl, this.answers);
+  var prompt = new Prompt(question, this.rl, this.answers);
+  this.activePrompt = prompt;
   return rx.Observable.defer(function () {
     return rx.Observable.fromPromise(prompt.run().then(function (answer) {
       return {name: question.name, answer: answer};

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -72,8 +72,9 @@ PromptUI.prototype.processQuestion = function (question) {
 };
 
 PromptUI.prototype.fetchAnswer = function (question) {
+  var screen = this.createScreen();
   var Prompt = this.prompts[question.type];
-  var prompt = new Prompt(question, this.rl, this.answers);
+  var prompt = new Prompt(question, screen, this.rl, this.answers);
   return rx.Observable.defer(function () {
     return rx.Observable.fromPromise(prompt.run().then(function (answer) {
       return {name: question.name, answer: answer};

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -92,10 +92,20 @@ ScreenManager.prototype.clean = function (extraLines) {
   util.clearLine(this.rl, this.height);
 };
 
+ScreenManager.prototype.releaseCursor = function () {
+  if (this.extraLinesUnderPrompt > 0) {
+    util.down(this.rl, this.extraLinesUnderPrompt);
+  }
+};
+
 ScreenManager.prototype.done = function () {
   this.rl.setPrompt('');
   this.rl.output.unmute();
   this.rl.output.write('\n');
+
+  // Clear state
+  this.height = 0;
+  this.extraLinesUnderPrompt = 0;
 };
 
 ScreenManager.prototype.normalizedCliWidth = function () {

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -92,20 +92,10 @@ ScreenManager.prototype.clean = function (extraLines) {
   util.clearLine(this.rl, this.height);
 };
 
-ScreenManager.prototype.releaseCursor = function () {
-  if (this.extraLinesUnderPrompt > 0) {
-    util.down(this.rl, this.extraLinesUnderPrompt);
-  }
-};
-
 ScreenManager.prototype.done = function () {
   this.rl.setPrompt('');
   this.rl.output.unmute();
   this.rl.output.write('\n');
-
-  // Clear state
-  this.height = 0;
-  this.extraLinesUnderPrompt = 0;
 };
 
 ScreenManager.prototype.normalizedCliWidth = function () {


### PR DESCRIPTION
I made some quick changes that implements it the alternative way.

And then I do in my prompt:

```js
Prompt.prototype.close = function() {
  if (this.screen.extraLinesUnderPrompt > 0) {
   utils.down(this.rl, this.screen.extraLinesUnderPrompt);
  }
}
```

This approach makes way less changes to the code. I am in favor of this.

Should also document this behaviour maybe? Nice for prompt authors to know about.