### PR TITLE
Remove all event listeners on close to avoid memory leak

### DIFF
--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -78,6 +78,7 @@ class Prompt {
    */
   close() {
     this.screen.releaseCursor();
+    this.rl.input.removeAllListeners();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fix for #805 by removing all event listeners on `prompt.ui.close()`.

## Testing

In the repro (https://github.com/jared-hexagon/inquirer-memory-leak-repro) I `npm link`ed my fork and the `MaxListenersExceededWarning` warning never shows up.

