### PR TITLE
Fixes tty error on custom input streams

### DIFF
--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -83,7 +83,10 @@ class PromptUI extends Base {
   fetchAnswer(question) {
     // Check if prompt is being called in TTY environment
     // If it isn't return a failed promise
-    if (!process.stdin.isTTY) {
+    const inputTTY = _.get(this, 'rl.input.isTTY');
+    const stdinTTY = process.stdin.isTTY;
+    const shouldTTYError = !inputTTY && !stdinTTY;
+    if (shouldTTYError) {
       const nonTtyError = new Error(
         'Prompts can not be meaningfully rendered in non-TTY environments'
       );

--- a/packages/inquirer/test/before.js
+++ b/packages/inquirer/test/before.js
@@ -4,7 +4,7 @@ var ReadlineStub = require('./helpers/readline');
 mockery.enable();
 mockery.warnOnUnregistered(false);
 mockery.registerMock('readline', {
-  createInterface: function() {
-    return new ReadlineStub();
+  createInterface: function(opts) {
+    return new ReadlineStub(opts);
   }
 });

--- a/packages/inquirer/test/helpers/readline.js
+++ b/packages/inquirer/test/helpers/readline.js
@@ -24,9 +24,10 @@ _.extend(stub, {
   }
 });
 
-var ReadlineStub = function() {
+var ReadlineStub = function(opts) {
+  opts = opts || {};
   this.line = '';
-  this.input = new EventEmitter();
+  this.input = opts.input || new EventEmitter();
   EventEmitter.apply(this, arguments);
 };
 


### PR DESCRIPTION
The implementation which introduces thrown errors when using non-tty environments didn't took into account the fact that a different input stream can be provided via config.

This changeset fixes it by introducing the appropriate checks and tests to ensure no further regressions.

/cc @SBoudrias @jhorbulyk 
ref: #891