### PR TITLE
Bugfix: Choices.push() breaks index if a disabled item was already in the Choices

### DIFF
--- a/packages/inquirer/lib/objects/choices.js
+++ b/packages/inquirer/lib/objects/choices.js
@@ -110,7 +110,9 @@ module.exports = class Choices {
   push() {
     var objs = _.map(arguments, val => new Choice(val));
     this.choices.push.apply(this.choices, objs);
-    this.realChoices = this.choices.filter(Separator.exclude);
+    this.realChoices = this.choices
+      .filter(Separator.exclude)
+      .filter(item => !item.disabled);
     return this.choices;
   }
 };

--- a/packages/inquirer/test/specs/objects/choices.js
+++ b/packages/inquirer/test/specs/objects/choices.js
@@ -72,11 +72,19 @@ describe('Choices collection', function() {
   });
 
   it('should façade push and update the realChoices internally', function() {
-    var choices = new Choices(['a']);
+    var choices = new Choices(['a', { name: 'b', disabled: true }]);
     choices.push('b', new inquirer.Separator());
-    expect(choices.length).to.equal(3);
+    expect(choices.length).to.equal(4);
     expect(choices.realLength).to.equal(2);
-    expect(choices.getChoice(1)).to.be.instanceOf(Choice);
-    expect(choices.get(2)).to.be.instanceOf(inquirer.Separator);
+    expect(choices.getChoice(0))
+      .to.be.instanceOf(Choice)
+      .and.have.property('name', 'a');
+    expect(choices.getChoice(1))
+      .to.be.instanceOf(Choice)
+      .and.have.property('name', 'b');
+    expect(choices.get(1))
+      .to.be.instanceOf(Choice)
+      .and.have.property('disabled', true);
+    expect(choices.get(3)).to.be.instanceOf(inquirer.Separator);
   });
 });


### PR DESCRIPTION
This fixes a bug in the following scenario:
- a new Choices is initialised, with one of the items being `disabled: true`
- `choices.push('item')` is used
In this situation, the realChoices/realLength of the Choices becomes incorrect, as disabled items weren't being filtered out of the list in the `push` function, only in the `constructor`. 

I've also added the necessary changes to the existing test. 