### PR TITLE
do not display password on async filter/validation, fixes #1022

### DIFF
--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -130,7 +130,7 @@ class Prompt {
   }
 
   startSpinner(value, bottomContent) {
-    value = this.spinningValue(value);
+    value = this.getSpinningValue(value);
     // If the question will spin, cut off the prefix (for layout purposes)
     const content = bottomContent
       ? this.getQuestion() + value
@@ -143,9 +143,9 @@ class Prompt {
    * Allow override, e.g. for password prompts
    * See: https://github.com/SBoudrias/Inquirer.js/issues/1022
    *
-   * @return (String) value to display while spinning
+   * @return {String} value to display while spinning
    */
-  spinningValue(value) {
+  getSpinningValue(value) {
     return value;
   }
 

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -130,12 +130,23 @@ class Prompt {
   }
 
   startSpinner(value, bottomContent) {
+    value = this.spinningValue(value);
     // If the question will spin, cut off the prefix (for layout purposes)
     const content = bottomContent
       ? this.getQuestion() + value
       : this.getQuestion().slice(this.opt.prefix.length + 1) + value;
 
     this.screen.renderWithSpinner(content, bottomContent);
+  }
+
+  /**
+   * Allow override, e.g. for password prompts
+   * See: https://github.com/SBoudrias/Inquirer.js/issues/1022
+   *
+   * @return (String) value to display while spinning
+   */
+  spinningValue(value) {
+    return value;
   }
 
   /**

--- a/packages/inquirer/lib/prompts/password.js
+++ b/packages/inquirer/lib/prompts/password.js
@@ -57,9 +57,9 @@ class PasswordPrompt extends Base {
     let bottomContent = '';
 
     if (this.status === 'answered') {
-      message += this.maskedValue(this.answer);
+      message += this.getMaskedValue(this.answer);
     } else {
-      message += this.maskedValue(this.rl.line || '');
+      message += this.getMaskedValue(this.rl.line || '');
     }
 
     if (error) {
@@ -69,7 +69,7 @@ class PasswordPrompt extends Base {
     this.screen.render(message, bottomContent);
   }
 
-  maskedValue(value) {
+  getMaskedValue(value) {
     if (this.status === 'answered') {
       return this.opt.mask
         ? chalk.cyan(mask(value, this.opt.mask))
@@ -83,8 +83,8 @@ class PasswordPrompt extends Base {
   /**
    * Mask value during async filter/validation.
    */
-  spinningValue(value) {
-    return this.maskedValue(value);
+  getSpinningValue(value) {
+    return this.getMaskedValue(value);
   }
 
   /**

--- a/packages/inquirer/lib/prompts/password.js
+++ b/packages/inquirer/lib/prompts/password.js
@@ -57,13 +57,9 @@ class PasswordPrompt extends Base {
     let bottomContent = '';
 
     if (this.status === 'answered') {
-      message += this.opt.mask
-        ? chalk.cyan(mask(this.answer, this.opt.mask))
-        : chalk.italic.dim('[hidden]');
-    } else if (this.opt.mask) {
-      message += mask(this.rl.line || '', this.opt.mask);
+      message += this.maskedValue(this.answer);
     } else {
-      message += chalk.italic.dim('[input is hidden] ');
+      message += this.maskedValue(this.rl.line || '');
     }
 
     if (error) {
@@ -71,6 +67,24 @@ class PasswordPrompt extends Base {
     }
 
     this.screen.render(message, bottomContent);
+  }
+
+  maskedValue(value) {
+    if (this.status === 'answered') {
+      return this.opt.mask
+        ? chalk.cyan(mask(value, this.opt.mask))
+        : chalk.italic.dim('[hidden]');
+    }
+    return this.opt.mask
+      ? mask(value, this.opt.mask)
+      : chalk.italic.dim('[input is hidden] ');
+  }
+
+  /**
+   * Mask value during async filter/validation.
+   */
+  spinningValue(value) {
+    return this.maskedValue(value);
   }
 
   /**

--- a/packages/inquirer/test/specs/prompts/password.js
+++ b/packages/inquirer/test/specs/prompts/password.js
@@ -96,7 +96,7 @@ describe('`password` prompt', () => {
     };
 
     /* This test should fail if you uncomment this line: */
-    // password.spinningValue = value => value;
+    // password.getSpinningValue = (value) => value;
 
     const promise = password.run().then((answer) => {
       expect(output).to.not.contain(input);

--- a/packages/inquirer/test/specs/prompts/password.js
+++ b/packages/inquirer/test/specs/prompts/password.js
@@ -66,4 +66,45 @@ describe('`password` prompt', () => {
     this.rl.emit('line', '');
     return promise;
   });
+
+  // See: https://github.com/SBoudrias/Inquirer.js/issues/1022
+  it('should not display input during async validation', function () {
+    let output = '';
+    let renderCount = 0;
+
+    this.fixture.validate = () =>
+      new Promise((resolve) => {
+        const id = setInterval(() => {
+          // Make sure we render at least once.
+          if (renderCount > 1) {
+            clearInterval(id);
+            resolve(true);
+          }
+        }, 10);
+      });
+
+    const password = new Password(this.fixture, this.rl);
+    const input = 'wvAq82yVujm5S9pf';
+
+    // Override screen.render to capture all output
+    const { screen } = password;
+    const { render } = screen;
+    screen.render = (...args) => {
+      output += stripAnsi(args.join(''));
+      renderCount += 1;
+      return render.call(screen, ...args);
+    };
+
+    /* This test should fail if you uncomment this line: */
+    // password.spinningValue = value => value;
+
+    const promise = password.run().then((answer) => {
+      expect(output).to.not.contain(input);
+      expect(answer).to.equal(input);
+    });
+
+    this.rl.emit('line', input);
+
+    return promise;
+  });
 });


### PR DESCRIPTION
The issue starts in [base.js line 100](https://github.com/SBoudrias/Inquirer.js/blob/9bee59b9/packages/inquirer/lib/prompts/base.js#L100):

```javascript
const validation = submit.pipe(
  flatMap((value) => {
    this.startSpinner(value, this.opt.filteringText);
    return asyncFilter(value, self.answers).then(
      (filteredValue) => {
        this.startSpinner(filteredValue, this.opt.validatingText);
```

My solution was to modify `startSpinner()` to call a new method `getSpinningValue()`, which defaults to a passthrough.

```javascript
startSpinner(value, bottomContent) {
  value = this.getSpinningValue(value);
  // ...
```
```javascript
getSpinningValue(value) {
  return value;
}
```

Then I modified `PasswordPrompt` to override that method to return the same as when it renders normally. I moved some code in `render()` to a new method `getMaskedValue()` to keep it dry.

The test case is committed before the fix, so you can checkout commit `6881259b` to see it fail. Or there is a line you can uncomment in the test case that should make it fail:

```javascript
/* This test should fail if you uncomment this line: */
// password.getSpinningValue = value => value;
```

I hoped to avoid adding a method to the base `Prompt` class, but couldn't think of a cleaner way. Maybe it is similar to the `transformer` feature on `InputPrompt`, so perhaps there is a better name than `getSpinningValue()`, or a way to combine masking, transforming, and spinning into something more general.