### PR TITLE
close keypress stream when rl close

### DIFF
--- a/packages/inquirer/lib/utils/events.js
+++ b/packages/inquirer/lib/utils/events.js
@@ -1,6 +1,6 @@
 'use strict';
 var { fromEvent } = require('rxjs');
-var { filter, map, share } = require('rxjs/operators');
+var { filter, map, share, takeUntil } = require('rxjs/operators');
 
 function normalizeKeypressEvents(value, key) {
   return { value: value, key: key || {} };
@@ -8,6 +8,7 @@ function normalizeKeypressEvents(value, key) {
 
 module.exports = function(rl) {
   var keypress = fromEvent(rl.input, 'keypress', normalizeKeypressEvents)
+    .pipe(takeUntil(fromEvent(rl, 'close')))
     // Ignore `enter` key. On the readline, we only care about the `line` event.
     .pipe(filter(({ key }) => key.name !== 'enter' && key.name !== 'return'));
 


### PR DESCRIPTION
In our CLI we capture SIGINT events and cancel any active prompt when this happens.
I noticed that when we do that, Inquirer leak the prompts, 
This happens because `rl` event streams (created when calling `observe(this.rl)`) never complete, thus causing underlying streams not to complete as well.

