### PR TITLE
Correct subscription method

### DIFF
--- a/lib/prompts/editor.js
+++ b/lib/prompts/editor.js
@@ -23,7 +23,7 @@ class EditorPrompt extends Base {
 
     // Open Editor on "line" (Enter Key)
     var events = observe(this.rl);
-    this.lineSubscription = events.line.forEach(this.startExternalEditor.bind(this));
+    this.lineSubscription = events.line.subscribe(this.startExternalEditor.bind(this));
 
     // Trigger Validation when editor closes
     var validation = this.handleSubmitEvents(this.editorResult);
@@ -83,7 +83,7 @@ class EditorPrompt extends Base {
 
   onEnd(state) {
     this.editorResult.unsubscribe();
-    this.lineSubscription.dispose();
+    this.lineSubscription.unsubscribe();
     this.answer = state.value;
     this.status = 'answered';
     // Re-render prompt


### PR DESCRIPTION
Fixes #637 

`forEach` now returns a promise instead of a disposable subscription (therefore `.dispose()` does not exist)