### PR TITLE
Checkbox: Do not show usage hints after selection  

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -37,6 +37,7 @@ function Prompt() {
   }
 
   this.pointer = 0;
+  this.firstRender = true;
 
   // Make sure no default is set (so it won't be printed)
   this.opt.default = null;
@@ -72,6 +73,7 @@ Prompt.prototype._run = function (cb) {
   // Init the prompt
   cliCursor.hide();
   this.render();
+  this.firstRender = false;
 
   return this;
 };
@@ -86,7 +88,7 @@ Prompt.prototype.render = function (error) {
   var message = this.getQuestion();
   var bottomContent = '';
 
-  if (!this.spaceKeyPressed) {
+  if (this.firstRender) {
     message += '(Press ' + chalk.cyan.bold('<space>') + ' to select, ' + chalk.cyan.bold('<a>') + ' to toggle all, ' + chalk.cyan.bold('<i>') + ' to inverse selection)';
   }
 
@@ -155,7 +157,6 @@ Prompt.prototype.onNumberKey = function (input) {
 };
 
 Prompt.prototype.onSpaceKey = function () {
-  this.spaceKeyPressed = true;
   this.toggleChoice(this.pointer);
   this.render();
 };


### PR DESCRIPTION
The usage hints will not be displyed after these events:
* Default choices are selected
* Using the "a" shortcut to select all items.
* Using the "i" shortcut to inverse current selection. 

Addresses #507 