### PR TITLE
Add prefix extra space only when not empty

### DIFF
--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -144,8 +144,7 @@ class Prompt {
    */
   getQuestion() {
     let message =
-      this.opt.prefix +
-      ' ' +
+      (this.opt.prefix ? this.opt.prefix + ' ' : '') +
       chalk.bold(this.opt.message) +
       this.opt.suffix +
       chalk.reset(' ');


### PR DESCRIPTION
When setting the `prefix` option to an empty string (effectively trying to remove it) the prompt still displays and empty space at the beginning of the message.

This PR should address that.

**Steps to reproduce**

```js
import inquirer from 'inquirer';

await inquirer.prompt([
  {
    type: 'confirm',
    name: 'confirm',
    prefix: '',
    message: 'Confirm test',
  },
]);
```

**Expected result**

```bash
Confirm test (Y/n)
```

**Actual result**

```bash
 Confirm test (Y/n)
```