### PR TITLE
Allow disabled checkboxes to still be counted in answers if they're checked programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A question object is a `hash` containing question related values:
 - **pageSize**: (Number) Change the number of lines that will be rendered when using `list`, `rawList`, `expand` or `checkbox`.
 - **prefix**: (String) Change the default _prefix_ message.
 - **suffix**: (String) Change the default _suffix_ message.
+- **includeDisabled**: (Boolean) In returned answers, include choices that are `{disabled: true}` as well as `{checked: true}`. Defaults: `false`
 
 `default`, `choices`(if defined as functions), `validate`, `filter` and `when` functions can be called asynchronously. Either return a promise or use `this.async()` to get a callback you'll call with the final value.
 
@@ -235,7 +236,7 @@ Take `type`, `name`, `message`, `choices`[, `filter`, `validate`, `default`] pro
 
 Choices marked as `{checked: true}` will be checked by default.
 
-Choices whose property `disabled` is truthy will be unselectable. If `disabled` is a string, then the string will be outputted next to the disabled choice, otherwise it'll default to `"Disabled"`. The `disabled` property can also be a synchronous function receiving the current answers as argument and returning a boolean or a string.
+Choices whose property `disabled` is truthy will be unselectable. By default, disabled choices will not be returned as answers. To include disabled choices that are marked as `{checked: true}` in the answers for a question, set the `includeDisabled` option on the question to `true`. If `disabled` is a string, then the string will be outputted next to the disabled choice, otherwise it'll default to `"Disabled"`. The `disabled` property can also be a synchronous function receiving the current answers as argument and returning a boolean or a string.
 
 ![Checkbox prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/checkbox.svg)
 

--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -96,6 +96,11 @@ class PromptUI extends Base {
       question.type = 'input';
     }
 
+    // By default, don't include disabled choices in answers
+    if (typeof question.includeDisabled === 'undefined') {
+      question.includeDisabled = false;
+    }
+
     return defer(() => of(question));
   }
 

--- a/packages/inquirer/test/specs/prompts/checkbox.js
+++ b/packages/inquirer/test/specs/prompts/checkbox.js
@@ -233,6 +233,20 @@ describe('`checkbox` prompt', function() {
       this.rl.emit('line');
     });
 
+    it('include choices that are disabled when includeDisabled is true', function(done) {
+      this.fixture.choices = [
+        { name: '1', checked: true, disabled: true },
+        { name: '2', checked: false, disabled: true }
+      ];
+      this.fixture.includeDisabled = true;
+      this.checkbox = new Checkbox(this.fixture, this.rl);
+      this.checkbox.run().then(answer => {
+        expect(answer.length).to.equal(1);
+        done();
+      });
+      this.rl.emit('line');
+    });
+
     it('disabled can be a function', function() {
       this.fixture.choices = [
         {


### PR DESCRIPTION
This PR is related to #575.

A new option for a question is introduced called `includeDisabled`. By default, this option is `false`, to keep the current behaviour as the default (disabled choices are not passed through to answers.

@SBoudrias Let me know if there's anything else I can contribute to this PR; looking forward to your feedback!

For disabled choices that are marked as `{checked: true}`, their radio buttons will be gray instead of green.