### PR TITLE
fix: retain number prompt default

### DIFF
--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -150,8 +150,12 @@ class Prompt {
       this.opt.suffix +
       chalk.reset(' ');
 
-    // Append the default if available, and if question isn't answered
-    if (this.opt.default != null && this.status !== 'answered') {
+    // Append the default if available, and if question isn't touched/answered
+    if (
+      this.opt.default != null &&
+      this.status !== 'touched' &&
+      this.status !== 'answered'
+    ) {
       // If default password is supplied, hide it
       if (this.opt.type === 'password') {
         message += chalk.italic.dim('[hidden] ');

--- a/packages/inquirer/lib/prompts/input.js
+++ b/packages/inquirer/lib/prompts/input.js
@@ -101,10 +101,7 @@ class InputPrompt extends Base {
    */
 
   onKeypress() {
-    // If user press a key, just clear the default value
-    if (this.opt.default) {
-      this.opt.default = undefined;
-    }
+    this.state = 'touched';
 
     this.render();
   }

--- a/packages/inquirer/test/specs/prompts/number.js
+++ b/packages/inquirer/test/specs/prompts/number.js
@@ -111,6 +111,7 @@ describe('`number` prompt', () => {
       done();
     });
 
-    this.rl.emit('line', '');
+    this.rl.input.emit('keypress', 'a', { name: 'a' });
+    this.rl.emit('line');
   });
 });


### PR DESCRIPTION
The number prompt wants to use the default value if the input was invalid, however after a keypress (and if the default value is truthy) the default gets cleared. This is done so the default value is not rendered in the prompt anymore, see: https://github.com/SBoudrias/Inquirer.js/pull/719

This PR changes the logic so that instead of clearing the default value it sets a new state called "touched". We can then use this state to hide the default value from the rendered prompt.

Updated the relevant test so it would have failed before.