### PR TITLE
Keep checkbox instructions/hint on screen.

### DIFF
--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -92,16 +92,16 @@ class CheckboxPrompt extends Base {
     let message = this.getQuestion();
     let bottomContent = '';
 
-    if (!this.spaceKeyPressed) {
-      message +=
-        '(Press ' +
-        chalk.cyan.bold('<space>') +
-        ' to select, ' +
-        chalk.cyan.bold('<a>') +
-        ' to toggle all, ' +
-        chalk.cyan.bold('<i>') +
-        ' to invert selection)';
-    }
+    message +=
+      '(Press ' +
+      chalk.cyan.bold('<space>') +
+      ' to select, ' +
+      chalk.cyan.bold('<a>') +
+      ' to toggle all, ' +
+      chalk.cyan.bold('<i>') +
+      ' to invert selection, and ' + 
+      chalk.cyan.bold('<enter>') + 
+      ' to proceed)';
 
     // Render choices or answer depending on the state
     if (this.status === 'answered') {


### PR DESCRIPTION
This keeps the checkbox hint/instructions on screen and adds `, and <enter> to proceed` to the hint.

Fixes https://github.com/SBoudrias/Inquirer.js/issues/1031.