### PR TITLE
The delimiter can now be set with an option in question config

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -8,25 +8,24 @@ var chalk = require('chalk');
 var runAsync = require('run-async');
 var Choices = require('../objects/choices');
 var ScreenManager = require('../utils/screen-manager');
-
-var Prompt = module.exports = function (question, rl, answers) {
+var Prompt = (module.exports = function(question, rl, answers) {
   // Setup instance defaults property
   _.assign(this, {
     answers: answers,
-    status: 'pending'
+    status: 'pending',
   });
 
   // Set defaults prompt options
   this.opt = _.defaults(_.clone(question), {
-    validate: function () {
+    validate: function() {
       return true;
     },
-    filter: function (val) {
+    filter: function(val) {
       return val;
     },
-    when: function () {
+    when: function() {
       return true;
-    }
+    },
   });
 
   // Check to make sure prompt requirements are there
@@ -44,23 +43,25 @@ var Prompt = module.exports = function (question, rl, answers) {
 
   this.rl = rl;
   this.screen = new ScreenManager(this.rl);
-};
+});
 
 /**
  * Start the Inquiry session and manage output value filtering
  * @return {Promise}
  */
 
-Prompt.prototype.run = function () {
-  return new Promise(function (resolve) {
-    this._run(function (value) {
-      resolve(value);
-    });
-  }.bind(this));
+Prompt.prototype.run = function() {
+  return new Promise(
+    function(resolve) {
+      this._run(function(value) {
+        resolve(value);
+      });
+    }.bind(this)
+  );
 };
 
 // default noop (this one should be overwritten in prompts)
-Prompt.prototype._run = function (cb) {
+Prompt.prototype._run = function(cb) {
   cb();
 };
 
@@ -70,14 +71,14 @@ Prompt.prototype._run = function (cb) {
  * @return {Throw Error}
  */
 
-Prompt.prototype.throwParamError = function (name) {
+Prompt.prototype.throwParamError = function(name) {
   throw new Error('You must provide a `' + name + '` parameter');
 };
 
 /**
  * Called when the UI closes. Override to do any specific cleanup necessary
  */
-Prompt.prototype.close = function () {
+Prompt.prototype.close = function() {
   this.screen.releaseCursor();
 };
 
@@ -86,37 +87,45 @@ Prompt.prototype.close = function () {
  * @param  {Rx.Observable} submit - submit event flow
  * @return {Object}        Object containing two observables: `success` and `error`
  */
-Prompt.prototype.handleSubmitEvents = function (submit) {
+Prompt.prototype.handleSubmitEvents = function(submit) {
   var self = this;
   var validate = runAsync(this.opt.validate);
   var filter = runAsync(this.opt.filter);
-  var validation = submit.flatMap(function (value) {
-    return filter(value, self.answers).then(function (filteredValue) {
-      return validate(filteredValue, self.answers).then(function (isValid) {
-        return {isValid: isValid, value: filteredValue};
-      }, function (err) {
-        return {isValid: err};
-      });
-    }, function (err) {
-      return {isValid: err};
-    });
-  }).share();
+  var validation = submit
+    .flatMap(function(value) {
+      return filter(value, self.answers).then(
+        function(filteredValue) {
+          return validate(filteredValue, self.answers).then(
+            function(isValid) {
+              return { isValid: isValid, value: filteredValue };
+            },
+            function(err) {
+              return { isValid: err };
+            }
+          );
+        },
+        function(err) {
+          return { isValid: err };
+        }
+      );
+    })
+    .share();
 
   var success = validation
-    .filter(function (state) {
+    .filter(function(state) {
       return state.isValid === true;
     })
     .take(1);
 
   var error = validation
-    .filter(function (state) {
+    .filter(function(state) {
       return state.isValid !== true;
     })
     .takeUntil(success);
 
   return {
     success: success,
-    error: error
+    error: error,
   };
 };
 
@@ -125,8 +134,9 @@ Prompt.prototype.handleSubmitEvents = function (submit) {
  * @return {String} prompt question string
  */
 
-Prompt.prototype.getQuestion = function () {
-  var message = chalk.green('?') + ' ' + chalk.bold(this.opt.message) + chalk.reset(' ');
+Prompt.prototype.getQuestion = function() {
+  var message =
+    this.opt.delimiter + ' ' + chalk.bold(this.opt.message) + chalk.reset(' ');
 
   // Append the default if available, and if question isn't answered
   if (this.opt.default != null && this.status !== 'answered') {

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -135,6 +135,9 @@ Prompt.prototype.handleSubmitEvents = function(submit) {
  */
 
 Prompt.prototype.getQuestion = function() {
+  if (!this.opt.delimiter) {
+    this.opt.delimiter = chalk.green('?');
+  }
   var message =
     this.opt.delimiter + ' ' + chalk.bold(this.opt.message) + chalk.reset(' ');
 


### PR DESCRIPTION
```js
[
 {
    name: 'example',
    message: 'What is your name?  ',
    delimiter: chalk.blue('+'),
    validate: value => {
      if (value) {
        return true;
      } else {
        return 'Please answer this question' && false;
      }
    },
  }
]
```

Will result in, 

<img width="174" alt="screen shot 2017-09-17 at 15 40 14" src="https://user-images.githubusercontent.com/31746454/30521852-966ee8ec-9bbe-11e7-9db6-bbe36e5d35dd.png">

If no delimiter is set, it will default back to the green `?`

<img width="173" alt="screen shot 2017-09-17 at 15 41 15" src="https://user-images.githubusercontent.com/31746454/30521854-b5d93778-9bbe-11e7-8030-a54b614cf809.png">


I added this because I was after a quick and easy way to set the delimiter, I also couldn't find any other way to do it. So a quick read over the source-code and this is the result. 