### PR TITLE
Added highlight for selected line in checkbox

### DIFF
--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -226,7 +226,7 @@ function renderChoices(choices, pointer) {
       output += ' - ' + choice.name;
       output += ' (' + (_.isString(choice.disabled) ? choice.disabled : 'Disabled') + ')';
     } else {
-      var line = getCheckbox(choice.checked) + choice.name;
+      var line = getCheckbox(choice.checked) + ' ' + choice.name;
       if (i - separatorOffset === pointer) {
         output += chalk.cyan(figures.pointer + line);
       } else {

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -226,9 +226,12 @@ function renderChoices(choices, pointer) {
       output += ' - ' + choice.name;
       output += ' (' + (_.isString(choice.disabled) ? choice.disabled : 'Disabled') + ')';
     } else {
-      var isSelected = i - separatorOffset === pointer;
-      output += isSelected ? chalk.cyan(figures.pointer) : ' ';
-      output += getCheckbox(choice.checked) + ' ' + choice.name;
+      var line = getCheckbox(choice.checked) + choice.name;
+      if (i - separatorOffset === pointer) {
+        output += chalk.cyan(figures.pointer + line);
+      } else {
+        output += ' ' + line;
+      }
     }
 
     output += '\n';


### PR DESCRIPTION
fixes #479 

There is inconsistency between list and checkbox selected line. It is highlighted in list and ignored in checkbox module. It is hard to follow what item is currently selected, when there are to many similar items with checkboxes. This fix changes code in order to highlight selected line with cyan color.