### PR TITLE
Only mport used lodash methods

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,4 +1,6 @@
-const _ = require('lodash');
+const _ = {
+  isFunction: require('lodash/isFunction')
+};
 const readline = require('readline');
 const chalk = require('chalk');
 const MuteStream = require('mute-stream');

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,5 +1,6 @@
 const _ = {
-  isFunction: require('lodash/isFunction')
+  isFunction: require('lodash/isFunction'),
+  noop: require('lodash/noop')
 };
 const readline = require('readline');
 const chalk = require('chalk');

--- a/packages/core/lib/Paginator.js
+++ b/packages/core/lib/Paginator.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const _ = require('lodash');
+const _ = {
+  flatten: require('lodash/flatten')
+};
 const chalk = require('chalk');
 const cliWidth = require('cli-width');
 const { breakLines } = require('./utils');

--- a/packages/core/lib/screen-manager.js
+++ b/packages/core/lib/screen-manager.js
@@ -1,4 +1,6 @@
-const _ = require('lodash');
+const _ = {
+  last: require('lodash/last')
+};
 const cliWidth = require('cli-width');
 const stripAnsi = require('strip-ansi');
 const stringWidth = require('string-width');

--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -1,4 +1,6 @@
-const _ = require('lodash');
+const _ = {
+  flatten: require('lodash/flatten')
+};
 
 /**
  * Force line returns at specific width. This function is ANSI code friendly and it'll

--- a/packages/inquirer/lib/objects/choice.js
+++ b/packages/inquirer/lib/objects/choice.js
@@ -1,5 +1,10 @@
 'use strict';
-var _ = require('lodash');
+var _ = {
+  isString: require('lodash/isString'),
+  isNumber: require('lodash/isNumber'),
+  extend: require('lodash/extend'),
+  isFunction: require('lodash/isFunction')
+};
 
 /**
  * Choice object

--- a/packages/inquirer/lib/objects/choices.js
+++ b/packages/inquirer/lib/objects/choices.js
@@ -1,6 +1,11 @@
 'use strict';
 var assert = require('assert');
-var _ = require('lodash');
+var _ = {
+  isNumber: require('lodash/isNumber'),
+  filter: require('lodash/filter'),
+  map: require('lodash/map'),
+  find: require('lodash/find')
+};
 var Separator = require('./separator');
 var Choice = require('./choice');
 

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -3,8 +3,11 @@
  * Base prompt implementation
  * Should be extended by prompt types.
  */
-
-var _ = require('lodash');
+var _ = {
+  assign: require('lodash/assign'),
+  defaults: require('lodash/defaults'),
+  clone: require('lodash/clone')
+};
 var chalk = require('chalk');
 var runAsync = require('run-async');
 var { filter, flatMap, share, take, takeUntil } = require('rxjs/operators');

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -3,7 +3,11 @@
  * `list` type prompt
  */
 
-var _ = require('lodash');
+var _ = {
+  isArray: require('lodash/isArray'),
+  map: require('lodash/map'),
+  isString: require('lodash/isString')
+};
 var chalk = require('chalk');
 var cliCursor = require('cli-cursor');
 var figures = require('figures');

--- a/packages/inquirer/lib/prompts/confirm.js
+++ b/packages/inquirer/lib/prompts/confirm.js
@@ -3,7 +3,10 @@
  * `confirm` type prompt
  */
 
-var _ = require('lodash');
+var _ = {
+  extend: require('lodash/extend'),
+  isBoolean: require('lodash/isBoolean')
+};
 var chalk = require('chalk');
 var { take, takeUntil } = require('rxjs/operators');
 var Base = require('./base');

--- a/packages/inquirer/lib/prompts/expand.js
+++ b/packages/inquirer/lib/prompts/expand.js
@@ -3,7 +3,12 @@
  * `rawlist` type prompt
  */
 
-var _ = require('lodash');
+var _ = {
+  uniq: require('lodash/uniq'),
+  isString: require('lodash/isString'),
+  isNumber: require('lodash/isNumber'),
+  findIndex: require('lodash/findIndex')
+};
 var chalk = require('chalk');
 var { map, takeUntil } = require('rxjs/operators');
 var Base = require('./base');

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -3,7 +3,11 @@
  * `list` type prompt
  */
 
-var _ = require('lodash');
+var _ = {
+  isNumber: require('lodash/isNumber'),
+  findIndex: require('lodash/findIndex'),
+  isString: require('lodash/isString')
+};
 var chalk = require('chalk');
 var figures = require('figures');
 var cliCursor = require('cli-cursor');

--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -3,7 +3,11 @@
  * `rawlist` type prompt
  */
 
-var _ = require('lodash');
+var _ = {
+  extend: require('lodash/extend'),
+  isNumber: require('lodash/isNumber'),
+  findIndex: require('lodash/findIndex')
+};
 var chalk = require('chalk');
 var { map, takeUntil } = require('rxjs/operators');
 var Base = require('./base');

--- a/packages/inquirer/lib/ui/baseUI.js
+++ b/packages/inquirer/lib/ui/baseUI.js
@@ -1,5 +1,8 @@
 'use strict';
-var _ = require('lodash');
+var _ = {
+  extend: require('lodash/extend'),
+  omit: require('lodash/omit')
+};
 var MuteStream = require('mute-stream');
 var readline = require('readline');
 

--- a/packages/inquirer/lib/ui/bottom-bar.js
+++ b/packages/inquirer/lib/ui/bottom-bar.js
@@ -6,7 +6,9 @@
 var through = require('through');
 var Base = require('./baseUI');
 var rlUtils = require('../utils/readline');
-var _ = require('lodash');
+var _ = {
+  last: require('lodash/last')
+};
 
 class BottomBar extends Base {
   constructor(opt) {

--- a/packages/inquirer/lib/ui/prompt.js
+++ b/packages/inquirer/lib/ui/prompt.js
@@ -1,5 +1,11 @@
 'use strict';
-var _ = require('lodash');
+var _ = {
+  isPlainObject: require('lodash/isPlainObject'),
+  clone: require('lodash/clone'),
+  isArray: require('lodash/isArray'),
+  set: require('lodash/set'),
+  isFunction: require('lodash/isFunction')
+};
 var { defer, empty, from, of } = require('rxjs');
 var { concatMap, filter, publish, reduce } = require('rxjs/operators');
 var runAsync = require('run-async');

--- a/packages/inquirer/lib/utils/paginator.js
+++ b/packages/inquirer/lib/utils/paginator.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var _ = require('lodash');
+var _ = {
+  sum: require('lodash/sum'),
+  flatten: require('lodash/flatten')
+};
 var chalk = require('chalk');
 
 /**

--- a/packages/inquirer/lib/utils/screen-manager.js
+++ b/packages/inquirer/lib/utils/screen-manager.js
@@ -1,5 +1,8 @@
 'use strict';
-var _ = require('lodash');
+var _ = {
+  last: require('lodash/last'),
+  flatten: require('lodash/flatten')
+};
 var util = require('./readline');
 var cliWidth = require('cli-width');
 var stripAnsi = require('strip-ansi');

--- a/packages/inquirer/lib/utils/utils.js
+++ b/packages/inquirer/lib/utils/utils.js
@@ -1,5 +1,7 @@
 'use strict';
-var _ = require('lodash');
+var _ = {
+  isFunction: require('lodash/isFunction')
+};
 var { from, of } = require('rxjs');
 var runAsync = require('run-async');
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

- Inquirer is currently loading lodash through the main entrypoint which makes it impossible for webpack to treeshake the unused code.
- Yarn is using Inquirer in its cli and, because of this, is shipping a lot of unnecessary code that we don't need in our bundle.

Compared to the other PRs that attempted to tackle this in the past (https://github.com/SBoudrias/Inquirer.js/pulls?q=is%3Apr+is%3Aclosed+lodash+module) this PR doesn't use the per method packages (they're deprecated and didn't help; https://lodash.com/per-method-packages) but instead requires the used methods directly. This will get rid of unused code and potentially help startup times as there is less code to process.

I made the diff as small as possible which is why I construct a `_` object with the used methods. If the project switches to es2015 imports then this can be removed in favour of using https://github.com/lodash/babel-plugin-lodash

**How did you fix it?**

Imported only the used lodash methods