### PR TITLE
Revert "Remove all event listeners on close to avoid memory leak (#808)"

### DIFF
--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -78,7 +78,6 @@ class Prompt {
    */
   close() {
     this.screen.releaseCursor();
-    this.rl.input.removeAllListeners();
   }
 
   /**


### PR DESCRIPTION
Investigation in [this comment](https://github.com/SBoudrias/Inquirer.js/pull/808#issuecomment-504183694)

Fixes #811