### PR TITLE
[docs] clarification about prompt method. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ node packages/inquirer/examples/checkbox.js
 
 <a name="methods"></a>
 
-#### `inquirer.prompt(questions) -> promise`
+#### `inquirer.prompt(questions, answers) -> promise`
 
 Launch the prompt interface (inquiry session)
 
 - **questions** (Array) containing [Question Object](#question) (using the [reactive interface](#reactive-interface), you can also pass a `Rx.Observable` instance)
+- **answers** (object) contains values of already answered questions. Inquirer will avoid asking answers already provided here. Defaults `{}`.
 - returns a **Promise**
 
 #### `inquirer.registerPrompt(name, prompt)`


### PR DESCRIPTION
I had to look into the source code to find out that providing already answered questions was as easy as filling them in the 2nd argument. That's why I had to do this PR to help save time to future users. I saw it even has tests so it looks like a very thought-out feature.

Hope this helps.
Great library!