### PR TITLE
Add option to not clear input upon validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A question object is a `hash` containing question related values:
 - **pageSize**: (Number) Change the number of lines that will be rendered when using `list`, `rawList`, `expand` or `checkbox`.
 - **prefix**: (String) Change the default _prefix_ message.
 - **suffix**: (String) Change the default _suffix_ message.
+- **keepAnswerOnValidationError**: (Boolean) If true and user answer fails validation, the answer is kept in the input.
 
 `default`, `choices`(if defined as functions), `validate`, `filter` and `when` functions can be called asynchronously. Either return a promise or use `this.async()` to get a callback you'll call with the final value.
 

--- a/packages/inquirer/lib/prompts/input.js
+++ b/packages/inquirer/lib/prompts/input.js
@@ -90,6 +90,11 @@ class InputPrompt extends Base {
   }
 
   onError(state) {
+    if (this.opt.keepAnswerOnValidationError && (typeof state.value !== 'number' || !isNaN(state.value))) {
+      this.rl.line += state.value;
+      this.rl.cursor = state.value.length;
+    }
+
     this.render(state.isValid);
   }
 


### PR DESCRIPTION
Currently when an user enters invalid answer, the input line is cleared. I have added an option that keeps the answer if the flag is set.

For strings, the input is always kept. For numbers, the input is only kept if the number is not NaN, which usually happens if the user inputs non-number answers.

Issue: #374 