### PR TITLE
Add README file to 'inquirer' npm package

### DIFF
--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of common interactive command line user interfaces.",
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "files": [
-    "lib"
+    "lib",
+    "README.md"
   ],
   "main": "lib/inquirer.js",
   "keywords": [
@@ -31,7 +32,9 @@
   "scripts": {
     "test": "nyc mocha test/**/* -r ./test/before",
     "posttest": "nyc report --reporter=text-lcov > ../../coverage/nyc-report.lcov",
-    "prepublish": "nsp check"
+    "prepublish": "nsp check",
+    "prepublishOnly": "cp ../../README.md .",
+    "postpublish": "rm -f README.md"
   },
   "repository": "SBoudrias/Inquirer.js",
   "license": "MIT",


### PR DESCRIPTION
Right now, the npm `README` of inquirer is empty, so it looks like you're looking at the wrong module

![image](https://user-images.githubusercontent.com/17952318/46465677-86e04a00-c7c9-11e8-8249-5cb82cd22e16.png)

I've added two npm scripts:
- Just before publishing, the `README` from `./` is copied to `./packages/inquirer`
- Just after publishing, that file is deleted

That should fix the problem
