### PR TITLE
fix: rawlist displays 'value' instead of 'short' after selection

### DIFF
--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -94,7 +94,7 @@ class RawListPrompt extends Base {
     var bottomContent = '';
 
     if (this.status === 'answered') {
-      message += chalk.cyan(this.answer);
+      message += chalk.cyan(this.opt.choices.getChoice(this.selected).short);
     } else {
       var choicesStr = renderChoices(this.opt.choices, this.selected);
       message +=


### PR DESCRIPTION
Addresses 
https://github.com/SBoudrias/Inquirer.js/issues/929
https://github.com/SBoudrias/Inquirer.js/issues/889