### PR TITLE
compatibility fix #1042

### DIFF
--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -123,8 +123,7 @@ class RawListPrompt extends Base {
     if (index == null) {
       index = this.rawDefault;
     } else if (index === '') {
-      this.selected =
-        this.selected !== null && this.selected !== undefined ? this.selected : -1;
+      this.selected = this.selected === undefined ? -1 : this.selected;
       index = this.selected;
     } else {
       index -= 1;

--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -123,7 +123,8 @@ class RawListPrompt extends Base {
     if (index == null) {
       index = this.rawDefault;
     } else if (index === '') {
-      this.selected = this.selected ?? -1;
+      this.selected =
+        this.selected !== null && this.selected !== undefined ? this.selected : -1;
       index = this.selected;
     } else {
       index -= 1;


### PR DESCRIPTION
Fix of #1042 #1045 
For compatibility with older versions of `node` ES2020 operator been replaced with explicit check.

```
this.selected =
        this.selected !== null && this.selected !== undefined ? this.selected : -1;
```