### PR TITLE
Hide default values for passwords

### DIFF
--- a/lib/prompts/base.js
+++ b/lib/prompts/base.js
@@ -123,7 +123,12 @@ class Prompt {
 
     // Append the default if available, and if question isn't answered
     if (this.opt.default != null && this.status !== 'answered') {
-      message += chalk.dim('(' + this.opt.default + ') ');
+      // If default password is supplied, hide it
+      if (this.opt.type === 'password') {
+        message += chalk.italic.dim('[hidden] ');
+      } else {
+        message += chalk.dim('(' + this.opt.default + ') ');
+      }
     }
 
     return message;


### PR DESCRIPTION
Addressing issue #635, this PR displays `[hidden]` as the default value instead of displaying the actual password, when applicable. The message is consistent with text displayed when the password is masked.