### PR TITLE
Upgrade lodash to 4.17.12 to Fix Vulnerability

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inquirer/core",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.5-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -76,9 +76,9 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.12.tgz",
+      "integrity": "sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "chalk": "^2.4.2",
     "cli-spinners": "^1.3.1",
     "cli-width": "^2.2.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.12",
     "mute-stream": "^0.0.7",
     "run-async": "^2.3.0",
     "string-width": "^2.1.1",

--- a/packages/inquirer/package-lock.json
+++ b/packages/inquirer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer",
-  "version": "6.3.1",
+  "version": "6.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -492,9 +492,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.12.tgz",
+      "integrity": "sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -642,6 +642,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -966,7 +967,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -1050,6 +1052,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1096,7 +1099,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -1362,7 +1366,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -43,7 +43,7 @@
     "cli-width": "^2.0.0",
     "external-editor": "^3.0.3",
     "figures": "^2.0.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.12",
     "mute-stream": "0.0.7",
     "run-async": "^2.2.0",
     "rxjs": "^6.4.0",


### PR DESCRIPTION
https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/