### PR TITLE
ci: use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ node_js:
   - node
 before_script:
   - npm run bootstrap
-script: npm test
+script:
+  - npm test
 after_success:
   - npm run codecov
 env:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "packages/*"
   ],
   "scripts": {
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "lerna bootstrap --no-ci",
     "pretest": "eslint .",
     "test": "jest --coverage && lerna exec npm test --scope inquirer"
   },


### PR DESCRIPTION
With a lockfile Travis CI now uses `npm ci` by default which is not what we want.
Also see the failing CI build.