### PR TITLE
Add possiblity to specify extension in editor (fixes #914)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,9 +287,11 @@ Note that `mask` is required to hide the actual user input.
 
 #### Editor - `{type: 'editor'}`
 
-Take `type`, `name`, `message`[, `default`, `filter`, `validate`] properties
+Take `type`, `name`, `message`[, `default`, `filter`, `validate`, `postfix`] properties
 
 Launches an instance of the users preferred editor on a temporary file. Once the user exits their editor, the contents of the temporary file are read in as the result. The editor to use is determined by reading the $VISUAL or $EDITOR environment variables. If neither of those are present, notepad (on Windows) or vim (Linux or Mac) is used.
+
+The `postfix` property is useful if you want to provide an extension.
 
 <a name="layouts"></a>
 

--- a/packages/editor/index.js
+++ b/packages/editor/index.js
@@ -16,25 +16,29 @@ module.exports = createPrompt((config, done) => {
 
     if (isEnterKey(key)) {
       rl.pause();
-      editAsync(config.default || '', async (error, answer) => {
-        rl.resume();
-        if (error) {
-          setError(error);
-        } else {
-          setStatus('loading');
-          const isValid = await config.validate(answer);
-          if (isValid === true) {
-            setError(undefined);
-            setStatus('done');
-            done(answer);
+      editAsync(
+        config.default || '',
+        async (error, answer) => {
+          rl.resume();
+          if (error) {
+            setError(error);
           } else {
-            setError(isValid || 'You must provide a valid value');
-            setStatus('pending');
+            setStatus('loading');
+            const isValid = await config.validate(answer);
+            if (isValid === true) {
+              setError(undefined);
+              setStatus('done');
+              done(answer);
+            } else {
+              setError(isValid || 'You must provide a valid value');
+              setStatus('pending');
+            }
           }
+        },
+        {
+          postfix: config.postfix || '.txt',
         }
-      }, {
-        postfix: config.postfix || ".txt"
-      });
+      );
     }
   });
 

--- a/packages/editor/index.js
+++ b/packages/editor/index.js
@@ -32,6 +32,8 @@ module.exports = createPrompt((config, done) => {
             setStatus('pending');
           }
         }
+      }, {
+        postfix: config.postfix || ".txt"
       });
     }
   });


### PR DESCRIPTION
With these changes, it is possible to add an extension to the tmp file used by the editor in order to enable syntax highlighting etc.

This PR fixes issue #914 