### PR TITLE
Fix hidden password validation quirk

### DIFF
--- a/examples/password.js
+++ b/examples/password.js
@@ -8,6 +8,18 @@ var inquirer = require('..');
 inquirer.prompt([
   {
     type: 'password',
+    message: 'Enter "Passw0rd"',
+    name: 'password3',
+    validate: (input) => {
+      if (input !== 'Passw0rd') {
+        return 'invalid password'
+      }
+
+      return true;
+    }
+  },
+  {
+    type: 'password',
     message: 'Enter a password',
     name: 'password1'
   },

--- a/examples/password.js
+++ b/examples/password.js
@@ -10,9 +10,9 @@ inquirer.prompt([
     type: 'password',
     message: 'Enter "Passw0rd"',
     name: 'password3',
-    validate: (input) => {
+    validate: function (input) {
       if (input !== 'Passw0rd') {
-        return 'invalid password'
+        return 'invalid password';
       }
 
       return true;

--- a/lib/prompts/password.js
+++ b/lib/prompts/password.js
@@ -52,6 +52,8 @@ Prompt.prototype._run = function (cb) {
 
   if (this.opt.mask) {
     events.keypress.takeUntil(validation.success).forEach(this.onKeypress.bind(this));
+  } else {
+    events.keypress.forEach(this.onNoMaskKeypress.bind(this));
   }
 
   // Init
@@ -65,7 +67,8 @@ Prompt.prototype._run = function (cb) {
  * @return {Prompt} self
  */
 
-Prompt.prototype.render = function (error) {
+Prompt.prototype.render = function () {
+  var error = this.error;
   var message = this.getQuestion();
   var bottomContent = '';
 
@@ -101,14 +104,15 @@ Prompt.prototype.onEnd = function (state) {
 
   // Re-render prompt
   this.render();
+  this.rl.output.unmute();
 
   this.screen.done();
   this.done(state.value);
 };
 
 Prompt.prototype.onError = function (state) {
-  this.render(state.isValid);
-  this.rl.output.unmute();
+  this.error = state.isValid;
+  this.render();
 };
 
 /**
@@ -117,4 +121,11 @@ Prompt.prototype.onError = function (state) {
 
 Prompt.prototype.onKeypress = function () {
   this.render();
+};
+
+Prompt.prototype.onNoMaskKeypress = function () {
+  if (this.error) {
+    this.error = false;
+    this.render();
+  }
 };

--- a/lib/prompts/password.js
+++ b/lib/prompts/password.js
@@ -120,12 +120,16 @@ Prompt.prototype.onError = function (state) {
  */
 
 Prompt.prototype.onKeypress = function () {
+  if (this.error) {
+    this.error = null;
+  }
+
   this.render();
 };
 
 Prompt.prototype.onNoMaskKeypress = function () {
   if (this.error) {
-    this.error = false;
+    this.error = null;
     this.render();
   }
 };

--- a/test/specs/prompts/password.js
+++ b/test/specs/prompts/password.js
@@ -53,6 +53,56 @@ describe('`password` prompt', function () {
   it('should display an error on validation error', function (done) {
     var rl = this.rl;
 
+    this.fixture.validate = function (input) {
+      if (input !== 'Passw0rd') {
+        return 'invalid password';
+      }
+
+      return true;
+    };
+
+    var password = new Password(this.fixture, this.rl);
+    password.run();
+
+    rl.emit('line', 'Inquirer');
+
+    setTimeout(function () {
+      var expectOutput = expect(stripAnsi(rl.output.__raw__));
+      expectOutput.to.contain('invalid password');
+      done();
+    }, 25);
+  });
+
+  it('should remove an error on keypress without mask', function (done) {
+    var rl = this.rl;
+
+    this.fixture.validate = function (input) {
+      if (input !== 'Passw0rd') {
+        return 'invalid password';
+      }
+
+      return true;
+    };
+
+    var password = new Password(this.fixture, this.rl);
+    password.run();
+
+    rl.emit('line', 'Inquirer');
+
+    setTimeout(function () {
+      rl.input.emit('keypress', 'a', {name: 'a'});
+      rl.input.emit('keypress', 'b', {name: 'b'});
+
+      setTimeout(function () {
+        expect(password.error).to.be.null;
+        done();
+      }, 25);
+    }, 25);
+  });
+
+  it('should remove an error on keypress with mask', function (done) {
+    var rl = this.rl;
+
     this.fixture.mask = '*';
     this.fixture.validate = function (input) {
       if (input !== 'Passw0rd') {
@@ -66,12 +116,15 @@ describe('`password` prompt', function () {
     password.run();
 
     rl.emit('line', 'Inquirer');
-    setTimeout(function () {
-      console.log('\n\nBABA\n\n\n\n', rl.output.__raw__, '\n\n\n\nBABA\n\n');
-      var expectOutput = expect(stripAnsi(rl.output.__raw__));
-      expectOutput.to.contain('invalid password');
 
-      done();
-    }, 250);
+    setTimeout(function () {
+      rl.input.emit('keypress', 'a', {name: 'a'});
+      rl.input.emit('keypress', 'b', {name: 'b'});
+
+      setTimeout(function () {
+        expect(password.error).to.be.null;
+        done();
+      }, 25);
+    }, 25);
   });
 });

--- a/test/specs/prompts/password.js
+++ b/test/specs/prompts/password.js
@@ -49,4 +49,29 @@ describe('`password` prompt', function () {
     this.rl.emit('line', 'Inquirer');
     return promise;
   });
+
+  it('should display an error on validation error', function (done) {
+    var rl = this.rl;
+
+    this.fixture.mask = '*';
+    this.fixture.validate = function (input) {
+      if (input !== 'Passw0rd') {
+        return 'invalid password';
+      }
+
+      return true;
+    };
+
+    var password = new Password(this.fixture, this.rl);
+    password.run();
+
+    rl.emit('line', 'Inquirer');
+    setTimeout(function () {
+      console.log('\n\nBABA\n\n\n\n', rl.output.__raw__, '\n\n\n\nBABA\n\n');
+      var expectOutput = expect(stripAnsi(rl.output.__raw__));
+      expectOutput.to.contain('invalid password');
+
+      done();
+    }, 250);
+  });
 });


### PR DESCRIPTION
When using a hidden password prompt, with a validation, after having raised an error the password was displayed. This PR fixes this.

See `examples/password.js` for an example of this bug.