### PR TITLE
Restores functionality of clearing screen

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -40,6 +40,8 @@ UI.prototype.close = function () {
   this.rl.removeListener('SIGINT', this.onForceClose);
   process.removeListener('exit', this.onForceClose);
 
+  this.rl.output.unmute();
+
   if (this.activePrompt && typeof this.activePrompt.close === 'function') {
     this.activePrompt.close();
   }


### PR DESCRIPTION
After the changes you @SBoudrias  introduced here https://github.com/SBoudrias/Inquirer.js/commit/79eebac61d2b1843df77435ca938fe3283ff8f5a and that are in 3.0.2, the clearing of the screen does not work any more.

I located what change caused it. This should restore it. Tested with my autocomplete prompt https://github.com/mokkabonna/inquirer-autocomplete-prompt