### PR TITLE
Use name as default message

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A question object is a `hash` containing question related values:
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
 `list`, `rawlist`, `expand`, `checkbox`, `password`, `editor`
 - **name**: (String) The name to use when storing the answer in the answers hash. If the name contains periods, it will define a path in the answers hash.
-- **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers.
+- **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers. Defaults to the value of `name` (followed by a colon).
 - **default**: (String|Number|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.
 - **choices**: (Array|Function) Choices array or a function returning a choices array. If defined as a function, the first parameter will be the current inquirer session answers.
 Array values can be simple `strings`, or `objects` containing a `name` (to display in list), a `value` (to save in the answers hash) and a `short` (to display after selection) properties. The choices array can also contain [a `Separator`](#separator).

--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -27,12 +27,14 @@ class Prompt {
       prefix: chalk.green('?')
     });
 
-    // Check to make sure prompt requirements are there
-    if (!this.opt.message) {
-      this.throwParamError('message');
-    }
+    // Make sure name is present
     if (!this.opt.name) {
       this.throwParamError('name');
+    }
+
+    // Set default message if no message defined
+    if (!this.opt.message) {
+      this.opt.message = this.opt.name + ':';
     }
 
     // Normalize choices

--- a/test/specs/api.js
+++ b/test/specs/api.js
@@ -324,6 +324,15 @@ var tests = {
 
         expect(this.rl.output.__raw__).to.contain(this.fixture.message);
       });
+      it('should default to name for message', function() {
+        this.fixture.name = 'testfoobarbarfoobar';
+        delete this.fixture.message;
+
+        var prompt = new this.Prompt(this.fixture, this.rl);
+        prompt.run();
+
+        expect(this.rl.output.__raw__).to.contain(this.fixture.name + ':');
+      });
     });
   },
 
@@ -344,13 +353,6 @@ var tests = {
 
   requiredValues: function() {
     describe('Missing value', function() {
-      it('`message` should throw', function() {
-        expect(() => {
-          delete this.fixture.message;
-          return new this.Prompt(this.fixture, this.rl);
-        }).to.throw(/message/);
-      });
-
       it('`name` should throw', function() {
         expect(() => {
           delete this.fixture.name;


### PR DESCRIPTION
Following the style of wizards like `npm init` (see [PromZard](https://github.com/npm/promzard) and its precedents).