### PR TITLE
Use rx-lite-aggregates instead of full rx

### DIFF
--- a/examples/rx-observable-array.js
+++ b/examples/rx-observable-array.js
@@ -1,5 +1,5 @@
 var inquirer = require('..');
-var Rx = require('rx');
+var Rx = require('rx-lite-aggregates');
 
 var questions = [
   {

--- a/examples/rx-observable-create.js
+++ b/examples/rx-observable-create.js
@@ -1,5 +1,5 @@
 var inquirer = require('..');
-var Rx = require('rx');
+var Rx = require('rx-lite-aggregates');
 
 var observe = Rx.Observable.create(function (obs) {
   obs.onNext({

--- a/lib/prompts/editor.js
+++ b/lib/prompts/editor.js
@@ -7,7 +7,7 @@ var chalk = require('chalk');
 var ExternalEditor = require('external-editor');
 var Base = require('./base');
 var observe = require('../utils/events');
-var rx = require('rx');
+var rx = require('rx-lite-aggregates');
 
 /**
  * Module exports

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -1,6 +1,6 @@
 'use strict';
 var _ = require('lodash');
-var rx = require('rx');
+var rx = require('rx-lite-aggregates');
 var util = require('util');
 var runAsync = require('run-async');
 var utils = require('../utils/utils');

--- a/lib/utils/events.js
+++ b/lib/utils/events.js
@@ -1,5 +1,5 @@
 'use strict';
-var rx = require('rx');
+var rx = require('rx-lite-aggregates');
 
 function normalizeKeypressEvents(value, key) {
   return {value: value, key: key || {}};

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 var _ = require('lodash');
-var rx = require('rx');
+var rx = require('rx-lite-aggregates');
 var runAsync = require('run-async');
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lodash": "^4.3.0",
     "mute-stream": "0.0.7",
     "run-async": "^2.2.0",
-    "rx": "^4.1.0",
+    "rx-lite": "^4.0.8",
+    "rx-lite-aggregates": "^4.0.8",
     "string-width": "^2.0.0",
     "strip-ansi": "^3.0.0",
     "through": "^2.3.6"

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -5,7 +5,7 @@
 var expect = require('chai').expect;
 var sinon = require('sinon');
 var _ = require('lodash');
-var rx = require('rx');
+var rx = require('rx-lite-aggregates');
 var inquirer = require('../../lib/inquirer');
 var autosubmit = require('../helpers/events').autosubmit;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,13 +2257,19 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
-
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
 samsam@1.1.2, samsam@~1.1:
   version "1.1.2"


### PR DESCRIPTION
While profiling our dependencies we noticed that inquirer includes the full `rx` module which adds around `7MB` to the inquirer dependencies, vs `~500K` for `rx-lite-aggregates` + `rx-lite`.  One thing I was not entirely happy with was that this bumps `rx` back from `^4.1.0` to `^4.0.8`, which is the latest `rx-lite-aggregates` version.  I also added an `rx-lite` dependency because otherwise `3.1.2` satisfies the `*` version from `rx-lite-aggregates`.

I did see in a8b2ce91fa88dd1c2aeec97c3cf9c220f032acd2 that the `rx-lite` dependency was swapped out for `rx` which I presume was because the `reduce` functionality was needed looking at the diff.  Are there any other reasons why it was changed to `rx`?
```
-> % du -h -s node_modules/rx-lite-aggregates
104K	node_modules/rx-lite-aggregates
-> % du -h -s node_modules/rx-lite           
464K	node_modules/rx-lite
-> % du -h -s node_modules/rx                
7.1M	node_modules/rx
```