### PR TITLE
Fix @inquirer/confirm formatted output value

### DIFF
--- a/packages/confirm/index.js
+++ b/packages/confirm/index.js
@@ -22,7 +22,7 @@ module.exports = createPrompt((config, done) => {
   let formattedValue = value;
   let defaultValue = '';
   if (status === 'done') {
-    formattedValue = chalk.cyan(value ? 'yes' : 'no');
+    formattedValue = chalk.cyan(value);
   } else {
     defaultValue = chalk.dim(config.default === false ? ' (y/N)' : ' (Y/n)');
   }


### PR DESCRIPTION
The `@inquirer/confirm` value is formatted twice, on keypress and once done for display:

https://github.com/SBoudrias/Inquirer.js/blob/32ee96f8ffa96198734c46faf86340bc36878914/packages/confirm/index.js#L13-L14

https://github.com/SBoudrias/Inquirer.js/blob/32ee96f8ffa96198734c46faf86340bc36878914/packages/confirm/index.js#L24-L25

This means the final formatted value is always `yes`, even if the entered value is `no`:

![Issue demo](https://user-images.githubusercontent.com/874370/80862857-80050c00-8c78-11ea-9120-37d1a2dd2f4c.gif)

(callback value is correct, as it is not called with the formatted value.)

---

This PR removes the second formatting, thus fixing the issue:

![Solution demo](https://user-images.githubusercontent.com/874370/80862989-6adcad00-8c79-11ea-91ed-1294e1a21d9b.gif)
