### PR TITLE
chore(deps): bump lodash to 4.17.19

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-mzxOTaU4AsJhnIujhngm+OnA6JX4fTI8D5H26wwGd+BJ57bW70oyRwTqo6EFJm1jTZ7hCo7yVzH1vB8TMFd2ww=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "run-async": {
       "version": "2.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "cli-width": "^3.0.0",
-    "lodash": "^4.17.16",
+    "lodash": "^4.17.19",
     "mute-stream": "^0.0.8",
     "run-async": "^2.3.0",
     "string-width": "^4.1.0",

--- a/packages/inquirer/package-lock.json
+++ b/packages/inquirer/package-lock.json
@@ -75,9 +75,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-mzxOTaU4AsJhnIujhngm+OnA6JX4fTI8D5H26wwGd+BJ57bW70oyRwTqo6EFJm1jTZ7hCo7yVzH1vB8TMFd2ww=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "mockery": {
       "version": "2.1.0",

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -43,7 +43,7 @@
     "cli-width": "^3.0.0",
     "external-editor": "^3.0.3",
     "figures": "^3.0.0",
-    "lodash": "^4.17.16",
+    "lodash": "^4.17.19",
     "mute-stream": "0.0.8",
     "run-async": "^2.4.0",
     "rxjs": "^6.6.0",


### PR DESCRIPTION
Hi ! :wave: 

I don't know why Snyk missed it ([see their website](https://snyk.io/vuln/npm:lodash)), but there's currently an npm advisory to upgrade Lodash to 4.17.19 or later : https://www.npmjs.com/advisories/1523