### PR TITLE
Revert tty behavior for inquirer 7.x

### DIFF
--- a/packages/inquirer/lib/inquirer.js
+++ b/packages/inquirer/lib/inquirer.js
@@ -24,7 +24,12 @@ inquirer.ui = {
  */
 inquirer.createPromptModule = function(opt) {
   var promptModule = function(questions) {
-    var ui = new inquirer.ui.Prompt(promptModule.prompts, opt);
+    var ui;
+    try {
+      ui = new inquirer.ui.Prompt(promptModule.prompts, opt);
+    } catch (error) {
+      return Promise.reject(error);
+    }
     var promise = ui.run(questions);
 
     // Monkey patch the UI on the promise object so

--- a/packages/inquirer/lib/ui/baseUI.js
+++ b/packages/inquirer/lib/ui/baseUI.js
@@ -65,13 +65,16 @@ class UI {
 
 function setupReadlineOptions(opt) {
   opt = opt || {};
+  // Inquirer 8.x:
+  // opt.skipTTYChecks = opt.skipTTYChecks === undefined ? opt.input !== undefined : opt.skipTTYChecks;
+  opt.skipTTYChecks = opt.skipTTYChecks === undefined ? true : opt.skipTTYChecks;
 
   // Default `input` to stdin
   var input = opt.input || process.stdin;
 
   // Check if prompt is being called in TTY environment
   // If it isn't return a failed promise
-  if (!input.isTTY) {
+  if (!opt.skipTTYChecks && !input.isTTY) {
     const nonTtyError = new Error(
       'Prompts can not be meaningfully rendered in non-TTY environments'
     );

--- a/packages/inquirer/lib/ui/baseUI.js
+++ b/packages/inquirer/lib/ui/baseUI.js
@@ -69,6 +69,16 @@ function setupReadlineOptions(opt) {
   // Default `input` to stdin
   var input = opt.input || process.stdin;
 
+  // Check if prompt is being called in TTY environment
+  // If it isn't return a failed promise
+  if (!input.isTTY) {
+    const nonTtyError = new Error(
+      'Prompts can not be meaningfully rendered in non-TTY environments'
+    );
+    nonTtyError.isTtyError = true;
+    throw nonTtyError;
+  }
+
   // Add mute capabilities to the output
   var ms = new MuteStream();
   ms.pipe(opt.output || process.stdout);

--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -81,16 +81,6 @@ class PromptUI extends Base {
   }
 
   fetchAnswer(question) {
-    // Check if prompt is being called in TTY environment
-    // If it isn't return a failed promise
-    if (!process.stdin.isTTY) {
-      const nonTtyError = new Error(
-        'Prompts can not be meaningfully rendered in non-TTY environments'
-      );
-      nonTtyError.isTtyError = true;
-      return Promise.reject(nonTtyError);
-    }
-
     var Prompt = this.prompts[question.type];
     this.activePrompt = new Prompt(question, this.rl, this.answers);
     return defer(() =>

--- a/packages/inquirer/test/specs/inquirer.js
+++ b/packages/inquirer/test/specs/inquirer.js
@@ -6,6 +6,8 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var _ = require('lodash');
 var { Observable } = require('rxjs');
+var stream = require('stream');
+
 var inquirer = require('../../lib/inquirer');
 var autosubmit = require('../helpers/events').autosubmit;
 
@@ -687,7 +689,114 @@ describe('inquirer.prompt', function() {
     });
 
     it('Throw an exception when run in non-tty', function() {
+      var prompt = inquirer.createPromptModule({ skipTTYChecks: false });
+
+      var prompts = [
+        {
+          type: 'confirm',
+          name: 'q1',
+          message: 'message'
+        }
+      ];
+
+      var promise = prompt(prompts);
+
+      return promise
+        .then(() => {
+          // Failure
+          expect(true).to.equal(false);
+        })
+        .catch(error => {
+          expect(error.isTtyError).to.equal(true);
+        });
+    });
+
+    it("Don't throw an exception when run in non-tty by default", function(done) {
       var prompt = inquirer.createPromptModule();
+      var prompts = [
+        {
+          type: 'confirm',
+          name: 'q1',
+          message: 'message'
+        },
+        {
+          type: 'confirm',
+          name: 'q2',
+          message: 'message'
+        }
+      ];
+
+      var promise = prompt(prompts);
+      autosubmit(promise.ui);
+      promise
+        .then(() => {
+          done();
+        })
+        .catch(error => {
+          console.log(error);
+          expect(error.isTtyError).to.equal(false);
+        });
+    });
+
+    it("Don't throw an exception when run in non-tty and skipTTYChecks is true", function(done) {
+      var prompt = inquirer.createPromptModule({ skipTTYChecks: true });
+      var prompts = [
+        {
+          type: 'confirm',
+          name: 'q1',
+          message: 'message'
+        },
+        {
+          type: 'confirm',
+          name: 'q2',
+          message: 'message'
+        }
+      ];
+
+      var promise = prompt(prompts);
+      autosubmit(promise.ui);
+      promise
+        .then(() => {
+          done();
+        })
+        .catch(error => {
+          console.log(error);
+          expect(error.isTtyError).to.equal(false);
+        });
+    });
+
+    it("Don't throw an exception when run in non-tty and custom input is provided", function(done) {
+      var prompt = inquirer.createPromptModule({ input: new stream.Readable() });
+      var prompts = [
+        {
+          type: 'confirm',
+          name: 'q1',
+          message: 'message'
+        },
+        {
+          type: 'confirm',
+          name: 'q2',
+          message: 'message'
+        }
+      ];
+
+      var promise = prompt(prompts);
+      autosubmit(promise.ui);
+      promise
+        .then(() => {
+          done();
+        })
+        .catch(error => {
+          console.log(error);
+          expect(error.isTtyError).to.equal(false);
+        });
+    });
+
+    it('Throw an exception when run in non-tty and custom input is provided with skipTTYChecks: false', function() {
+      var prompt = inquirer.createPromptModule({
+        input: new stream.Readable(),
+        skipTTYChecks: false
+      });
 
       var prompts = [
         {

--- a/packages/inquirer/test/specs/inquirer.js
+++ b/packages/inquirer/test/specs/inquirer.js
@@ -708,24 +708,5 @@ describe('inquirer.prompt', function() {
           expect(error.isTtyError).to.equal(true);
         });
     });
-
-    it('No exception when when flags non-tty', function() {
-      var prompt = inquirer.createPromptModule();
-
-      var prompts = [
-        {
-          name: 'name',
-          message: 'give a name to your app',
-          default: 'foo',
-          when: () => false
-        }
-      ];
-
-      var promise = prompt(prompts);
-
-      return promise.then(answers => {
-        expect(answers).to.deep.equal({});
-      });
-    });
   });
 });


### PR DESCRIPTION
- Move tty check to setupReadlineOptions
- Add skipTTYChecks
- Enable skipTTYChecks by default for 7.x behavior stability.

Fixes https://github.com/SBoudrias/Inquirer.js/issues/902.