### PR TITLE
feat: checkbox hints now stay on screen until enter is pressed

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "auto",
   "singleQuote": true,
   "printWidth": 90
 }

--- a/packages/inquirer/lib/prompts/checkbox.js
+++ b/packages/inquirer/lib/prompts/checkbox.js
@@ -92,7 +92,7 @@ class CheckboxPrompt extends Base {
     let message = this.getQuestion();
     let bottomContent = '';
 
-    if (!this.spaceKeyPressed) {
+    if (!this.dontShowHints) {
       message +=
         '(Press ' +
         chalk.cyan.bold('<space>') +
@@ -100,7 +100,9 @@ class CheckboxPrompt extends Base {
         chalk.cyan.bold('<a>') +
         ' to toggle all, ' +
         chalk.cyan.bold('<i>') +
-        ' to invert selection)';
+        ' to invert selection, and ' +
+        chalk.cyan.bold('<enter>') +
+        ' to proceed)';
     }
 
     // Render choices or answer depending on the state
@@ -149,7 +151,7 @@ class CheckboxPrompt extends Base {
 
   onEnd(state) {
     this.status = 'answered';
-    this.spaceKeyPressed = true;
+    this.dontShowHints = true;
     // Rerender prompt (and clean subline error)
     this.render();
 
@@ -191,7 +193,6 @@ class CheckboxPrompt extends Base {
   }
 
   onSpaceKey() {
-    this.spaceKeyPressed = true;
     this.toggleChoice(this.pointer);
     this.render();
   }


### PR DESCRIPTION
This keeps the checkbox hint/instructions on screen and adds `, and <enter> to proceed` to the hint.

It also allows linting and testing to occur on Windows.

Example:
![prompthints](https://user-images.githubusercontent.com/1084688/135125915-82427c97-bb62-4234-8cef-3a71fd2efefa.gif)

Fixes #1031 