### PR TITLE
Replace coveralls with codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - yarn lerna bootstrap
 script: yarn test
 after_success:
-  - yarn lerna exec --scope inquirer -- yarn coverage
+  - yarn codecov
 env:
   global:
     - FORCE_COLOR=1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-Inquirer.js
-===========
+# Inquirer.js
 
-[![npm](https://badge.fury.io/js/inquirer.svg)](http://badge.fury.io/js/inquirer) [![tests](https://travis-ci.org/SBoudrias/Inquirer.js.svg?branch=master)](http://travis-ci.org/SBoudrias/Inquirer.js) [![Coverage Status](https://coveralls.io/repos/yeoman/generator/badge.svg)](https://coveralls.io/r/SBoudrias/Inquirer.js) [![dependencies](https://david-dm.org/SBoudrias/Inquirer.js.svg?theme=shields.io)](https://david-dm.org/SBoudrias/Inquirer.js)
+[![npm](https://badge.fury.io/js/inquirer.svg)](http://badge.fury.io/js/inquirer) [![tests](https://travis-ci.org/SBoudrias/Inquirer.js.svg?branch=master)](http://travis-ci.org/SBoudrias/Inquirer.js) [![Coverage Status](https://codecov.io/gh/SBoudrias/Inquirer.js/branch/master/graph/badge.svg)](https://codecov.io/gh/SBoudrias/Inquirer.js) [![dependencies](https://david-dm.org/SBoudrias/Inquirer.js.svg?theme=shields.io)](https://david-dm.org/SBoudrias/Inquirer.js)
 
 A collection of common interactive command line user interfaces.
 
@@ -9,23 +8,22 @@ A collection of common interactive command line user interfaces.
 
 ## Table of Contents
 
-  1. [Documentation](#documentation)
-    1. [Installation](#installation)
-    2. [Examples](#examples)
-    3. [Methods](#methods)
-    4. [Objects](#objects)
-      1. [Questions](#questions)
-      2. [Answers](#answers)
-      3. [Separator](#separator)
-    4. [Prompt Types](#prompt)
-  2. [User Interfaces and Layouts](#layouts)
-    1. [Reactive Interface](#reactive)
-  3. [Support](#support)
-  4. [News](#news)
-  5. [Contributing](#contributing)
-  6. [License](#license)
-  7. [Plugins](#plugins)
-
+1.  [Documentation](#documentation)
+    1.  [Installation](#installation)
+    2.  [Examples](#examples)
+    3.  [Methods](#methods)
+    4.  [Objects](#objects)
+    5.  [Questions](#questions)
+    6.  [Answers](#answers)
+    7.  [Separator](#separator)
+    8.  [Prompt Types](#prompt)
+2.  [User Interfaces and Layouts](#layouts)
+    1.  [Reactive Interface](#reactive)
+3.  [Support](#support)
+4.  [News](#news)
+5.  [Contributing](#contributing)
+6.  [License](#license)
+7.  [Plugins](#plugins)
 
 ## Goal and Philosophy
 
@@ -34,45 +32,54 @@ A collection of common interactive command line user interfaces.
 **`Inquirer.js`** strives to be an easily embeddable and beautiful command line interface for [Node.js](https://nodejs.org/) (and perhaps the "CLI [Xanadu](https://en.wikipedia.org/wiki/Citizen_Kane)").
 
 **`Inquirer.js`** should ease the process of
-- providing *error feedback*
-- *asking questions*
-- *parsing* input
-- *validating* answers
-- managing *hierarchical prompts*
+
+- providing _error feedback_
+- _asking questions_
+- _parsing_ input
+- _validating_ answers
+- managing _hierarchical prompts_
 
 > **Note:** **`Inquirer.js`** provides the user interface and the inquiry session flow. If you're searching for a full blown command line program utility, then check out [commander](https://github.com/visionmedia/commander.js), [vorpal](https://github.com/dthree/vorpal) or [args](https://github.com/leo/args).
 
-
 ## [Documentation](#documentation)
+
 <a name="documentation"></a>
 
 ### Installation
+
 <a name="installation"></a>
 
-``` shell
+```shell
 npm install inquirer
 ```
 
 ```javascript
 var inquirer = require('inquirer');
-inquirer.prompt([/* Pass your questions in here */]).then(answers => {
-	// Use user feedback for... whatever!!
-});
+inquirer
+  .prompt([
+    /* Pass your questions in here */
+  ])
+  .then(answers => {
+    // Use user feedback for... whatever!!
+  });
 ```
 
 <a name="examples"></a>
+
 ### Examples (Run it and see it)
+
 Check out the `examples/` folder for code and interface examples.
 
-``` shell
+```shell
 node examples/pizza.js
 node examples/checkbox.js
 # etc...
 ```
 
-
 ### Methods
+
 <a name="methods"></a>
+
 #### `inquirer.prompt(questions) -> promise`
 
 Launch the prompt interface (inquiry session)
@@ -98,19 +105,21 @@ prompt(questions).then(/* ... */);
 ```
 
 ### Objects
+
 <a name="objects"></a>
 
 #### Question
+
 <a name="questions"></a>
 A question object is a `hash` containing question related values:
 
 - **type**: (String) Type of the prompt. Defaults: `input` - Possible values: `input`, `confirm`,
-`list`, `rawlist`, `expand`, `checkbox`, `password`, `editor`
+  `list`, `rawlist`, `expand`, `checkbox`, `password`, `editor`
 - **name**: (String) The name to use when storing the answer in the answers hash. If the name contains periods, it will define a path in the answers hash.
 - **message**: (String|Function) The question to print. If defined as a function, the first parameter will be the current inquirer session answers. Defaults to the value of `name` (followed by a colon).
 - **default**: (String|Number|Boolean|Array|Function) Default value(s) to use if nothing is entered, or a function that returns the default value(s). If defined as a function, the first parameter will be the current inquirer session answers.
 - **choices**: (Array|Function) Choices array or a function returning a choices array. If defined as a function, the first parameter will be the current inquirer session answers.
-Array values can be simple `strings`, or `objects` containing a `name` (to display in list), a `value` (to save in the answers hash) and a `short` (to display after selection) properties. The choices array can also contain [a `Separator`](#separator).
+  Array values can be simple `strings`, or `objects` containing a `name` (to display in list), a `value` (to save in the answers hash) and a `short` (to display after selection) properties. The choices array can also contain [a `Separator`](#separator).
 - **validate**: (Function) Receive the user input and answers hash. Should return `true` if the value is valid, and an error message (`String`) otherwise. If `false` is returned, a default error message is provided.
 - **filter**: (Function) Receive the user input and return the filtered value to be used inside the program. The value returned will be added to the _Answers_ hash.
 - **transformer**: (Function) Receive the user input, answers hash and option flags, and return a transformed value to display to the user. The transformation only impacts what is shown while editing. It does not modify the answers hash.
@@ -121,7 +130,7 @@ Array values can be simple `strings`, or `objects` containing a `name` (to displ
 
 `default`, `choices`(if defined as functions), `validate`, `filter` and `when` functions can be called asynchronously. Either return a promise or use `this.async()` to get a callback you'll call with the final value.
 
-``` javascript
+```javascript
 {
   /* Preferred way: with promise */
   filter() {
@@ -148,6 +157,7 @@ Array values can be simple `strings`, or `objects` containing a `name` (to displ
 ```
 
 ### Answers
+
 <a name="answers"></a>
 A key/value hash containing the client answers in each prompt.
 
@@ -158,6 +168,7 @@ A key/value hash containing the client answers in each prompt.
   - `rawlist`, `list` : Selected choice value (or name if no value specified) (String)
 
 ### Separator
+
 <a name="separator"></a>
 A separator can be added to any `choices` array:
 
@@ -179,8 +190,10 @@ The constructor takes a facultative `String` value that'll be use as the separat
 Separator instances have a property `type` equal to `separator`. This should allow tools façading Inquirer interface from detecting separator types in lists.
 
 <a name="prompt"></a>
+
 ### Prompt types
----------------------
+
+---
 
 > **Note:**: _allowed options written inside square brackets (`[]`) are optional. Others are required._
 
@@ -259,8 +272,8 @@ Take `type`, `name`, `message`[, `default`, `filter`, `validate`] properties
 Launches an instance of the users preferred editor on a temporary file. Once the user exits their editor, the contents of the temporary file are read in as the result. The editor to use is determined by reading the $VISUAL or $EDITOR environment variables. If neither of those are present, notepad (on Windows) or vim (Linux or Mac) is used.
 
 <a name="layouts"></a>
-## User Interfaces and layouts
 
+## User Interfaces and layouts
 
 Along with the prompts, Inquirer offers some basic text UI.
 
@@ -284,8 +297,8 @@ ui.updateBottomBar('new bottom bar content');
 ```
 
 <a name="reactive"></a>
-## Reactive interface
 
+## Reactive interface
 
 Internally, Inquirer uses the [JS reactive extension](https://github.com/ReactiveX/rxjs) to handle events and async flows.
 
@@ -296,8 +309,12 @@ var prompts = new Rx.Subject();
 inquirer.prompt(prompts);
 
 // At some point in the future, push new questions
-prompts.next({ /* question... */ });
-prompts.next({ /* question... */ });
+prompts.next({
+  /* question... */
+});
+prompts.next({
+  /* question... */
+});
 
 // When you're done
 prompts.complete();
@@ -306,14 +323,11 @@ prompts.complete();
 And using the return value `process` property, you can access more fine grained callbacks:
 
 ```js
-inquirer.prompt(prompts).ui.process.subscribe(
-  onEachAnswer,
-  onError,
-  onComplete
-);
+inquirer.prompt(prompts).ui.process.subscribe(onEachAnswer, onError, onComplete);
 ```
 
 ## Support (OS Terminals)
+
 <a name="support"></a>
 
 You should expect mostly good support for the CLI below. This does not mean we won't
@@ -331,15 +345,14 @@ look at issues found on other command line - feel free to report any!
   - gnome-terminal (Terminal GNOME)
   - konsole
 
-
 ## News on the march (Release notes)
-<a name="news"></a>
 
+<a name="news"></a>
 
 Please refer to the [Github releases section for the changelog](https://github.com/SBoudrias/Inquirer.js/releases)
 
-
 ## Contributing
+
 <a name="contributing"></a>
 
 **Unit test**
@@ -354,54 +367,56 @@ get feedback before release. Let us know if you want to be added to the list (ju
 to [@vaxilart](https://twitter.com/Vaxilart)) or just add your name to [the wiki](https://github.com/SBoudrias/Inquirer.js/wiki/Testers)
 
 ## License
+
 <a name="license"></a>
 
 Copyright (c) 2016 Simon Boudrias (twitter: [@vaxilart](https://twitter.com/Vaxilart))
 Licensed under the MIT license.
 
 ## Plugins
+
 <a name="plugins"></a>
 
-### Prompts ###
+### Prompts
 
-[__autocomplete__](https://github.com/mokkabonna/inquirer-autocomplete-prompt)<br>
+[**autocomplete**](https://github.com/mokkabonna/inquirer-autocomplete-prompt)<br>
 Presents a list of options as the user types, compatible with other packages such as fuzzy (for search)<br>
 <br>
 ![autocomplete prompt](https://github.com/mokkabonna/inquirer-autocomplete-prompt/raw/master/inquirer.gif)
 
-[__checkbox-plus__](https://github.com/faressoft/inquirer-checkbox-plus-prompt)<br>
+[**checkbox-plus**](https://github.com/faressoft/inquirer-checkbox-plus-prompt)<br>
 Checkbox list with autocomplete and other additions<br>
 <br>
 ![checkbox-plus](https://github.com/faressoft/inquirer-checkbox-plus-prompt/raw/master/demo.gif)
 
-[__datetime__](https://github.com/DerekTBrown/inquirer-datepicker-prompt)<br>
+[**datetime**](https://github.com/DerekTBrown/inquirer-datepicker-prompt)<br>
 Customizable date/time selector using both number pad and arrow keys<br>
 <br>
 ![Datetime Prompt](https://github.com/DerekTBrown/inquirer-datepicker-prompt/raw/master/example/datetime-prompt.png)
 
-[__inquirer-select-line__](https://github.com/adam-golab/inquirer-select-line)<br>
+[**inquirer-select-line**](https://github.com/adam-golab/inquirer-select-line)<br>
 Prompt for selecting index in array where add new element<br>
 <br>
 ![inquirer-select-line gif](https://media.giphy.com/media/xUA7b1MxpngddUvdHW/giphy.gif)
 
-[__command__](https://github.com/sullof/inquirer-command-prompt)<br>
+[**command**](https://github.com/sullof/inquirer-command-prompt)<br>
 <br>
 Simple prompt with command history and dynamic autocomplete
 
-[__inquirer-fuzzy-path__](https://github.com/adelsz/inquirer-fuzzy-path)<br>
+[**inquirer-fuzzy-path**](https://github.com/adelsz/inquirer-fuzzy-path)<br>
 Prompt for fuzzy file/directory selection.<br>
 <br>
 ![inquirer-fuzzy-path](https://raw.githubusercontent.com/adelsz/inquirer-fuzzy-path/master/recording.gif)
 
-[__inquirer-chalk-pipe__](https://github.com/LitoMore/inquirer-chalk-pipe)<br>
+[**inquirer-chalk-pipe**](https://github.com/LitoMore/inquirer-chalk-pipe)<br>
 Prompt for input chalk-pipe style strings<br>
 <br>
 ![inquirer-chalk-pipe](https://github.com/LitoMore/inquirer-chalk-pipe/raw/master/screenshot.gif)
 
-[__inquirer-search-checkbox__](https://github.com/clinyong/inquirer-search-checkbox)<br>
+[**inquirer-search-checkbox**](https://github.com/clinyong/inquirer-search-checkbox)<br>
 Searchable Inquirer checkbox<br>
 
-[__inquirer-prompt-suggest__](https://github.com/olistic/inquirer-prompt-suggest)<br>
+[**inquirer-prompt-suggest**](https://github.com/olistic/inquirer-prompt-suggest)<br>
 Inquirer prompt for your less creative users.
 
 ![inquirer-prompt-suggest](https://user-images.githubusercontent.com/5600126/40391192-d4f3d6d0-5ded-11e8-932f-4b75b642c09e.gif)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "babel-core": "^6.26.3",
     "babel-jest": "^23.0.1",
     "babel-preset-env": "^1.7.0",
+    "codecov": "^3.0.2",
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^2.4.0",
     "eslint-config-xo": "^0.22.1",
@@ -32,5 +33,9 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "jest": {
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true
   }
 }

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -22,7 +22,6 @@
     "chai": "^4.0.1",
     "chalk-pipe": "^1.2.0",
     "cmdify": "^0.0.4",
-    "coveralls": "^3.0.0",
     "mocha": "^5.0.0",
     "mockery": "^2.1.0",
     "nsp": "^3.0.0",
@@ -31,8 +30,8 @@
   },
   "scripts": {
     "test": "nyc mocha test/**/* -r ./test/before",
-    "prepublish": "nsp check",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "posttest": "nyc report --reporter=text-lcov > ../../coverage/nyc-report.lcov",
+    "prepublish": "nsp check"
   },
   "repository": "SBoudrias/Inquirer.js",
   "license": "MIT",

--- a/packages/inquirer/yarn.lock
+++ b/packages/inquirer/yarn.lock
@@ -661,16 +661,6 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-coveralls@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.0.tgz#22ef730330538080d29b8c151dc9146afde88a99"
-  dependencies:
-    js-yaml "^3.6.1"
-    lcov-parse "^0.0.10"
-    log-driver "^1.2.5"
-    minimist "^1.2.0"
-    request "^2.79.0"
-
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,6 +257,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -1189,6 +1193,14 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+codecov@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.2.tgz#aea43843a5cd2fb6b7e488b2eff25d367ab70b12"
+  dependencies:
+    argv "0.0.2"
+    request "^2.81.0"
+    urlgrey "0.4.4"
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -1440,16 +1452,6 @@ cosmiconfig@^5.0.2:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
-
-coveralls@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.1.tgz#12e15914eaa29204e56869a5ece7b9e1492d2ae2"
-  dependencies:
-    js-yaml "^3.6.1"
-    lcov-parse "^0.0.10"
-    log-driver "^1.2.5"
-    minimist "^1.2.0"
-    request "^2.79.0"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -3280,7 +3282,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.11.0, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.11.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -3414,10 +3416,6 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
-
-lcov-parse@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
 left-pad@^1.2.0:
   version "1.3.0"
@@ -3620,10 +3618,6 @@ lodash@^3.10.1:
 lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-
-log-driver@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -4667,7 +4661,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.79.0, request@^2.83.0:
+request@^2.81.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -5442,6 +5436,10 @@ url-parse-lax@^1.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 use@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Codecov seems to have better support for merging many coverage reports. This will be useful while we're maintaining the old project at the same time as the refactor.