### PR TITLE
[fix] #293 Exit script when SIGINT signal received

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -19,9 +19,9 @@ var UI = module.exports = function (opt) {
 
   // Make sure new prompt start on a newline when closing
   process.on('exit', this.onForceClose);
-  
+
   // Terminate process on SIGINT (which will call process.on('exit') in return)
-  this.rl.on('SIGINT', function() {
+  this.rl.on('SIGINT', function () {
     process.exit(0);
   });
 };

--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -18,8 +18,12 @@ var UI = module.exports = function (opt) {
   this.onForceClose = this.onForceClose.bind(this);
 
   // Make sure new prompt start on a newline when closing
-  this.rl.on('SIGINT', this.onForceClose);
   process.on('exit', this.onForceClose);
+  
+  // Terminate process on SIGINT (which will call process.on('exit') in return)
+  this.rl.on('SIGINT', function() {
+    process.exit(0);
+  });
 };
 
 /**


### PR DESCRIPTION
This PR properly addresses https://github.com/SBoudrias/Inquirer.js/issues/293 by triggering a `process.exit(0)` on `SIGINT` on the readline.