### PR TITLE
feat: add inquirer-file-tree-selection-prompt readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,3 +442,8 @@ An S3 object selector for Inquirer.
 
 [**inquirer-autosubmit-prompt**](https://github.com/yaodingyd/inquirer-autosubmit-prompt)<br>
 Auto submit based on your current input, saving one extra enter
+
+[**inquirer-file-tree-selection-prompt**](https://github.com/anc95/inquirer-file-tree-selection)<br>
+Inquirer prompt for to select a file or directory in file tree
+
+![inquirer-file-tree-selection-prompt](https://github.com/anc95/inquirer-file-tree-selection/blob/master/example/screenshot.gif)


### PR DESCRIPTION
Hi:
I write a prompt `inquirer-file-tree-selection-prompt`, it's used for select a file or directory in a file tree, now I add it to your README.md, can u merge it? thx~

![inquirer-file-tree-selection-prompt-demo](https://raw.githubusercontent.com/anc95/inquirer-file-tree-selection/master/example/screenshot.gif)

regards anc95