### PR TITLE
Workaround node.js bug that closes main input and output stream.

### DIFF
--- a/packages/inquirer/lib/ui/baseUI.js
+++ b/packages/inquirer/lib/ui/baseUI.js
@@ -2,6 +2,7 @@
 var _ = require('lodash');
 var MuteStream = require('mute-stream');
 var readline = require('readline');
+var {PassThrough} = require('stream')
 
 /**
  * Base interface class other can inherits from
@@ -69,6 +70,14 @@ function setupReadlineOptions(opt) {
   var ms = new MuteStream();
   ms.pipe(opt.output || process.stdout);
   var output = ms;
+
+  if (/^win/i.test(process.platform)) {
+    // @see https://github.com/nodejs/node/issues/21771
+    // rl.close() closes main stream.
+    var oldInput = input;
+    input = new PassThrough();
+    oldInput.pipe(input);
+  }
 
   return _.extend(
     {

--- a/packages/inquirer/lib/ui/baseUI.js
+++ b/packages/inquirer/lib/ui/baseUI.js
@@ -2,7 +2,7 @@
 var _ = require('lodash');
 var MuteStream = require('mute-stream');
 var readline = require('readline');
-var {PassThrough} = require('stream')
+var { PassThrough } = require('stream');
 
 /**
  * Base interface class other can inherits from


### PR DESCRIPTION
Fixes https://github.com/SBoudrias/Inquirer.js/issues/767.