### PR TITLE
feat: add loop: false for checkbox type prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ See `examples/expand.js` for a running example.
 
 #### Checkbox - `{type: 'checkbox'}`
 
-Take `type`, `name`, `message`, `choices`[, `filter`, `validate`, `default`] properties. `default` is expected to be an Array of the checked choices value.
+Take `type`, `name`, `message`, `choices`[, `filter`, `validate`, `default`, `loop`] properties. `default` is expected to be an Array of the checked choices value.
 
 Choices marked as `{checked: true}` will be checked by default.
 

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -15,6 +15,7 @@ var { map, takeUntil } = require('rxjs/operators');
 var Base = require('./base');
 var observe = require('../utils/events');
 var Paginator = require('../utils/paginator');
+var incrementListIndex = require('../utils/incrementListIndex');
 
 class CheckboxPrompt extends Base {
   constructor(questions, rl, answers) {
@@ -37,7 +38,8 @@ class CheckboxPrompt extends Base {
     // Make sure no default is set (so it won't be printed)
     this.opt.default = null;
 
-    this.paginator = new Paginator(this.screen);
+    const shouldLoop = this.opt.loop === undefined ? true : this.opt.loop;
+    this.paginator = new Paginator(this.screen, { isInfinite: shouldLoop });
   }
 
   /**
@@ -170,14 +172,12 @@ class CheckboxPrompt extends Base {
   }
 
   onUpKey() {
-    var len = this.opt.choices.realLength;
-    this.pointer = this.pointer > 0 ? this.pointer - 1 : len - 1;
+    this.pointer = incrementListIndex(this.pointer, 'up', this.opt);
     this.render();
   }
 
   onDownKey() {
-    var len = this.opt.choices.realLength;
-    this.pointer = this.pointer < len - 1 ? this.pointer + 1 : 0;
+    this.pointer = incrementListIndex(this.pointer, 'down', this.opt);
     this.render();
   }
 

--- a/packages/inquirer/test/specs/prompts/checkbox.js
+++ b/packages/inquirer/test/specs/prompts/checkbox.js
@@ -277,4 +277,69 @@ describe('`checkbox` prompt', function () {
       });
     });
   });
+
+  describe('going out of boundaries', function () {
+    describe('when loop undefined / true', function () {
+      it('loops to bottom when too far up', async function () {
+        var promise = this.checkbox.run();
+
+        this.rl.input.emit('keypress', null, { name: 'up' });
+        this.rl.input.emit('keypress', null, { name: 'up' });
+
+        this.rl.input.emit('keypress', ' ', { name: 'space' });
+        this.rl.emit('line');
+
+        var answer = await promise;
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 2');
+      });
+      it('loops to top when too far down', async function () {
+        var promise = this.checkbox.run();
+
+        this.rl.input.emit('keypress', null, { name: 'down' });
+        this.rl.input.emit('keypress', null, { name: 'down' });
+        this.rl.input.emit('keypress', null, { name: 'down' });
+
+        this.rl.input.emit('keypress', ' ', { name: 'space' });
+        this.rl.emit('line');
+
+        var answer = await promise;
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 1');
+      });
+    });
+
+    describe('when loop: false', function () {
+      beforeEach(function () {
+        this.checkbox = new Checkbox(_.assign(this.fixture, { loop: false }), this.rl);
+      });
+      it('stays at top when too far up', async function () {
+        var promise = this.checkbox.run();
+
+        this.rl.input.emit('keypress', null, { name: 'up' });
+        this.rl.input.emit('keypress', null, { name: 'up' });
+
+        this.rl.input.emit('keypress', ' ', { name: 'space' });
+        this.rl.emit('line');
+
+        var answer = await promise;
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 1');
+      });
+      it('stays at bottom when too far down', async function () {
+        var promise = this.checkbox.run();
+
+        this.rl.input.emit('keypress', null, { name: 'down' });
+        this.rl.input.emit('keypress', null, { name: 'down' });
+        this.rl.input.emit('keypress', null, { name: 'down' });
+
+        this.rl.input.emit('keypress', ' ', { name: 'space' });
+        this.rl.emit('line');
+
+        var answer = await promise;
+        expect(answer.length).to.equal(1);
+        expect(answer[0]).to.equal('choice 3');
+      });
+    });
+  });
 });


### PR DESCRIPTION
I spent quite a long time figuring out why `loop: false` didn't work in checkbox prompts.
Turns out it wasn't implemented.

Here's my go at it. Fixes: #944