### PR TITLE
Fix cursor behavior

### DIFF
--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -35,7 +35,7 @@ ScreenManager.prototype.render = function (content, bottomContent) {
   // Remove the rl.line from our prompt. We can't rely on the content of
   // rl.line (mainly because of the password prompt), so just rely on it's
   // length.
-  var prompt = promptLine;
+  var prompt = rawPromptLine;
   if (this.rl.line.length) {
     prompt = prompt.slice(0, -this.rl.line.length);
   }


### PR DESCRIPTION
This bug can reproduce in [this case](https://github.com/LitoMore/inquirer-chalk-pipe/blob/89502b9c7e6ce194e155455d8c7999f8f0524ae3/index.js#L60).

ANSI escape code should not be counted in the length.

**Expected behavior**

![inquirer-chalk-pipe-expected](https://user-images.githubusercontent.com/8186898/29869765-e74e1fbe-8db6-11e7-8909-040a31adf7fe.gif)

**Actual behavior**

![inquirer-chalk-pipe-expected-behaivor](https://user-images.githubusercontent.com/8186898/29869802-191df0b4-8db7-11e7-869d-854c47d7e63b.gif)

**How to review this pull reuqest**

```bash
$ git clone -b instant-preview https://github.com/LitoMore/inquirer-chalk-pipe.git
$ cd inquirer-chalk-pipe
$ npm install
$ node example.js
# Then, try `green` or other styles
```