### PR TITLE
Allow non-string values as a list default option

### DIFF
--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -39,8 +39,8 @@ function Prompt() {
     this.selected = def;
   }
 
-  // Default being a String
-  if (_.isString(def)) {
+  // Anything else as a choice value
+  else if (def != null) {
     this.selected = this.opt.choices.pluck('value').indexOf(def);
   }
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -34,13 +34,10 @@ function Prompt() {
 
   var def = this.opt.default;
 
-  // Default being a Number
+  // If def is a Number, then use as index. Otherwise, check for value.
   if (_.isNumber(def) && def >= 0 && def < this.opt.choices.realLength) {
     this.selected = def;
-  }
-
-  // Anything else as a choice value
-  else if (!_.isNumber(def) && typeof def !== 'undefined') {
+  } else if (!_.isNumber(def) && def != null) {
     this.selected = this.opt.choices.pluck('value').indexOf(def);
   }
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -40,7 +40,7 @@ function Prompt() {
   }
 
   // Anything else as a choice value
-  else if (def != null) {
+  else if (typeof def !== 'undefined') {
     this.selected = this.opt.choices.pluck('value').indexOf(def);
   }
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -40,7 +40,7 @@ function Prompt() {
   }
 
   // Anything else as a choice value
-  else if (typeof def !== 'undefined') {
+  else if (!_.isNumber(def) && typeof def !== 'undefined') {
     this.selected = this.opt.choices.pluck('value').indexOf(def);
   }
 


### PR DESCRIPTION
At the moment the list default value only allows Numbers (choice array index) and Strings (choice array values). However, values might as well be anything, not just Strings. (In my case entire database objects with their name as then name of the choice)

This PR allows for any type of default option to be used.