### PR TITLE
fix of #1042 rawlist throw

### DIFF
--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -123,6 +123,7 @@ class RawListPrompt extends Base {
     if (index == null) {
       index = this.rawDefault;
     } else if (index === '') {
+      this.selected = this.selected ?? -1;
       index = this.selected;
     } else {
       index -= 1;


### PR DESCRIPTION
Fix of #1042

At the moment of pressing Enter key while Error being shown, `index` (1) [which](https://github.com/SBoudrias/Inquirer.js/blob/8e0b3d4c76bcf5c970936fec2561d3cc7964abb5/packages/inquirer/lib/prompts/rawlist.js#L122) comes as an argument equals to empty string.
At the same time `this.selected` equals to `undefined` (2) [here](https://github.com/SBoudrias/Inquirer.js/blob/8e0b3d4c76bcf5c970936fec2561d3cc7964abb5/packages/inquirer/lib/prompts/rawlist.js#L126).
```
  getCurrentValue(index) { // (1)
    if (index == null) {
      index = this.rawDefault;
    } else if (index === '') {
      index = this.selected; // (2)
    } else {
      index -= 1;
    }

    const choice = this.opt.choices.getChoice(index); // (4)
    return choice ? choice.value : null;
  }
```
This happens because (3) [here](https://github.com/SBoudrias/Inquirer.js/blob/8e0b3d4c76bcf5c970936fec2561d3cc7964abb5/packages/inquirer/lib/prompts/rawlist.js#L160) it gets `undefined` value every time non-existing index inserted, so at the time Error message shown, this value persists, which leads to assertion throw (4) [here](https://github.com/SBoudrias/Inquirer.js/blob/8e0b3d4c76bcf5c970936fec2561d3cc7964abb5/packages/inquirer/lib/prompts/rawlist.js#L131) -> (5) [here](https://github.com/SBoudrias/Inquirer.js/blob/8e0b3d4c76bcf5c970936fec2561d3cc7964abb5/packages/inquirer/lib/objects/choices.js#L63).
```
  onKeypress() {
    const index = this.rl.line.length ? Number(this.rl.line) - 1 : 0;


    if (this.opt.choices.getChoice(index)) {
      this.selected = index;
    } else {
      this.selected = undefined; // (3)
    }
    this.render();
  }
```
```
  getChoice(selector) {
    assert(_.isNumber(selector)); // (5)
    return this.realChoices[selector];
  }
```
To prevent this from happening I decided to re-assign (!) `this.selected` value if needed by checking with nullish coalescing operator.
This way, if user presses Enter without entering non-existing index beforehand (i.e. sending empty string), he gets the first (default) option selected, as it was before the change.
However, if Error been shown, `this.selected` will get `-1` value, which is number (so assert pass + no negative effect) and allows user to press Enter as much as he would like to (nothing happens, expected behavior; alternative to `-1` could be assigning `this.rawDefault`, then second Enter press just chooses first option available). 
At the same time this allows to get back to selection by just pressing arrows or entering number.
```
getCurrentValue(index) {
    if (index == null) {
      index = this.rawDefault;
    } else if (index === '') {
      this.selected = this.selected ?? -1; // (!)
      index = this.selected;
    } else {
      index -= 1;
    }

    const choice = this.opt.choices.getChoice(index);
    return choice ? choice.value : null;
  }
```