### PR TITLE
Better way to kill process

### DIFF
--- a/lib/ui/baseUI.js
+++ b/lib/ui/baseUI.js
@@ -22,7 +22,7 @@ var UI = module.exports = function (opt) {
 
   // Terminate process on SIGINT (which will call process.on('exit') in return)
   this.rl.on('SIGINT', function () {
-    process.exit(0);
+    process.kill(process.pid, 'SIGINT');
   });
 };
 


### PR DESCRIPTION
As per https://github.com/SBoudrias/Inquirer.js/issues/293#issuecomment-315944753, this change still keeps the desired behaviour of killing the process on CTRL-C, but it gives parent processes a chance to clean up.