### PR TITLE
fix multiline in list and checkbox

### DIFF
--- a/packages/inquirer/examples/long-list.js
+++ b/packages/inquirer/examples/long-list.js
@@ -17,7 +17,7 @@ choices.push({
   name:
     'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.',
   value: 'foo',
-  short: 'The long option',
+  short: 'The long option'
 });
 
 inquirer
@@ -26,15 +26,15 @@ inquirer
       type: 'list',
       name: 'letter',
       message: "What's your favorite letter?",
-      choices: choices,
+      choices: choices
     },
     {
       type: 'checkbox',
       name: 'name',
       message: 'Select the letter contained in your name:',
-      choices: choices,
-    },
+      choices: choices
+    }
   ])
-  .then((answers) => {
+  .then(answers => {
     console.log(JSON.stringify(answers, null, '  '));
   });

--- a/packages/inquirer/examples/long-list.js
+++ b/packages/inquirer/examples/long-list.js
@@ -6,12 +6,18 @@
 var inquirer = require('..');
 
 var choices = Array.apply(0, new Array(26)).map((x, y) => String.fromCharCode(y + 65));
+choices.push('Multiline option 1\n  super cool feature \n  more lines');
+choices.push('Multiline option 2\n  super cool feature \n  more lines');
+choices.push('Multiline option 3\n  super cool feature \n  more lines');
+choices.push('Multiline option 4\n  super cool feature \n  more lines');
+choices.push('Multiline option 5\n  super cool feature \n  more lines');
+choices.push(new inquirer.Separator());
 choices.push('Multiline option \n  super cool feature');
 choices.push({
   name:
     'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.',
   value: 'foo',
-  short: 'The long option'
+  short: 'The long option',
 });
 
 inquirer
@@ -20,15 +26,15 @@ inquirer
       type: 'list',
       name: 'letter',
       message: "What's your favorite letter?",
-      choices: choices
+      choices: choices,
     },
     {
       type: 'checkbox',
       name: 'name',
       message: 'Select the letter contained in your name:',
-      choices: choices
-    }
+      choices: choices,
+    },
   ])
-  .then(answers => {
+  .then((answers) => {
     console.log(JSON.stringify(answers, null, '  '));
   });

--- a/packages/inquirer/lib/objects/choices.js
+++ b/packages/inquirer/lib/objects/choices.js
@@ -4,7 +4,7 @@ var _ = {
   isNumber: require('lodash/isNumber'),
   filter: require('lodash/filter'),
   map: require('lodash/map'),
-  find: require('lodash/find')
+  find: require('lodash/find'),
 };
 var Separator = require('./separator');
 var Choice = require('./choice');
@@ -18,7 +18,7 @@ var Choice = require('./choice');
 
 module.exports = class Choices {
   constructor(choices, answers) {
-    this.choices = choices.map(val => {
+    this.choices = choices.map((val) => {
       if (val.type === 'separator') {
         if (!(val instanceof Separator)) {
           val = new Separator(val.line);
@@ -32,7 +32,7 @@ module.exports = class Choices {
 
     this.realChoices = this.choices
       .filter(Separator.exclude)
-      .filter(item => !item.disabled);
+      .filter((item) => !item.disabled);
 
     Object.defineProperty(this, 'length', {
       get() {
@@ -40,7 +40,7 @@ module.exports = class Choices {
       },
       set(val) {
         this.choices.length = val;
-      }
+      },
     });
 
     Object.defineProperty(this, 'realLength', {
@@ -49,7 +49,7 @@ module.exports = class Choices {
       },
       set() {
         throw new Error('Cannot set `realLength` of a Choices collection');
-      }
+      },
     });
   }
 
@@ -108,16 +108,20 @@ module.exports = class Choices {
     return this.choices.filter.apply(this.choices, arguments);
   }
 
+  reduce() {
+    return this.choices.reduce.apply(this.choices, arguments);
+  }
+
   find(func) {
     return _.find(this.choices, func);
   }
 
   push() {
-    var objs = _.map(arguments, val => new Choice(val));
+    var objs = _.map(arguments, (val) => new Choice(val));
     this.choices.push.apply(this.choices, objs);
     this.realChoices = this.choices
       .filter(Separator.exclude)
-      .filter(item => !item.disabled);
+      .filter((item) => !item.disabled);
     return this.choices;
   }
 };

--- a/packages/inquirer/lib/objects/choices.js
+++ b/packages/inquirer/lib/objects/choices.js
@@ -4,7 +4,7 @@ var _ = {
   isNumber: require('lodash/isNumber'),
   filter: require('lodash/filter'),
   map: require('lodash/map'),
-  find: require('lodash/find'),
+  find: require('lodash/find')
 };
 var Separator = require('./separator');
 var Choice = require('./choice');
@@ -18,7 +18,7 @@ var Choice = require('./choice');
 
 module.exports = class Choices {
   constructor(choices, answers) {
-    this.choices = choices.map((val) => {
+    this.choices = choices.map(val => {
       if (val.type === 'separator') {
         if (!(val instanceof Separator)) {
           val = new Separator(val.line);
@@ -32,7 +32,7 @@ module.exports = class Choices {
 
     this.realChoices = this.choices
       .filter(Separator.exclude)
-      .filter((item) => !item.disabled);
+      .filter(item => !item.disabled);
 
     Object.defineProperty(this, 'length', {
       get() {
@@ -40,7 +40,7 @@ module.exports = class Choices {
       },
       set(val) {
         this.choices.length = val;
-      },
+      }
     });
 
     Object.defineProperty(this, 'realLength', {
@@ -49,7 +49,7 @@ module.exports = class Choices {
       },
       set() {
         throw new Error('Cannot set `realLength` of a Choices collection');
-      },
+      }
     });
   }
 
@@ -117,11 +117,11 @@ module.exports = class Choices {
   }
 
   push() {
-    var objs = _.map(arguments, (val) => new Choice(val));
+    var objs = _.map(arguments, val => new Choice(val));
     this.choices.push.apply(this.choices, objs);
     this.realChoices = this.choices
       .filter(Separator.exclude)
-      .filter((item) => !item.disabled);
+      .filter(item => !item.disabled);
     return this.choices;
   }
 };

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -6,7 +6,7 @@
 var _ = {
   isArray: require('lodash/isArray'),
   map: require('lodash/map'),
-  isString: require('lodash/isString')
+  isString: require('lodash/isString'),
 };
 var chalk = require('chalk');
 var cliCursor = require('cli-cursor');
@@ -25,7 +25,7 @@ class CheckboxPrompt extends Base {
     }
 
     if (_.isArray(this.opt.default)) {
-      this.opt.choices.forEach(function(choice) {
+      this.opt.choices.forEach(function (choice) {
         if (this.opt.default.indexOf(choice.value) >= 0) {
           choice.checked = true;
         }
@@ -109,8 +109,20 @@ class CheckboxPrompt extends Base {
       var indexPosition = this.opt.choices.indexOf(
         this.opt.choices.getChoice(this.pointer)
       );
+      var realIndexPosition =
+        this.opt.choices.reduce(function (acc, value, i) {
+          if (i > indexPosition) {
+            return acc;
+          }
+          if (value.type === 'separator') {
+            return acc + 1;
+          }
+          var l = value.name;
+          l = l.split('\n');
+          return acc + l.length;
+        }, 0) - 1;
       message +=
-        '\n' + this.paginator.paginate(choicesStr, indexPosition, this.opt.pageSize);
+        '\n' + this.paginator.paginate(choicesStr, realIndexPosition, this.opt.pageSize);
     }
 
     if (error) {
@@ -140,7 +152,7 @@ class CheckboxPrompt extends Base {
   }
 
   getCurrentValue() {
-    var choices = this.opt.choices.filter(function(choice) {
+    var choices = this.opt.choices.filter(function (choice) {
       return Boolean(choice.checked) && !choice.disabled;
     });
 
@@ -177,12 +189,12 @@ class CheckboxPrompt extends Base {
 
   onAllKey() {
     var shouldBeChecked = Boolean(
-      this.opt.choices.find(function(choice) {
+      this.opt.choices.find(function (choice) {
         return choice.type !== 'separator' && !choice.checked;
       })
     );
 
-    this.opt.choices.forEach(function(choice) {
+    this.opt.choices.forEach(function (choice) {
       if (choice.type !== 'separator') {
         choice.checked = shouldBeChecked;
       }
@@ -192,7 +204,7 @@ class CheckboxPrompt extends Base {
   }
 
   onInverseKey() {
-    this.opt.choices.forEach(function(choice) {
+    this.opt.choices.forEach(function (choice) {
       if (choice.type !== 'separator') {
         choice.checked = !choice.checked;
       }
@@ -219,7 +231,7 @@ function renderChoices(choices, pointer) {
   var output = '';
   var separatorOffset = 0;
 
-  choices.forEach(function(choice, i) {
+  choices.forEach(function (choice, i) {
     if (choice.type === 'separator') {
       separatorOffset++;
       output += ' ' + choice + '\n';

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -6,7 +6,7 @@
 var _ = {
   isArray: require('lodash/isArray'),
   map: require('lodash/map'),
-  isString: require('lodash/isString'),
+  isString: require('lodash/isString')
 };
 var chalk = require('chalk');
 var cliCursor = require('cli-cursor');
@@ -25,7 +25,7 @@ class CheckboxPrompt extends Base {
     }
 
     if (_.isArray(this.opt.default)) {
-      this.opt.choices.forEach(function (choice) {
+      this.opt.choices.forEach(function(choice) {
         if (this.opt.default.indexOf(choice.value) >= 0) {
           choice.checked = true;
         }
@@ -110,14 +110,23 @@ class CheckboxPrompt extends Base {
         this.opt.choices.getChoice(this.pointer)
       );
       var realIndexPosition =
-        this.opt.choices.reduce(function (acc, value, i) {
+        this.opt.choices.reduce(function(acc, value, i) {
+          // Dont count lines past the choice we are looking at
           if (i > indexPosition) {
             return acc;
           }
+          // Add line if it's a separator
           if (value.type === 'separator') {
             return acc + 1;
           }
+
           var l = value.name;
+          // Non-strings take up one line
+          if (typeof l !== 'string') {
+            return acc + 1;
+          }
+
+          // Calculate lines taken up by string
           l = l.split('\n');
           return acc + l.length;
         }, 0) - 1;
@@ -152,7 +161,7 @@ class CheckboxPrompt extends Base {
   }
 
   getCurrentValue() {
-    var choices = this.opt.choices.filter(function (choice) {
+    var choices = this.opt.choices.filter(function(choice) {
       return Boolean(choice.checked) && !choice.disabled;
     });
 
@@ -189,12 +198,12 @@ class CheckboxPrompt extends Base {
 
   onAllKey() {
     var shouldBeChecked = Boolean(
-      this.opt.choices.find(function (choice) {
+      this.opt.choices.find(function(choice) {
         return choice.type !== 'separator' && !choice.checked;
       })
     );
 
-    this.opt.choices.forEach(function (choice) {
+    this.opt.choices.forEach(function(choice) {
       if (choice.type !== 'separator') {
         choice.checked = shouldBeChecked;
       }
@@ -204,7 +213,7 @@ class CheckboxPrompt extends Base {
   }
 
   onInverseKey() {
-    this.opt.choices.forEach(function (choice) {
+    this.opt.choices.forEach(function(choice) {
       if (choice.type !== 'separator') {
         choice.checked = !choice.checked;
       }
@@ -231,7 +240,7 @@ function renderChoices(choices, pointer) {
   var output = '';
   var separatorOffset = 0;
 
-  choices.forEach(function (choice, i) {
+  choices.forEach(function(choice, i) {
     if (choice.type === 'separator') {
       separatorOffset++;
       output += ' ' + choice + '\n';

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -6,7 +6,7 @@
 var _ = {
   isNumber: require('lodash/isNumber'),
   findIndex: require('lodash/findIndex'),
-  isString: require('lodash/isString')
+  isString: require('lodash/isString'),
 };
 var chalk = require('chalk');
 var figures = require('figures');
@@ -65,7 +65,7 @@ class ListPrompt extends Base {
       .pipe(
         take(1),
         map(this.getCurrentValue.bind(this)),
-        flatMap(value => runAsync(self.opt.filter)(value).catch(err => err))
+        flatMap((value) => runAsync(self.opt.filter)(value).catch((err) => err))
       )
       .forEach(this.onSubmit.bind(this));
 
@@ -97,8 +97,20 @@ class ListPrompt extends Base {
       var indexPosition = this.opt.choices.indexOf(
         this.opt.choices.getChoice(this.selected)
       );
+      var realIndexPosition =
+        this.opt.choices.reduce(function (acc, value, i) {
+          if (i > indexPosition) {
+            return acc;
+          }
+          if (value.type === 'separator') {
+            return acc + 1;
+          }
+          var l = value.name;
+          l = l.split('\n');
+          return acc + l.length;
+        }, 0) - 1;
       message +=
-        '\n' + this.paginator.paginate(choicesStr, indexPosition, this.opt.pageSize);
+        '\n' + this.paginator.paginate(choicesStr, realIndexPosition, this.opt.pageSize);
     }
 
     this.firstRender = false;

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -6,7 +6,7 @@
 var _ = {
   isNumber: require('lodash/isNumber'),
   findIndex: require('lodash/findIndex'),
-  isString: require('lodash/isString'),
+  isString: require('lodash/isString')
 };
 var chalk = require('chalk');
 var figures = require('figures');
@@ -65,7 +65,7 @@ class ListPrompt extends Base {
       .pipe(
         take(1),
         map(this.getCurrentValue.bind(this)),
-        flatMap((value) => runAsync(self.opt.filter)(value).catch((err) => err))
+        flatMap(value => runAsync(self.opt.filter)(value).catch(err => err))
       )
       .forEach(this.onSubmit.bind(this));
 
@@ -98,14 +98,23 @@ class ListPrompt extends Base {
         this.opt.choices.getChoice(this.selected)
       );
       var realIndexPosition =
-        this.opt.choices.reduce(function (acc, value, i) {
+        this.opt.choices.reduce(function(acc, value, i) {
+          // Dont count lines past the choice we are looking at
           if (i > indexPosition) {
             return acc;
           }
+          // Add line if it's a separator
           if (value.type === 'separator') {
             return acc + 1;
           }
+
           var l = value.name;
+          // Non-strings take up one line
+          if (typeof l !== 'string') {
+            return acc + 1;
+          }
+
+          // Calculate lines taken up by string
           l = l.split('\n');
           return acc + l.length;
         }, 0) - 1;

--- a/packages/inquirer/test/specs/prompts/checkbox.js
+++ b/packages/inquirer/test/specs/prompts/checkbox.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 var _ = require('lodash');
 var ReadlineStub = require('../../helpers/readline');
 var fixtures = require('../../helpers/fixtures');
+var sinon = require('sinon');
 
 var Checkbox = require('../../../lib/prompts/checkbox');
 
@@ -183,6 +184,30 @@ describe('`checkbox` prompt', function() {
     return promise.then(answer => {
       expect(answer.length).to.equal(3);
     });
+  });
+
+  it('pagination works with multiline choices', function(done) {
+    var multilineFixture = {
+      message: 'message',
+      name: 'name',
+      choices: ['a\n\n', 'b\n\n']
+    };
+    var list = new Checkbox(multilineFixture, this.rl);
+    const spy = sinon.spy(list.paginator, 'paginate');
+    list.run().then(answer => {
+      const realIndexPosition1 = spy.firstCall.args[1];
+      const realIndexPosition2 = spy.secondCall.args[1];
+
+      // 'a\n\n': 0th index, but pagination at 2nd index position due to 2 extra newlines
+      expect(realIndexPosition1).to.equal(2);
+      // 'b\n\n': 1st index, but pagination at 5th index position due to 4 extra newlines
+      expect(realIndexPosition2).to.equal(5);
+      expect(answer[0]).to.equal('b\n\n');
+      done();
+    });
+    this.rl.input.emit('keypress', '', { name: 'down' });
+    this.rl.input.emit('keypress', ' ', { name: 'space' });
+    this.rl.emit('line');
   });
 
   describe('with disabled choices', function() {


### PR DESCRIPTION
# what
here is a gif scrolling through a list with 200 multiline options - notice there are no cursors and it skips a huge chunk of choices.

![ezgif-6-95afd84c78d2](https://user-images.githubusercontent.com/6380927/83701709-67617c00-a5bf-11ea-9733-6741bd19cbe4.gif)

Fixes https://github.com/SBoudrias/Inquirer.js/issues/494

# how
- rebased @Ntag branch - https://github.com/NTag/Inquirer.js/commit/bc88006157a5723b34ed123e24681b138eab9f49
- added support for non-strings
- added comments for reader

# testing

- [x] long-list example works
- [x] new tests pass

