### PR TITLE
Paginator now handles multiple lines

### DIFF
--- a/lib/prompts/checkbox.js
+++ b/lib/prompts/checkbox.js
@@ -42,7 +42,7 @@ function Prompt() {
   // Make sure no default is set (so it won't be printed)
   this.opt.default = null;
 
-  this.paginator = new Paginator();
+  this.paginator = new Paginator(this.screen);
 }
 util.inherits(Prompt, Base);
 

--- a/lib/prompts/expand.js
+++ b/lib/prompts/expand.js
@@ -47,7 +47,7 @@ function Prompt() {
   // Setup the default string (capitalize the default key)
   this.opt.default = this.generateChoicesString(this.opt.choices, this.opt.default);
 
-  this.paginator = new Paginator();
+  this.paginator = new Paginator(this.screen);
 }
 util.inherits(Prompt, Base);
 

--- a/lib/prompts/list.js
+++ b/lib/prompts/list.js
@@ -44,7 +44,7 @@ function Prompt() {
   // Make sure no default is set (so it won't be printed)
   this.opt.default = null;
 
-  this.paginator = new Paginator();
+  this.paginator = new Paginator(this.screen);
 }
 util.inherits(Prompt, Base);
 

--- a/lib/utils/paginator.js
+++ b/lib/utils/paginator.js
@@ -8,15 +8,24 @@ var chalk = require('chalk');
  * a subset of the choices if the list is too long.
  */
 
-var Paginator = module.exports = function () {
+var Paginator = module.exports = function (screen) {
   this.pointer = 0;
   this.lastIndex = 0;
+  this.screen = screen;
 };
 
 Paginator.prototype.paginate = function (output, active, pageSize) {
   pageSize = pageSize || 7;
   var middleOfList = Math.floor(pageSize / 2);
   var lines = output.split('\n');
+
+  if (this.screen) {
+    lines = this.screen.breakLines(lines);
+    active = _.sum(lines.map(function (lineParts) {
+      return lineParts.length;
+    }).splice(0, active));
+    lines = _.flatten(lines);
+  }
 
   // Make sure there's enough lines to paginate
   if (lines.length <= pageSize) {

--- a/lib/utils/screen-manager.js
+++ b/lib/utils/screen-manager.js
@@ -45,9 +45,9 @@ ScreenManager.prototype.render = function (content, bottomContent) {
   var cursorPos = this.rl._getCursorPos();
   var width = this.normalizedCliWidth();
 
-  content = forceLineReturn(content, width);
+  content = this.forceLineReturn(content, width);
   if (bottomContent) {
-    bottomContent = forceLineReturn(bottomContent, width);
+    bottomContent = this.forceLineReturn(bottomContent, width);
   }
   // Manually insert an extra line if we're at the end of the line.
   // This prevent the cursor from appearing at the beginning of the
@@ -115,9 +115,10 @@ ScreenManager.prototype.normalizedCliWidth = function () {
   return width;
 };
 
-function breakLines(lines, width) {
-  // Break lines who're longuer than the cli width so we can normalize the natural line
-  // returns behavior accross terminals.
+ScreenManager.prototype.breakLines = function (lines, width) {
+  // Break lines who're longer than the cli width so we can normalize the natural line
+  // returns behavior across terminals.
+  width = width || this.normalizedCliWidth();
   var regex = new RegExp(
     '(?:(?:\\033[[0-9;]*m)*.?){1,' + width + '}',
     'g'
@@ -128,8 +129,9 @@ function breakLines(lines, width) {
     chunk.pop();
     return chunk || '';
   });
-}
+};
 
-function forceLineReturn(content, width) {
-  return _.flatten(breakLines(content.split('\n'), width)).join('\n');
-}
+ScreenManager.prototype.forceLineReturn = function (content, width) {
+  width = width || this.normalizedCliWidth();
+  return _.flatten(this.breakLines(content.split('\n'), width)).join('\n');
+};


### PR DESCRIPTION
Prior to this, a list with multi-line items works erratically; the current selection might be off the screen, or the list height may vary depending on which items are selected.

As part of this, Paginator now takes an optional ScreenManager instance. Prompts have been updated accordingly.

I noticed this most clearly with yarn's upgrade-interactive feature. To demonstrate:

1. Clone the yarn repo.
2. Within it, run `yarn upgrade-interactive` in a window that's too small to display the resulting table.
3. The current selection is off the top of the screen, and scrolling through the list doesn't work great in general.

The improvement can also be noticed by running [examples/long-list.js](https://github.com/SBoudrias/Inquirer.js/blob/651a569ccf37a8d8dd6ae4f348c414bab3649c19/examples/long-list.js). Without these changes, the height of the list changes depending how long individual list items are.

I have ran long-list and yarn upgrade-interactive (which uses checkbox) and have ran the test suite but have not tested further.