### PR TITLE
Bumped version to 4.1.0, bumped external-editor dependency to ^2.1.0 …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description":
     "A collection of common interactive command line user interfaces.",
   "author": "Simon Boudrias <admin@simonboudrias.com>",
@@ -41,7 +41,7 @@
     "chalk": "^2.0.0",
     "cli-cursor": "^2.1.0",
     "cli-width": "^2.0.0",
-    "external-editor": "^2.0.4",
+    "external-editor": "^2.1.0",
     "figures": "^2.0.0",
     "lodash": "^4.3.0",
     "mute-stream": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer",
-  "version": "4.1.0",
+  "version": "4.0.0",
   "description":
     "A collection of common interactive command line user interfaces.",
   "author": "Simon Boudrias <admin@simonboudrias.com>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,6 +358,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -795,6 +799,14 @@ external-editor@^2.0.4:
   dependencies:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
+    tmp "^0.0.33"
+
+external-editor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
 extglob@^0.3.1:


### PR DESCRIPTION
…to remove jschardet LGPL license dependency.

Final fix for Issue #574.