### PR TITLE
feat: checkbox hints now stay on screen until enter is pressed

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "auto",
   "singleQuote": true,
   "printWidth": 90
 }

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 # Inquirer.js
 
-[![npm](https://badge.fury.io/js/inquirer.svg)](http://badge.fury.io/js/inquirer)
-[![tests](https://travis-ci.com/SBoudrias/Inquirer.js.svg?branch=master)](https://app.travis-ci.com/github/SBoudrias/Inquirer.js)
-[![Coverage Status](https://codecov.io/gh/SBoudrias/Inquirer.js/branch/master/graph/badge.svg)](https://codecov.io/gh/SBoudrias/Inquirer.js)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FSBoudrias%2FInquirer.js.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FSBoudrias%2FInquirer.js?ref=badge_shield)
+Salesforce fork of [SBoudrias/Inquirer.js](https://github.com/SBoudrias/Inquirer.js).
+
+Post any issues related to this fork to [salesforcecli/cli](https://github.com/salesforcecli/cli/issues).
+
+This module is temporary and may be removed at any time. **DO NOT** use this module as a direct dependency.
 
 A collection of common interactive command line user interfaces.
 

--- a/packages/inquirer/CHANGELOG.md
+++ b/packages/inquirer/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [8.1.5-sf-tmp-01](https://github.com/salesforcecli/Inquirer.js/compare/v6.0.0...v8.1.5-sf-tmp-01) (2021-10-05)
+
+
+### Features
+
+* Add checkbox prompt ([7708993](https://github.com/salesforcecli/Inquirer.js/commit/7708993196a5bf10fc55e30f6adf90b12002a24d))
+* Add expand prompt ([bceb2e5](https://github.com/salesforcecli/Inquirer.js/commit/bceb2e530b1f21aec3d346d631fc38d3c847e43f))
+* add inquirer-file-tree-selection-prompt readme ([#815](https://github.com/salesforcecli/Inquirer.js/issues/815)) ([1f849ab](https://github.com/salesforcecli/Inquirer.js/commit/1f849abcf88690931e23ada062e0d19e9b83545b))
+* add link to examples folder ([#726](https://github.com/salesforcecli/Inquirer.js/issues/726)) ([7521843](https://github.com/salesforcecli/Inquirer.js/commit/75218438045561323c9ef10ea1a820daa983e405))
+* add loop: false for checkbox type prompts ([#945](https://github.com/salesforcecli/Inquirer.js/issues/945)) ([ffe393b](https://github.com/salesforcecli/Inquirer.js/commit/ffe393be56eba8320a4afd3a5d63a83ede178f3e))
+* add loop: false for list type prompts ([#925](https://github.com/salesforcecli/Inquirer.js/issues/925)) ([c82c145](https://github.com/salesforcecli/Inquirer.js/commit/c82c14553bb8e9ee54df9ef916eae794b5e1b91a))
+* checkbox hints now stay on screen until enter is pressed ([be3da99](https://github.com/salesforcecli/Inquirer.js/commit/be3da99d4b5f53b0bbbc2a462f8a2a8f02ce9511))
+* **checkbox:** Support more key controls ([8011510](https://github.com/salesforcecli/Inquirer.js/commit/80115102cd709b137060715f6ec30be3c2ffc679))
+* Confirm prompt ([b737271](https://github.com/salesforcecli/Inquirer.js/commit/b7372712e0dcbf3d53cfc1a82389947bd66df3ae))
+* **input:** Display default value as selected once prompt is done if no value has been provided ([8bfed5d](https://github.com/salesforcecli/Inquirer.js/commit/8bfed5d9d073a6966d50821a470eabc697d66aa0))
+* **prompt:** progress indicator for filter and validate with optiona… ([#1002](https://github.com/salesforcecli/Inquirer.js/issues/1002)) ([6717092](https://github.com/salesforcecli/Inquirer.js/commit/67170927437369909419a1f7fb8cc1739a390002))
+* **select:** Support number key navigation ([ece9b26](https://github.com/salesforcecli/Inquirer.js/commit/ece9b262e6c9dee2cb12377ef856776f08caf012))
+
+
+### Bug Fixes
+
+* allow running lint and tests on windows ([635611f](https://github.com/salesforcecli/Inquirer.js/commit/635611f91440334a144f7f390e0d2ce938fdea7d))
+* cleanup when the prompt fails. ([#947](https://github.com/salesforcecli/Inquirer.js/issues/947)) ([833a4cd](https://github.com/salesforcecli/Inquirer.js/commit/833a4cde10f190cbf3c79e8f5ad1200da31f0ce7))
+* fix mapping state to value for list style prompts ([12d85f6](https://github.com/salesforcecli/Inquirer.js/commit/12d85f636bd509206c11de47c6b65c17607c93bb))
+* paginator works with loop:false ([#939](https://github.com/salesforcecli/Inquirer.js/issues/939)) ([132682e](https://github.com/salesforcecli/Inquirer.js/commit/132682ecfb3972b0efc9b11a370e649a4a8b49c6))
+* passes answers to list's filter callback ([#988](https://github.com/salesforcecli/Inquirer.js/issues/988)) ([a3ddaa0](https://github.com/salesforcecli/Inquirer.js/commit/a3ddaa0c8e8d415c19d9c521cb0bb002c4348301))
+* rawlist displays 'value' instead of 'short' after selection ([#1013](https://github.com/salesforcecli/Inquirer.js/issues/1013)) ([357bbd9](https://github.com/salesforcecli/Inquirer.js/commit/357bbd93023d87ec691b780eb1aabac45d2961a4))
+* retain number prompt default ([#1020](https://github.com/salesforcecli/Inquirer.js/issues/1020)) ([73b6e65](https://github.com/salesforcecli/Inquirer.js/commit/73b6e6581169147a62d7cba08f3ae90d26dd9014))

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -92,7 +92,7 @@ class CheckboxPrompt extends Base {
     let message = this.getQuestion();
     let bottomContent = '';
 
-    if (!this.spaceKeyPressed) {
+    if (!this.dontShowHints) {
       message +=
         '(Press ' +
         chalk.cyan.bold('<space>') +
@@ -100,7 +100,9 @@ class CheckboxPrompt extends Base {
         chalk.cyan.bold('<a>') +
         ' to toggle all, ' +
         chalk.cyan.bold('<i>') +
-        ' to invert selection)';
+        ' to invert selection, and ' +
+        chalk.cyan.bold('<enter>') +
+        ' to proceed)';
     }
 
     // Render choices or answer depending on the state
@@ -149,7 +151,7 @@ class CheckboxPrompt extends Base {
 
   onEnd(state) {
     this.status = 'answered';
-    this.spaceKeyPressed = true;
+    this.dontShowHints = true;
     // Rerender prompt (and clean subline error)
     this.render();
 
@@ -191,7 +193,6 @@ class CheckboxPrompt extends Base {
   }
 
   onSpaceKey() {
-    this.spaceKeyPressed = true;
     this.toggleChoice(this.pointer);
     this.render();
   }

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "inquirer",
-  "version": "8.1.5",
-  "description": "A collection of common interactive command line user interfaces.",
-  "author": "Simon Boudrias <admin@simonboudrias.com>",
+  "name": "@salesforce/inquirer",
+  "version": "8.1.5-sf-tmp-01",
+  "description": "(Salesforce CLI fork) A collection of common interactive command line user interfaces.",
   "files": [
     "lib",
     "README.md"
@@ -32,9 +31,10 @@
     "test": "nyc mocha test/**/* -r ./test/before",
     "posttest": "nyc report --reporter=text-lcov > ../../coverage/nyc-report.lcov",
     "prepublishOnly": "cp ../../README.md .",
-    "postpublish": "rm -f README.md"
+    "postpublish": "rm -f README.md",
+    "build": "yarn prepublishOnly"
   },
-  "repository": "SBoudrias/Inquirer.js",
+  "repository": "salesforcecli/Inquirer.js",
   "license": "MIT",
   "dependencies": {
     "ansi-escapes": "^4.2.1",


### PR DESCRIPTION
This keeps the checkbox hint/instructions on screen and adds `, and <enter> to proceed` to the hint.

It also allows linting and testing to occur on Windows.

Example:
![prompthints](https://user-images.githubusercontent.com/1084688/135125915-82427c97-bb62-4234-8cef-3a71fd2efefa.gif)


Fixes #1031 