### PR TITLE
Add `maxSelections` option to checkbox prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install inquirer
 ```javascript
 var inquirer = require('inquirer');
 inquirer.prompt([/* Pass your questions in here */]).then(function (answers) {
-	// Use user feedback for... whatever!!
+  // Use user feedback for... whatever!!
 });
 ```
 
@@ -212,7 +212,7 @@ See `examples/expand.js` for a running example.
 
 #### Checkbox - `{type: 'checkbox'}`
 
-Take `type`, `name`, `message`, `choices`[, `filter`, `validate`, `default`] properties. `default` is expected to be an Array of the checked choices value.
+Take `type`, `name`, `message`, `choices`[, `filter`, `validate`, `default`, `maxSelections`] properties. `default` is expected to be an Array of the checked choices value. `maxSelections` allows you to limit the number of selections allowed.
 
 Choices marked as `{checked: true}` will be checked by default.
 

--- a/lib/objects/choices.js
+++ b/lib/objects/choices.js
@@ -89,6 +89,29 @@ Choices.prototype.pluck = function (propertyName) {
   return _.map(this.realChoices, propertyName);
 };
 
+/**
+ * Find the index of first valid choice predicate returns truthy for
+ * @param  {Object|Func} predicate
+ * @return {Integer}               Found index or -1
+ */
+Choices.prototype.findIndex = function (predicate, fromIndex) {
+  fromIndex = fromIndex || 0;
+  return _.findIndex(this.realChoices, predicate, fromIndex);
+};
+
+/**
+ * Find the index of first valid choice predicate returns truthy for
+ * iterating from right to left
+ * @param  {Object|Func} predicate
+ * @return {Integer}               Found index or -1
+ */
+Choices.prototype.findLastIndex = function (predicate, fromIndex) {
+  if (fromIndex === undefined) {
+    fromIndex = this.realChoices.length - 1;
+  }
+  return _.findLastIndex(this.realChoices, predicate, fromIndex);
+};
+
 // Expose usual Array methods
 Choices.prototype.indexOf = function () {
   return this.choices.indexOf.apply(this.choices, arguments);

--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -38,6 +38,7 @@ function Prompt() {
 
   this.pointer = 0;
   this.firstRender = true;
+  this.maxSelections = (typeof this.opt.maxSelections === 'number') && this.opt.maxSelections;
 
   // Make sure no default is set (so it won't be printed)
   this.opt.default = null;
@@ -67,8 +68,12 @@ Prompt.prototype._run = function (cb) {
   events.normalizedDownKey.takeUntil(validation.success).forEach(this.onDownKey.bind(this));
   events.numberKey.takeUntil(validation.success).forEach(this.onNumberKey.bind(this));
   events.spaceKey.takeUntil(validation.success).forEach(this.onSpaceKey.bind(this));
-  events.aKey.takeUntil(validation.success).forEach(this.onAllKey.bind(this));
-  events.iKey.takeUntil(validation.success).forEach(this.onInverseKey.bind(this));
+
+  // If `maxSelections` option has not been set, allow all and inverse
+  if (!this.maxSelections) {
+    events.aKey.takeUntil(validation.success).forEach(this.onAllKey.bind(this));
+    events.iKey.takeUntil(validation.success).forEach(this.onInverseKey.bind(this));
+  }
 
   // Init the prompt
   cliCursor.hide();
@@ -89,7 +94,8 @@ Prompt.prototype.render = function (error) {
   var bottomContent = '';
 
   if (this.firstRender) {
-    message += '(Press ' + chalk.cyan.bold('<space>') + ' to select, ' + chalk.cyan.bold('<a>') + ' to toggle all, ' + chalk.cyan.bold('<i>') + ' to inverse selection)';
+    message += '(Press ' + chalk.cyan.bold('<space>') + ' to select';
+    message += this.maxSelections ? ')' : ', ' + chalk.cyan.bold('<a>') + ' to toggle all, ' + chalk.cyan.bold('<i>') + ' to inverse selection)';
   }
 
   // Render choices or answer depending on the state
@@ -136,22 +142,61 @@ Prompt.prototype.getCurrentValue = function () {
   return _.map(choices, 'value');
 };
 
+Prompt.prototype.getNextSelectedIndex = function (fromIndex, direction) {
+  var nextIndex;
+
+  if (direction === 'up') {
+    nextIndex = this.opt.choices.findLastIndex({checked: true}, fromIndex - 1);
+    if (nextIndex === -1 || nextIndex === fromIndex) {
+      nextIndex = this.opt.choices.findLastIndex({checked: true});
+    }
+  }
+
+  if (direction === 'down') {
+    nextIndex = this.opt.choices.findIndex({checked: true}, fromIndex + 1);
+    if (nextIndex === -1 || nextIndex === fromIndex) {
+      nextIndex = this.opt.choices.findIndex({checked: true});
+    }
+  }
+
+  return nextIndex;
+};
+
 Prompt.prototype.onUpKey = function () {
+  var checkedLength = this.getCurrentValue().length;
   var len = this.opt.choices.realLength;
-  this.pointer = (this.pointer > 0) ? this.pointer - 1 : len - 1;
+  if (this.maxSelections && (checkedLength >= this.maxSelections)) {
+    this.pointer = this.getNextSelectedIndex(this.pointer, 'up');
+  } else {
+    this.pointer = (this.pointer > 0) ? this.pointer - 1 : len - 1;
+  }
   this.render();
 };
 
 Prompt.prototype.onDownKey = function () {
+  var checkedLength = this.getCurrentValue().length;
   var len = this.opt.choices.realLength;
-  this.pointer = (this.pointer < len - 1) ? this.pointer + 1 : 0;
+  if (this.maxSelections && (checkedLength >= this.maxSelections)) {
+    this.pointer = this.getNextSelectedIndex(this.pointer, 'down');
+  } else {
+    this.pointer = (this.pointer < len - 1) ? this.pointer + 1 : 0;
+  }
   this.render();
 };
 
 Prompt.prototype.onNumberKey = function (input) {
+  var checkedLength = this.getCurrentValue().length;
   if (input <= this.opt.choices.realLength) {
-    this.pointer = input - 1;
-    this.toggleChoice(this.pointer);
+    if (this.maxSelections && (checkedLength >= this.maxSelections)) {
+      var isChecked = this.opt.choices.getChoice(input - 1).checked;
+      if (isChecked) {
+        this.pointer = input - 1;
+        this.toggleChoice(this.pointer);
+      }
+    } else {
+      this.pointer = input - 1;
+      this.toggleChoice(this.pointer);
+    }
   }
   this.render();
 };

--- a/test/specs/objects/choices.js
+++ b/test/specs/objects/choices.js
@@ -47,6 +47,54 @@ describe('Choices collection', function () {
     }]);
   });
 
+  it('should allow finding an index among valid choices', function () {
+    var choices = new Choices([
+      {name: 'a', disabled: true},
+      {name: 'b', checked: true},
+      {name: 'c', checked: false},
+      {name: 'd', checked: false},
+      {name: 'e', checked: false}
+    ]);
+    var foundIndex = choices.findIndex({checked: true});
+    expect(foundIndex).to.equal(0);
+  });
+
+  it('should allow finding an index among valid choices, starting from specific index', function () {
+    var choices = new Choices([
+      {name: 'a', disabled: true},
+      {name: 'b', checked: true},
+      {name: 'c', checked: false},
+      {name: 'd', checked: true},
+      {name: 'e', checked: false}
+    ]);
+    var foundIndex = choices.findIndex({checked: true}, 1);
+    expect(foundIndex).to.equal(2);
+  });
+
+  it('should allow finding a last index among valid choices', function () {
+    var choices = new Choices([
+      {name: 'a', disabled: true},
+      {name: 'b', checked: true},
+      {name: 'c', checked: false},
+      {name: 'd', checked: true},
+      {name: 'e', checked: false}
+    ]);
+    var foundIndex = choices.findLastIndex({checked: true});
+    expect(foundIndex).to.equal(2);
+  });
+
+  it('should allow finding a last index among valid choices, starting from specific index', function () {
+    var choices = new Choices([
+      {name: 'a', disabled: true},
+      {name: 'b', checked: true},
+      {name: 'c', checked: false},
+      {name: 'd', checked: false},
+      {name: 'e', checked: true}
+    ]);
+    var foundIndex = choices.findLastIndex({checked: true}, 2);
+    expect(foundIndex).to.equal(0);
+  });
+
   it('should façade forEach', function () {
     var raw = ['a', 'b', 'c'];
     var choices = new Choices(raw);
@@ -62,6 +110,14 @@ describe('Choices collection', function () {
     });
     expect(filtered.length).to.equal(1);
     expect(filtered[0].name).to.equal('a');
+  });
+
+  it('should façade find', function () {
+    var choices = new Choices(['a', 'b', 'c']);
+    var found = choices.find(function (val) {
+      return val.name === 'a';
+    });
+    expect(found.name).to.equal('a');
   });
 
   it('should façade push and update the realChoices internally', function () {

--- a/test/specs/prompts/checkbox.js
+++ b/test/specs/prompts/checkbox.js
@@ -30,7 +30,7 @@ describe('`checkbox` prompt', function () {
       expect(answer[0]).to.equal('choice 1');
       expect(answer[1]).to.equal('choice 2');
       done();
-    });
+    }).catch(err => console.log(err));
     this.rl.input.emit('keypress', ' ', {name: 'space'});
     this.rl.input.emit('keypress', null, {name: 'down'});
     this.rl.input.emit('keypress', ' ', {name: 'space'});
@@ -253,6 +253,76 @@ describe('`checkbox` prompt', function () {
       promise.then(function () {
         expect(this.rl.output.__raw__).to.contain('- dis1 (Disabled)');
       }.bind(this));
+    });
+  });
+
+  describe('with maxSelections option', function () {
+    beforeEach(function () {
+      this.fixture.maxSelections = 2;
+      this.checkbox = new Checkbox(this.fixture, this.rl);
+    });
+
+    it('disables selecting all', function () {
+      this.checkbox.run().then(function (answer) {
+        expect(answer.length).to.equal(0);
+      });
+
+      this.rl.input.emit('keypress', 'a', {name: 'a'});
+      this.rl.emit('line');
+    });
+
+    it('disables selecting inverse', function () {
+      this.checkbox.run().then(function (answer) {
+        expect(answer.length).to.equal(0);
+      });
+
+      this.rl.input.emit('keypress', 'i', {name: 'i'});
+      this.rl.emit('line');
+    });
+
+    it('navigates only between selected items', function () {
+      this.checkbox.run().then(function (answer) {
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 2');
+      });
+
+      this.rl.input.emit('keypress', ' ', {name: 'space'});
+      this.rl.input.emit('keypress', null, {name: 'down'});
+      this.rl.input.emit('keypress', ' ', {name: 'space'});
+      this.rl.input.emit('keypress', null, {name: 'down'});
+      this.rl.input.emit('keypress', null, {name: 'down'});
+      this.rl.input.emit('keypress', null, {name: 'up'});
+      this.rl.input.emit('keypress', ' ', {name: 'space'});
+      this.rl.emit('line');
+    });
+
+    it('navigates only between selected items, consecutive', function () {
+      this.checkbox.run().then(function (answer) {
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 2');
+      });
+
+      this.rl.input.emit('keypress', null, {name: 'down'});
+      this.rl.input.emit('keypress', ' ', {name: 'space'});
+      this.rl.input.emit('keypress', null, {name: 'down'});
+      this.rl.input.emit('keypress', ' ', {name: 'space'});
+      this.rl.input.emit('keypress', null, {name: 'up'});
+      this.rl.input.emit('keypress', null, {name: 'up'});
+      this.rl.input.emit('keypress', ' ', {name: 'space'});
+      this.rl.emit('line');
+    });
+
+    it('navigates only between selected items, using 1-9 shortcut key', function () {
+      this.checkbox.run().then(function (answer) {
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 2');
+      });
+
+      this.rl.input.emit('keypress', '1');
+      this.rl.input.emit('keypress', '2');
+      this.rl.input.emit('keypress', '3');
+      this.rl.input.emit('keypress', '1');
+      this.rl.emit('line');
     });
   });
 });


### PR DESCRIPTION
With the `maxSelections` option, users can limit how many choices can be selected in the checkbox prompt. The limiting is done by only allowing navigation between selected items when the max has been reached, thus preventing the selection of additional items beyond the specified max.