### PR TITLE
Allow empty input by removing default if user enters backspace on empty input

### DIFF
--- a/packages/inquirer/lib/prompts/input.js
+++ b/packages/inquirer/lib/prompts/input.js
@@ -97,7 +97,23 @@ class InputPrompt extends Base {
    * When user press a key
    */
 
-  onKeypress() {
+  onKeypress(event) {
+    const { key } = event;
+
+    // Empty the default when a user clears the input
+    // The `this.hasInput` flag is required to properly detect when the user
+    // has pressed the backspace key while the line is already empty, in which
+    // case we reset the default, which allows a user to supply an empty response.
+    if (key.name === 'backspace' && !this.rl.line) {
+      if (this.hasInput) {
+        this.hasInput = undefined;
+      } else {
+        this.opt.default = undefined;
+      }
+    } else if (this.rl.line && !this.hasInput) {
+      this.hasInput = true;
+    }
+
     this.render();
   }
 }

--- a/packages/inquirer/test/specs/prompts/input.js
+++ b/packages/inquirer/test/specs/prompts/input.js
@@ -98,4 +98,47 @@ describe('`input` prompt', function() {
       done();
     }, 200);
   });
+
+  it('should use the default when the user submits empty input', function() {
+    this.fixture.default = 'DEFAULT';
+
+    var prompt = new Input(this.fixture, this.rl);
+    var promise = prompt.run();
+
+    this.rl.emit('line', '');
+
+    return promise.then(answer => {
+      expect(answer).to.equal('DEFAULT');
+    });
+  });
+
+  it('should use the default when the user enters some input then deletes it', function() {
+    this.fixture.default = 'DEFAULT';
+
+    var prompt = new Input(this.fixture, this.rl);
+    var promise = prompt.run();
+
+    this.rl.line = 'a';
+    this.rl.input.emit('keypress', ' ', { name: 'backspace' });
+    this.rl.emit('line', '');
+
+    return promise.then(answer => {
+      expect(answer).to.equal('DEFAULT');
+    });
+  });
+
+  it('should clear the default when the user hits backspace when input is empty', function() {
+    this.fixture.default = 'DEFAULT';
+
+    var prompt = new Input(this.fixture, this.rl);
+    var promise = prompt.run();
+
+    this.rl.line = '';
+    this.rl.input.emit('keypress', ' ', { name: 'backspace' });
+    this.rl.emit('line', '');
+
+    return promise.then(answer => {
+      expect(answer).to.equal('');
+    });
+  });
 });


### PR DESCRIPTION
~~Strip surrounding quotes from input value; enable empty values~~

As mentioned a loooong time ago in #108, there's currently no way to input an empty value for an input with a default value.

~~But what if we allowed users to put quotes around their input values the way you would when setting a bash variable? And then the value would be set to the unquoted value.~~

~~In other words, when a user enters `"foo"` the value would be set to `foo` (without quotes).~~

~~This feels like expected behavior to me, and it would enable an empty value for an input with a default value, because `""` would become an empty string.~~

~~Is this too magical or unexpected?~~

~~Would it be better to simply treat a value of `""` or `''` as a special case that should be transformed to an empty string?~~

I think _some_ solution would be preferable to the current recommendation (adding an extra Y/N question).

**UPDATED** in line with [comment](https://github.com/SBoudrias/Inquirer.js/pull/700#issuecomment-405063832) to use `backspace` instead of stripping quotes.