### PR TITLE
Handle questions as a plain object {[name]: question}

### DIFF
--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -32,7 +32,12 @@ class PromptUI extends Base {
 
     // Make sure questions is an array.
     if (_.isPlainObject(questions)) {
-      questions = [questions];
+      // It's either an object of questions or a single question
+      questions = Object.values(questions).every(
+        (v) => _.isPlainObject(v) && !_.has(v, 'name')
+      )
+        ? Object.entries(questions).map(([name, question]) => ({ name, ...question }))
+        : [questions];
     }
 
     // Create an observable, unless we received one as parameter.

--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -34,7 +34,7 @@ class PromptUI extends Base {
     if (_.isPlainObject(questions)) {
       // It's either an object of questions or a single question
       questions = Object.values(questions).every(
-        (v) => _.isPlainObject(v) && !_.has(v, 'name')
+        (v) => _.isPlainObject(v) && v.name === undefined
       )
         ? Object.entries(questions).map(([name, question]) => ({ name, ...question }))
         : [questions];

--- a/packages/inquirer/test/specs/inquirer.js
+++ b/packages/inquirer/test/specs/inquirer.js
@@ -99,6 +99,26 @@ describe('inquirer.prompt', function () {
     });
   });
 
+  it('should take a prompts nested object and return answers', async function () {
+    var prompts = {
+      q1: {
+        type: 'confirm',
+        message: 'message',
+      },
+      q2: {
+        type: 'input',
+        message: 'message',
+        default: 'Foo',
+      },
+    };
+
+    var promise = this.prompt(prompts);
+    autosubmit(promise.ui);
+    const { q1, q2 } = await promise;
+    expect(q1).to.equal(true);
+    expect(q2).to.equal('Foo');
+  });
+
   it('should take a prompts array with nested names', function () {
     var prompts = [
       {


### PR DESCRIPTION
I think it's worth to support a questions object, like this:
```js
const { foo, bar } = await inquirer.prompt({
  foo: {
    message: '...',
    default: '...',
  },
  bar: {
    default: '...',
  }
}):
```
it looks better imo, `{ foo, bar }` visually matches the corresponding keys in the question object

and object literals keys are ordered (as long as they're not numeric)

This PR detects such an object, safely normally, since a question should contain a `name` prop, there can't be a conflict with a single question object