### PR TITLE
feat: pre-defined answers

### DIFF
--- a/packages/inquirer/lib/inquirer.js
+++ b/packages/inquirer/lib/inquirer.js
@@ -21,11 +21,13 @@ inquirer.ui = {
 
 /**
  * Create a new self-contained prompt module.
+ * @param {Object} opt Readline options
+ * @return {Function}
  */
 inquirer.createPromptModule = function(opt) {
-  var promptModule = function(questions) {
+  var promptModule = function(questions, answers) {
     var ui = new inquirer.ui.Prompt(promptModule.prompts, opt);
-    var promise = ui.run(questions);
+    var promise = ui.run(questions, answers);
 
     // Monkey patch the UI on the promise object so
     // that it remains publicly accessible.

--- a/packages/inquirer/lib/objects/choices.js
+++ b/packages/inquirer/lib/objects/choices.js
@@ -105,6 +105,14 @@ module.exports = class Choices {
     return _.find(this.choices, func);
   }
 
+  findIndex(func) {
+    var length = this.length;
+    for (var i = 0; i < length; i++) {
+      if (func(this.choices[i])) return i;
+    }
+    return -1;
+  }
+
   push() {
     var objs = _.map(arguments, val => new Choice(val));
     this.choices.push.apply(this.choices, objs);

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -58,6 +58,12 @@ class Prompt {
       this.done = resolve;
 
       var val = this.answers[this.opt.name];
+      if (val == null) {
+        this._run();
+        this.render();
+        return;
+      }
+
       if (_.isFunction(val)) {
         val = rx.from(Promise.resolve(val(this.answers)));
       } else {

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -71,10 +71,7 @@ class Prompt {
           this._run();
           this.render();
         } else {
-          this.firstRender = false;
-          this.render();
-
-          this.firstRender = true;
+          // Run the prompt if the answer is invalid.
           this.submit(rx.of(val)).error.forEach(() => this._run());
         }
       });

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -57,7 +57,7 @@ class Prompt {
     return new Promise(resolve => {
       this.done = resolve;
 
-      var val = this.answers[this.opt.name];
+      var val = _.get(this.answers, this.opt.name);
       if (val == null) {
         this._run();
         this.render();

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -76,22 +76,21 @@ class CheckboxPrompt extends Base {
     var message = this.getQuestion();
     var bottomContent = '';
 
-    if (this.firstRender) {
-      this.firstRender = false;
-      message +=
-        '(Press ' +
-        chalk.cyan.bold('<space>') +
-        ' to select, ' +
-        chalk.cyan.bold('<a>') +
-        ' to toggle all, ' +
-        chalk.cyan.bold('<i>') +
-        ' to invert selection)';
-    }
-
     // Render choices or answer depending on the state
     if (this.status === 'answered') {
       message += chalk.cyan(this.selection.join(', '));
     } else {
+      if (this.firstRender) {
+        this.firstRender = false;
+        message +=
+          '(Press ' +
+          chalk.cyan.bold('<space>') +
+          ' to select, ' +
+          chalk.cyan.bold('<a>') +
+          ' to toggle all, ' +
+          chalk.cyan.bold('<i>') +
+          ' to invert selection)';
+      }
       var choicesStr = renderChoices(this.opt.choices, this.pointer);
       var indexPosition = this.opt.choices.indexOf(
         this.opt.choices.getChoice(this.pointer)

--- a/packages/inquirer/lib/prompts/confirm.js
+++ b/packages/inquirer/lib/prompts/confirm.js
@@ -12,47 +12,22 @@ var observe = require('../utils/events');
 class ConfirmPrompt extends Base {
   constructor(questions, rl, answers) {
     super(questions, rl, answers);
-
-    var rawDefault = true;
-
-    _.extend(this.opt, {
-      filter: function(input) {
-        var value = rawDefault;
-        if (input != null && input !== '') {
-          value = /^y(es)?/i.test(input);
-        }
-        return value;
-      }
-    });
-
-    if (_.isBoolean(this.opt.default)) {
-      rawDefault = this.opt.default;
-    }
-
-    this.opt.default = rawDefault ? 'Y/n' : 'y/N';
-
+    this.rawDefault = this.opt.default !== false;
+    this.opt.default = this.rawDefault ? 'Y/n' : 'y/N';
     return this;
   }
 
   /**
    * Start the Inquiry session
-   * @param  {Function} cb   Callback when prompt is done
    * @return {this}
    */
 
-  _run(cb) {
-    this.done = cb;
-
+  _run() {
     // Once user confirm (enter key)
     var events = observe(this.rl);
+
     events.keypress.pipe(takeUntil(events.line)).forEach(this.onKeypress.bind(this));
-
     events.line.pipe(take(1)).forEach(this.onEnd.bind(this));
-
-    // Init
-    this.render();
-
-    return this;
   }
 
   /**
@@ -72,6 +47,14 @@ class ConfirmPrompt extends Base {
     this.screen.render(message);
 
     return this;
+  }
+
+  filterInput(input) {
+    return _.isBoolean(input) ? input : input ? /^y(es)?/i.test(input) : this.rawDefault;
+  }
+
+  filterBypass(input) {
+    return input === true || /^y(es)?/i.test(input);
   }
 
   /**

--- a/packages/inquirer/lib/prompts/confirm.js
+++ b/packages/inquirer/lib/prompts/confirm.js
@@ -5,7 +5,7 @@
 
 var _ = require('lodash');
 var chalk = require('chalk');
-var { take, takeUntil } = require('rxjs/operators');
+var { map, take, takeUntil } = require('rxjs/operators');
 var Base = require('./base');
 var observe = require('../utils/events');
 
@@ -27,7 +27,9 @@ class ConfirmPrompt extends Base {
     var events = observe(this.rl);
 
     events.keypress.pipe(takeUntil(events.line)).forEach(this.onKeypress.bind(this));
-    events.line.pipe(take(1)).forEach(this.onEnd.bind(this));
+    events.line
+      .pipe(take(1), map(this.filterInput, this))
+      .forEach(input => this.onEnd({ isValid: true, value: input }));
   }
 
   /**
@@ -61,10 +63,10 @@ class ConfirmPrompt extends Base {
    * When user press `enter` key
    */
 
-  onEnd(input) {
+  onEnd(state) {
     this.status = 'answered';
 
-    var output = this.opt.filter(input);
+    var output = this.opt.filter(state.value);
     this.render(output);
 
     this.screen.done();

--- a/packages/inquirer/lib/prompts/editor.js
+++ b/packages/inquirer/lib/prompts/editor.js
@@ -12,32 +12,21 @@ var { Subject } = require('rxjs');
 class EditorPrompt extends Base {
   /**
    * Start the Inquiry session
-   * @param  {Function} cb      Callback when prompt is done
    * @return {this}
    */
 
-  _run(cb) {
-    this.done = cb;
-
-    this.editorResult = new Subject();
-
+  _run() {
     // Open Editor on "line" (Enter Key)
     var events = observe(this.rl);
     this.lineSubscription = events.line.subscribe(this.startExternalEditor.bind(this));
 
-    // Trigger Validation when editor closes
-    var validation = this.handleSubmitEvents(this.editorResult);
-    validation.success.forEach(this.onEnd.bind(this));
-    validation.error.forEach(this.onError.bind(this));
+    // Trigger validation when editor closes
+    this.editorResult = new Subject();
+    this.submit(this.editorResult);
 
     // Prevents default from being printed on screen (can look weird with multiple lines)
     this.currentText = this.opt.default;
     this.opt.default = null;
-
-    // Init
-    this.render();
-
-    return this;
   }
 
   /**
@@ -85,9 +74,8 @@ class EditorPrompt extends Base {
     this.editorResult.unsubscribe();
     this.lineSubscription.unsubscribe();
     this.answer = state.value;
-    this.status = 'answered';
-    // Re-render prompt
-    this.render();
+    super.onEnd();
+
     this.screen.done();
     this.done(this.answer);
   }

--- a/packages/inquirer/lib/prompts/input.js
+++ b/packages/inquirer/lib/prompts/input.js
@@ -4,36 +4,24 @@
  */
 
 var chalk = require('chalk');
-var { map, takeUntil } = require('rxjs/operators');
+var { takeUntil } = require('rxjs/operators');
 var Base = require('./base');
 var observe = require('../utils/events');
 
 class InputPrompt extends Base {
   /**
    * Start the Inquiry session
-   * @param  {Function} cb      Callback when prompt is done
    * @return {this}
    */
 
-  _run(cb) {
-    this.done = cb;
-
+  _run() {
     // Once user confirm (enter key)
     var events = observe(this.rl);
-    var submit = events.line.pipe(map(this.filterInput.bind(this)));
-
-    var validation = this.handleSubmitEvents(submit);
-    validation.success.forEach(this.onEnd.bind(this));
-    validation.error.forEach(this.onError.bind(this));
+    var validation = this.submit(events.line);
 
     events.keypress
       .pipe(takeUntil(validation.success))
       .forEach(this.onKeypress.bind(this));
-
-    // Init
-    this.render();
-
-    return this;
   }
 
   /**
@@ -80,10 +68,7 @@ class InputPrompt extends Base {
 
   onEnd(state) {
     this.answer = state.value;
-    this.status = 'answered';
-
-    // Re-render prompt
-    this.render();
+    super.onEnd();
 
     this.screen.done();
     this.done(state.value);

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -76,15 +76,14 @@ class ListPrompt extends Base {
     // Render question
     var message = this.getQuestion();
 
-    if (this.firstRender) {
-      this.firstRender = false;
-      message += chalk.dim('(Use arrow keys)');
-    }
-
     // Render choices or answer depending on the state
     if (this.status === 'answered') {
       message += chalk.cyan(this.opt.choices.getChoice(this.selected).short);
     } else {
+      if (this.firstRender) {
+        this.firstRender = false;
+        message += chalk.dim('(Use arrow keys)');
+      }
       var choicesStr = listRender(this.opt.choices, this.selected);
       var indexPosition = this.opt.choices.indexOf(
         this.opt.choices.getChoice(this.selected)

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -62,7 +62,7 @@ class ListPrompt extends Base {
         map(this.getCurrentValue, this),
         flatMap(value => runAsync(this.opt.filter)(value).catch(err => err))
       )
-      .forEach(this.onEnd.bind(this));
+      .forEach(input => this.onEnd({ isValid: true, value: input }));
 
     cliCursor.hide();
   }
@@ -117,12 +117,12 @@ class ListPrompt extends Base {
    * When user press `enter` key
    */
 
-  onEnd(value) {
+  onEnd(state) {
     super.onEnd();
 
     this.screen.done();
     cliCursor.show();
-    this.done(value);
+    this.done(state.value);
   }
 
   /**

--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -59,7 +59,7 @@ class PromptUI extends Base {
       if (names.indexOf(name) === -1) {
         console.log(chalk.red('>> ') + 'Invalid question: %O', name);
       } else {
-        this.answers[name] = answers[name];
+        _.set(this.answers, name, answers[name]);
       }
     }
   }

--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var { defer, empty, from, of } = require('rxjs');
 var { concatMap, filter, publish, reduce } = require('rxjs/operators');
 var runAsync = require('run-async');
+var chalk = require('chalk');
 var utils = require('../utils/utils');
 var Base = require('./baseUI');
 
@@ -16,9 +17,13 @@ class PromptUI extends Base {
     this.prompts = prompts;
   }
 
-  run(questions) {
-    // Keep global reference to the answers
+  run(questions, answers) {
     this.answers = {};
+
+    // Pre-defined answers
+    if (answers) {
+      this.prefill(questions, answers);
+    }
 
     // Make sure questions is an array.
     if (_.isPlainObject(questions)) {
@@ -46,6 +51,17 @@ class PromptUI extends Base {
       )
       .toPromise(Promise)
       .then(this.onCompletion.bind(this));
+  }
+
+  prefill(questions, answers) {
+    var names = questions.map(question => question.name);
+    for (var name in answers) {
+      if (names.indexOf(name) === -1) {
+        console.log(chalk.red('>> ') + 'Invalid question: %O', name);
+      } else {
+        this.answers[name] = answers[name];
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #708
```js
const {prompt} = require('inquirer');

const answers = await prompt(questions, {
  semver: true,      // confirm
  version: '1.0.0',  // input
  license: 2,        // list (choices index)
  libs: [],          // checkbox
});
```

Pre-defined answers are always passed to the `filter`, `transformer`, and `validate` options.

For `list` and `rawlist` prompts, we look for a choice that matches the pre-defined answer, which may be an index, a choice `name`, or a choice `value`. If no match is found, the prompt is used.

For `checkbox` prompts, we set `checked = true` for any matching choices. The pre-defined answer can be an array of strings or a comma-separated string (eg: `"a,b,c"`). If the pre-defined answer `!== ""` and no matching choices are found, the prompt is used.

For `confirm` prompts, the pre-defined answer can be a boolean or a string (eg: `"yes"` or `"y"`).

For `input`, `password`, `number`, and `editor` prompts, the pre-defined answer is coerced to a string.

When a pre-defined answer is rejected, its associated prompt is used.

Pre-defined answers that have no associated question cause a warning to be printed.

Prompt classes may have a `filterBypass` method that transforms the value of pre-defined answers.

### Changes
- make `prompt` accept an answers object as its 2nd argument
- add default behavior to `Prompt#onEnd` and `Prompt#onError`
- throw error if `Prompt#_run` is not overridden
- rename `Prompt#handleSubmitEvents` to `submit`
- hook up `filterInput`, `onEnd`, and `onError` in `Prompt#submit`
- support `filterBypass` method on Prompt objects
- set `done` property of Prompt objects before calling `_run`
- stop passing `done` callback to `Prompt#_run`
- rename `ExpandPrompt#getCurrentValue` to `filterInput`
- rename `onSubmit` methods to `onEnd`
- add `Choices#findIndex` method