### PR TITLE
Add inquirer-s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,3 +422,8 @@ Searchable Inquirer checkbox<br>
 Inquirer prompt for your less creative users.
 
 ![inquirer-prompt-suggest](https://user-images.githubusercontent.com/5600126/40391192-d4f3d6d0-5ded-11e8-932f-4b75b642c09e.gif)
+
+[**inquirer-s3**](https://github.com/HQarroum/inquirer-s3)<br>
+An S3 object selector for Inquirer.
+
+![inquirer-s3](https://github.com/HQarroum/inquirer-s3/raw/master/docs/inquirer-screenshot.png)


### PR DESCRIPTION
This PR adds the `inquirer-s3` plugin in the documented list of available plugins for Inquirer.