### PR TITLE
Remove paginated option from example

### DIFF
--- a/packages/inquirer/examples/long-list.js
+++ b/packages/inquirer/examples/long-list.js
@@ -20,14 +20,12 @@ inquirer
       type: 'list',
       name: 'letter',
       message: "What's your favorite letter?",
-      paginated: true,
       choices: choices
     },
     {
       type: 'checkbox',
       name: 'name',
       message: 'Select the letter contained in your name:',
-      paginated: true,
       choices: choices
     }
   ])


### PR DESCRIPTION
This `paginated` option only exists in this example, but nowhere in the code. It was removed in https://github.com/SBoudrias/Inquirer.js/pull/55.