### PR TITLE
fix: paginator works with loop:false

### DIFF
--- a/packages/inquirer/examples/long-list.js
+++ b/packages/inquirer/examples/long-list.js
@@ -24,6 +24,7 @@ inquirer
   .prompt([
     {
       type: 'list',
+      loop: false,
       name: 'letter',
       message: "What's your favorite letter?",
       choices: choices,

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -42,7 +42,8 @@ class ListPrompt extends Base {
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
 
-    this.paginator = new Paginator(this.screen);
+    var shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
+    this.paginator = new Paginator(this.screen, shouldLoop);
   }
 
   /**

--- a/packages/inquirer/lib/prompts/list.js
+++ b/packages/inquirer/lib/prompts/list.js
@@ -42,8 +42,8 @@ class ListPrompt extends Base {
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
 
-    var shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
-    this.paginator = new Paginator(this.screen, shouldLoop);
+    const shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
+    this.paginator = new Paginator(this.screen, { isInfinite: shouldLoop });
   }
 
   /**

--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -49,7 +49,8 @@ class RawListPrompt extends Base {
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
 
-    this.paginator = new Paginator();
+    var shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
+    this.paginator = new Paginator(undefined, shouldLoop);
   }
 
   /**

--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -49,8 +49,8 @@ class RawListPrompt extends Base {
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
 
-    var shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
-    this.paginator = new Paginator(undefined, shouldLoop);
+    const shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
+    this.paginator = new Paginator(undefined, { isInfinite: shouldLoop });
   }
 
   /**

--- a/packages/inquirer/lib/utils/paginator.js
+++ b/packages/inquirer/lib/utils/paginator.js
@@ -11,10 +11,11 @@ var chalk = require('chalk');
  */
 
 class Paginator {
-  constructor(screen, isInfinite) {
+  constructor(screen, options = {}) {
+    const { isInfinite = true } = options;
     this.lastIndex = 0;
     this.screen = screen;
-    this.isInfinite = isInfinite === undefined ? true : isInfinite;
+    this.isInfinite = isInfinite;
   }
 
   paginate(output, active, pageSize) {
@@ -31,8 +32,9 @@ class Paginator {
     if (lines.length <= pageSize) {
       return output;
     }
-    var getLinesFn = this.isInfinite ? this.getInfiniteLines : this.getFiniteLines;
-    var visibleLines = getLinesFn.call(this, lines, active, pageSize);
+    const visibleLines = this.isInfinite
+      ? this.getInfiniteLines(lines, active, pageSize)
+      : this.getFiniteLines(lines, active, pageSize);
     this.lastIndex = active;
     return (
       visibleLines.join('\n') +

--- a/packages/inquirer/lib/utils/paginator.js
+++ b/packages/inquirer/lib/utils/paginator.js
@@ -7,20 +7,18 @@ var _ = {
 var chalk = require('chalk');
 
 /**
- * The paginator keeps track of a pointer index in a list and returns
- * a subset of the choices if the list is too long.
+ * The paginator returns a subset of the choices if the list is too long.
  */
 
 class Paginator {
-  constructor(screen) {
-    this.pointer = 0;
+  constructor(screen, isInfinite) {
     this.lastIndex = 0;
     this.screen = screen;
+    this.isInfinite = isInfinite === undefined ? true : isInfinite;
   }
 
   paginate(output, active, pageSize) {
     pageSize = pageSize || 7;
-    var middleOfList = Math.floor(pageSize / 2);
     var lines = output.split('\n');
 
     if (this.screen) {
@@ -33,7 +31,21 @@ class Paginator {
     if (lines.length <= pageSize) {
       return output;
     }
+    var getLinesFn = this.isInfinite ? this.getInfiniteLines : this.getFiniteLines;
+    var visibleLines = getLinesFn.call(this, lines, active, pageSize);
+    this.lastIndex = active;
+    return (
+      visibleLines.join('\n') +
+      '\n' +
+      chalk.dim('(Move up and down to reveal more choices)')
+    );
+  }
 
+  getInfiniteLines(lines, active, pageSize) {
+    if (this.pointer === undefined) {
+      this.pointer = 0;
+    }
+    var middleOfList = Math.floor(pageSize / 2);
     // Move the pointer only when the user go down and limit it to the middle of the list
     if (
       this.pointer < middleOfList &&
@@ -43,14 +55,21 @@ class Paginator {
       this.pointer = Math.min(middleOfList, this.pointer + active - this.lastIndex);
     }
 
-    this.lastIndex = active;
-
     // Duplicate the lines so it give an infinite list look
     var infinite = _.flatten([lines, lines, lines]);
     var topIndex = Math.max(0, active + lines.length - this.pointer);
 
-    var section = infinite.splice(topIndex, pageSize).join('\n');
-    return section + '\n' + chalk.dim('(Move up and down to reveal more choices)');
+    return infinite.splice(topIndex, pageSize);
+  }
+
+  getFiniteLines(lines, active, pageSize) {
+    var topIndex = active - pageSize / 2;
+    if (topIndex < 0) {
+      topIndex = 0;
+    } else if (topIndex + pageSize > lines.length) {
+      topIndex = lines.length - pageSize;
+    }
+    return lines.splice(topIndex, pageSize);
   }
 }
 

--- a/packages/inquirer/test/specs/prompts/list.js
+++ b/packages/inquirer/test/specs/prompts/list.js
@@ -223,4 +223,16 @@ describe('`list` prompt', function () {
     this.rl.input.emit('keypress', '', { name: 'down' });
     this.rl.emit('line');
   });
+
+  it('paginator uses non infinite version with loop:false', function () {
+    var list = new List(
+      {
+        name: 'numbers',
+        choices: [1, 2, 3],
+        loop: false,
+      },
+      this.rl
+    );
+    expect(list.paginator.isInfinite).equal(false);
+  });
 });

--- a/packages/inquirer/test/specs/utils/paginator.js
+++ b/packages/inquirer/test/specs/utils/paginator.js
@@ -79,7 +79,7 @@ b`);
   });
   describe('non infinite mode', function () {
     beforeEach(function () {
-      this.paginator = new Paginator(undefined, false);
+      this.paginator = new Paginator(undefined, { isInfinite: false });
     });
     it('shows start for as long as possible', function () {
       expect(getPage(this.paginator, 0)).equal(`\

--- a/packages/inquirer/test/specs/utils/paginator.js
+++ b/packages/inquirer/test/specs/utils/paginator.js
@@ -1,0 +1,128 @@
+const expect = require('chai').expect;
+const ReadlineStub = require('../../helpers/readline');
+const Paginator = require('../../../lib/utils/paginator');
+
+const output = `\
+a
+b
+c
+d
+e
+f
+g
+h
+i
+j
+k
+l
+m
+n
+o
+p
+q
+r
+s
+t
+u
+v
+w
+x
+y
+z`;
+const pageSize = 3;
+const endIndex = output.split('\n').length - 1;
+const getPage = (paginator, index) => {
+  const lines = paginator.paginate(output, index, pageSize).split('\n');
+  const lastLine = lines.pop();
+  if (!lastLine.match(/Move up and down/)) {
+    lines.push(lastLine);
+  }
+  return lines.join('\n');
+};
+
+describe('paginator', function () {
+  beforeEach(function () {
+    this.rl = new ReadlineStub();
+    this.paginator = new Paginator();
+  });
+
+  it('does nothing if output is smaller than page size', function () {
+    expect(this.paginator.paginate(output, 0, endIndex + 1)).equal(output);
+  });
+
+  it('paginate returns slice of lines', function () {
+    expect(getPage(this.paginator, 0)).equal(`\
+a
+b
+c`);
+  });
+  it('slice has offset after later pages are rendered', function () {
+    expect(getPage(this.paginator, 0)).equal(`\
+a
+b
+c`);
+    expect(getPage(this.paginator, 1)).equal(`\
+a
+b
+c`);
+    expect(getPage(this.paginator, 2)).equal(`\
+b
+c
+d`);
+  });
+  it('slice offset does not reset', function () {
+    expect(getPage(this.paginator, 2));
+    expect(getPage(this.paginator, 0)).equal(`\
+z
+a
+b`);
+  });
+  describe('non infinite mode', function () {
+    beforeEach(function () {
+      this.paginator = new Paginator(undefined, false);
+    });
+    it('shows start for as long as possible', function () {
+      expect(getPage(this.paginator, 0)).equal(`\
+a
+b
+c`);
+      expect(getPage(this.paginator, 1)).equal(`\
+a
+b
+c`);
+      expect(getPage(this.paginator, 2)).equal(`\
+a
+b
+c`);
+      expect(getPage(this.paginator, 3)).equal(`\
+b
+c
+d`);
+    });
+    it('slice offset does reset', function () {
+      getPage(this.paginator, 3);
+      expect(getPage(this.paginator, 0)).equal(`\
+a
+b
+c`);
+    });
+    it('aligns end to bottom', function () {
+      expect(getPage(this.paginator, endIndex - 3)).equal(`\
+u
+v
+w`);
+      expect(getPage(this.paginator, endIndex - 2)).equal(`\
+v
+w
+x`);
+      expect(getPage(this.paginator, endIndex - 1)).equal(`\
+w
+x
+y`);
+      expect(getPage(this.paginator, endIndex)).equal(`\
+x
+y
+z`);
+    });
+  });
+});


### PR DESCRIPTION
Follow up to https://github.com/SBoudrias/Inquirer.js/pull/925

I'm not sure if I should have changed the Paginator in packages/core. It seems like a copy, and it seems like this repo is moving toward a monorepo style, but I think the one in inquirer/utils that I've changed will fix the actual problem so I'll leave it to the maintainers to copy these changes in, unless you want me to do it.