### PR TITLE
Prevent extra items in list, higher than pageSize

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -40,6 +40,8 @@ UI.prototype.close = function () {
   this.rl.removeListener('SIGINT', this.onForceClose);
   process.removeListener('exit', this.onForceClose);
 
+  this.rl.output.unmute();
+
   if (this.activePrompt && typeof this.activePrompt.close === 'function') {
     this.activePrompt.close();
   }

--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -24,7 +24,7 @@ Paginator.prototype.paginate = function (output, active, pageSize) {
   }
 
   // Move the pointer only when the user go down and limit it to the middle of the list
-  if (this.pointer < middleOfList && this.lastIndex < active && active - this.lastIndex < 9) {
+  if (this.pointer < middleOfList && this.lastIndex < active && active - this.lastIndex < pageSize) {
     this.pointer = Math.min(middleOfList, this.pointer + active - this.lastIndex);
   }
   this.lastIndex = active;

--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -19,7 +19,7 @@ Paginator.prototype.paginate = function (output, active, pageSize) {
   var lines = output.split('\n');
 
   // Make sure there's enough lines to paginate
-  if (lines.length <= pageSize + 2) {
+  if (lines.length <= pageSize) {
     return output;
   }
 


### PR DESCRIPTION
Now if you have a list of pageSize +2 items they are all shown without pagination. IMO it should be strictly fixed pagesize.

![image](https://cloud.githubusercontent.com/assets/230877/23352666/da9f2936-fcc8-11e6-93fb-5f3b7fd710aa.png)


Is there any other reason for the +2? Also should the "9" here https://github.com/SBoudrias/Inquirer.js/pull/509/files#diff-232d5c801450a865eb599f3512b9d8c0L27
actually be pageSize +2? I can't see any change when changing the 9.

Issue originally reported here: https://github.com/mokkabonna/inquirer-autocomplete-prompt/issues/23