### PR TITLE
Fix for not clearing final line

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -29,6 +29,7 @@ var UI = module.exports = function (opt) {
 
 UI.prototype.onForceClose = function () {
   this.close();
+  console.log('');
 };
 
 /**


### PR DESCRIPTION
Can you test this @SBoudrias ? This restores the correct functionality without giving an extra line for me, same for you?

Before you had an console.log('\n') there, but gives an extra line.