### PR TITLE
Patch observable operators

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -10,6 +10,12 @@ var runAsync = require('run-async');
 var Choices = require('../objects/choices');
 var ScreenManager = require('../utils/screen-manager');
 
+require('rxjs/add/operator/filter');
+require('rxjs/add/operator/mergeMap');
+require('rxjs/add/operator/share');
+require('rxjs/add/operator/take');
+require('rxjs/add/operator/takeUntil');
+
 class Prompt {
   constructor(question, rl, answers) {
     // Setup instance defaults property
@@ -87,7 +93,7 @@ class Prompt {
     var validate = runAsync(this.opt.validate);
     var filter = runAsync(this.opt.filter);
     var validation = submit
-      .flatMap(value =>
+      .mergeMap(value =>
         filter(value, self.answers).then(
           filteredValue =>
             validate(filteredValue, self.answers).then(

--- a/lib/prompts/editor.js
+++ b/lib/prompts/editor.js
@@ -7,7 +7,7 @@ var chalk = require('chalk');
 var ExternalEditor = require('external-editor');
 var Base = require('./base');
 var observe = require('../utils/events');
-var Rx = require('rxjs/Rx');
+var Subject = require('rxjs/Subject').Subject;
 
 class EditorPrompt extends Base {
   /**
@@ -19,7 +19,7 @@ class EditorPrompt extends Base {
   _run(cb) {
     this.done = cb;
 
-    this.editorResult = new Rx.Subject();
+    this.editorResult = new Subject();
 
     // Open Editor on "line" (Enter Key)
     var events = observe(this.rl);

--- a/lib/ui/prompt.js
+++ b/lib/ui/prompt.js
@@ -1,9 +1,19 @@
 'use strict';
 var _ = require('lodash');
-var Rx = require('rxjs/Rx');
+var Observable = require('rxjs/Observable').Observable;
 var runAsync = require('run-async');
 var utils = require('../utils/utils');
 var Base = require('./baseUI');
+
+require('rxjs/add/observable/defer');
+require('rxjs/add/observable/empty');
+require('rxjs/add/observable/from');
+require('rxjs/add/observable/fromPromise');
+require('rxjs/add/observable/of');
+require('rxjs/add/operator/concatMap');
+require('rxjs/add/operator/publish');
+require('rxjs/add/operator/reduce');
+require('rxjs/add/operator/toPromise');
 
 /**
  * Base interface class other can inherits from
@@ -27,7 +37,7 @@ class PromptUI extends Base {
     // Create an observable, unless we received one as parameter.
     // Note: As this is a public interface, we cannot do an instanceof check as we won't
     // be using the exact same object in memory.
-    var obs = _.isArray(questions) ? Rx.Observable.from(questions) : questions;
+    var obs = _.isArray(questions) ? Observable.from(questions) : questions;
 
     this.process = obs
       .concatMap(this.processQuestion.bind(this))
@@ -57,8 +67,8 @@ class PromptUI extends Base {
 
   processQuestion(question) {
     question = _.clone(question);
-    return Rx.Observable.defer(() => {
-      var obs = Rx.Observable.of(question);
+    return Observable.defer(() => {
+      var obs = Observable.of(question);
 
       return obs
         .concatMap(this.setDefaultType.bind(this))
@@ -79,8 +89,8 @@ class PromptUI extends Base {
   fetchAnswer(question) {
     var Prompt = this.prompts[question.type];
     this.activePrompt = new Prompt(question, this.rl, this.answers);
-    return Rx.Observable.defer(() =>
-      Rx.Observable.fromPromise(
+    return Observable.defer(() =>
+      Observable.fromPromise(
         this.activePrompt.run().then(answer => ({ name: question.name, answer: answer }))
       )
     );
@@ -91,21 +101,21 @@ class PromptUI extends Base {
     if (!this.prompts[question.type]) {
       question.type = 'input';
     }
-    return Rx.Observable.defer(() => Rx.Observable.of(question));
+    return Observable.defer(() => Observable.of(question));
   }
 
   filterIfRunnable(question) {
     if (question.when === false) {
-      return Rx.Observable.empty();
+      return Observable.empty();
     }
 
     if (!_.isFunction(question.when)) {
-      return Rx.Observable.of(question);
+      return Observable.of(question);
     }
 
     var answers = this.answers;
-    return Rx.Observable.defer(() =>
-      Rx.Observable.fromPromise(
+    return Observable.defer(() =>
+      Observable.fromPromise(
         runAsync(question.when)(answers).then(shouldRun => {
           if (shouldRun) {
             return question;

--- a/lib/utils/events.js
+++ b/lib/utils/events.js
@@ -1,17 +1,22 @@
 'use strict';
-var Rx = require('rxjs/Rx');
+var Observable = require('rxjs/Observable').Observable;
+
+require('rxjs/add/observable/fromEvent');
+require('rxjs/add/operator/filter');
+require('rxjs/add/operator/map');
+require('rxjs/add/operator/share');
 
 function normalizeKeypressEvents(value, key) {
   return { value: value, key: key || {} };
 }
 
 module.exports = function(rl) {
-  var keypress = Rx.Observable.fromEvent(rl.input, 'keypress', normalizeKeypressEvents)
+  var keypress = Observable.fromEvent(rl.input, 'keypress', normalizeKeypressEvents)
     // Ignore `enter` key. On the readline, we only care about the `line` event.
     .filter(({ key }) => key.name !== 'enter' && key.name !== 'return');
 
   return {
-    line: Rx.Observable.fromEvent(rl, 'line'),
+    line: Observable.fromEvent(rl, 'line'),
     keypress: keypress,
 
     normalizedUpKey: keypress

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,7 +1,10 @@
 'use strict';
 var _ = require('lodash');
-var Rx = require('rxjs/Rx');
+var Observable = require('rxjs/Observable').Observable;
 var runAsync = require('run-async');
+
+require('rxjs/add/observable/fromPromise');
+require('rxjs/add/observable/of');
 
 /**
  * Resolve a question property value if it is passed as a function.
@@ -14,10 +17,10 @@ var runAsync = require('run-async');
 
 exports.fetchAsyncQuestionProperty = function(question, prop, answers) {
   if (!_.isFunction(question[prop])) {
-    return Rx.Observable.of(question);
+    return Observable.of(question);
   }
 
-  return Rx.Observable.fromPromise(
+  return Observable.fromPromise(
     runAsync(question[prop])(answers).then(value => {
       question[prop] = value;
       return question;

--- a/test/specs/inquirer.js
+++ b/test/specs/inquirer.js
@@ -5,7 +5,7 @@
 var expect = require('chai').expect;
 var sinon = require('sinon');
 var _ = require('lodash');
-var Rx = require('rxjs/Rx');
+var Observable = require('rxjs/Observable').Observable;
 var inquirer = require('../../lib/inquirer');
 var autosubmit = require('../helpers/events').autosubmit;
 
@@ -386,7 +386,7 @@ describe('inquirer.prompt', function() {
 
   it('takes an Observable as question', function() {
     var promise;
-    var prompts = Rx.Observable.create(function(obs) {
+    var prompts = Observable.create(function(obs) {
       obs.next({
         type: 'confirm',
         name: 'q1',


### PR DESCRIPTION
Hello, thank you for this wonderful package. 

I've noticed that by simply importing `inquirer` 5.1.0, **519** (~.28s on my computer) modules get added to the module cache.  Here's a quick script to test:

```js
const inquirer = require('inquirer');
console.log(Object.keys(require.cache).length);
```

By inspecting the module cache, I noticed that the majority of the modules being imported by inquirer are unused rxjs operators.

This PR brings the number of imported modules down to **152** (~.15s on my computer) by using rxjs [patching](https://github.com/ReactiveX/rxjs/tree/stable#installation-and-usage) instead of importing the entire set of rxjs functionality.

Please consider this may be a breaking change if dependent modules are expecting inquirer observables to have all operators attached (not sure if inquirer API returns observables anywhere--I don't use observables with inquirer).