### PR TITLE
lodash almost gone

### DIFF
--- a/packages/core/lib/Paginator.js
+++ b/packages/core/lib/Paginator.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const _ = {
-  flatten: require('lodash/flatten'),
-};
 const chalk = require('chalk');
 const cliWidth = require('cli-width');
 const { breakLines } = require('./utils');
@@ -45,7 +42,7 @@ class Paginator {
     this.lastIndex = active;
 
     // Duplicate the lines so it give an infinite list look
-    const infinite = _.flatten([lines, lines, lines]);
+    const infinite = [lines, lines, lines].flat();
     const topIndex = Math.max(0, active + lines.length - this.pointer);
 
     const section = infinite.splice(topIndex, pageSize).join('\n');

--- a/packages/inquirer/lib/ui/bottom-bar.js
+++ b/packages/inquirer/lib/ui/bottom-bar.js
@@ -6,9 +6,6 @@
 const through = require('through');
 const Base = require('./baseUI');
 const rlUtils = require('../utils/readline');
-const _ = {
-  last: require('lodash/last'),
-};
 
 class BottomBar extends Base {
   constructor(opt = {}) {
@@ -84,7 +81,7 @@ class BottomBar extends Base {
     this.height = msgLines.length;
 
     // Write message to screen and setPrompt to control backspace
-    this.rl.setPrompt(_.last(msgLines));
+    this.rl.setPrompt(msgLines[msgLines.length - 1]);
 
     if (this.rl.output.rows === 0 && this.rl.output.columns === 0) {
       /* When it's a tty through serial port there's no terminal info and the render will malfunction,

--- a/packages/inquirer/test/specs/api.js
+++ b/packages/inquirer/test/specs/api.js
@@ -3,7 +3,6 @@
  */
 
 const { expect } = require('chai');
-const _ = require('lodash');
 const fixtures = require('../helpers/fixtures');
 const ReadlineStub = require('../helpers/readline');
 const inquirer = require('../../lib/inquirer');
@@ -345,7 +344,7 @@ const tests = {
 
         prompt.run();
 
-        _.each(choices.filter(inquirer.Separator.exclude), (choice) => {
+        choices.filter(inquirer.Separator.exclude).forEach((choice) => {
           expect(this.rl.output.__raw__).to.contain(choice.name);
         });
       });
@@ -366,15 +365,15 @@ const tests = {
 
 // Run tests
 describe('Prompt public APIs', () => {
-  _.each(prompts, (detail) => {
+  prompts.forEach((detail) => {
     describe('on ' + detail.name + ' prompt', () => {
       beforeEach(function () {
-        this.fixture = _.clone(fixtures[detail.name]);
+        this.fixture = { ...fixtures[detail.name] };
         this.Prompt = inquirer.prompt.prompts[detail.name];
         this.rl = new ReadlineStub();
       });
 
-      _.each(detail.apis, (apiName) => {
+      detail.apis.forEach((apiName) => {
         tests[apiName](detail.name);
       });
     });

--- a/packages/inquirer/test/specs/prompts/checkbox.js
+++ b/packages/inquirer/test/specs/prompts/checkbox.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 const sinon = require('sinon');
@@ -8,7 +7,7 @@ const Checkbox = require('../../../lib/prompts/checkbox');
 
 describe('`checkbox` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.checkbox);
+    this.fixture = { ...fixtures.checkbox };
     this.rl = new ReadlineStub();
     this.checkbox = new Checkbox(this.fixture, this.rl);
   });
@@ -311,7 +310,10 @@ describe('`checkbox` prompt', () => {
 
     describe('when loop: false', () => {
       beforeEach(function () {
-        this.checkbox = new Checkbox(_.assign(this.fixture, { loop: false }), this.rl);
+        this.checkbox = new Checkbox(
+          Object.assign(this.fixture, { loop: false }),
+          this.rl
+        );
       });
       it('stays at top when too far up', async function () {
         const promise = this.checkbox.run();

--- a/packages/inquirer/test/specs/prompts/confirm.js
+++ b/packages/inquirer/test/specs/prompts/confirm.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -7,7 +6,7 @@ const Confirm = require('../../../lib/prompts/confirm');
 
 describe('`confirm` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.confirm);
+    this.fixture = { ...fixtures.confirm };
     this.rl = new ReadlineStub();
     this.confirm = new Confirm(this.fixture, this.rl);
   });

--- a/packages/inquirer/test/specs/prompts/editor.js
+++ b/packages/inquirer/test/specs/prompts/editor.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -10,7 +9,7 @@ describe('`editor` prompt', () => {
     this.previousVisual = process.env.VISUAL;
     // Writes the word "testing" to the file
     process.env.VISUAL = 'node ./test/bin/write.js testing';
-    this.fixture = _.clone(fixtures.editor);
+    this.fixture = { ...fixtures.editor };
     this.rl = new ReadlineStub();
   });
 

--- a/packages/inquirer/test/specs/prompts/expand.js
+++ b/packages/inquirer/test/specs/prompts/expand.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -7,7 +6,7 @@ const Expand = require('../../../lib/prompts/expand');
 
 describe('`expand` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.expand);
+    this.fixture = { ...fixtures.expand };
     this.rl = new ReadlineStub();
     this.expand = new Expand(this.fixture, this.rl);
   });

--- a/packages/inquirer/test/specs/prompts/input.js
+++ b/packages/inquirer/test/specs/prompts/input.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -7,7 +6,7 @@ const Input = require('../../../lib/prompts/input');
 
 describe('`input` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.input);
+    this.fixture = { ...fixtures.input };
     this.rl = new ReadlineStub();
   });
 

--- a/packages/inquirer/test/specs/prompts/list.js
+++ b/packages/inquirer/test/specs/prompts/list.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 const sinon = require('sinon');
@@ -8,7 +7,7 @@ const List = require('../../../lib/prompts/list');
 
 describe('`list` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.list);
+    this.fixture = { ...fixtures.list };
     this.rl = new ReadlineStub();
     this.list = new List(this.fixture, this.rl);
   });
@@ -94,7 +93,7 @@ describe('`list` prompt', () => {
 
     describe('when loop: false', () => {
       beforeEach(function () {
-        this.list = new List(_.assign(this.fixture, { loop: false }), this.rl);
+        this.list = new List(Object.assign(this.fixture, { loop: false }), this.rl);
       });
       it('stays at top when too far up', async function () {
         const promise = this.list.run();

--- a/packages/inquirer/test/specs/prompts/number.js
+++ b/packages/inquirer/test/specs/prompts/number.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -9,7 +8,7 @@ const ACCEPTABLE_ERROR = 0.001;
 
 describe('`number` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.number);
+    this.fixture = { ...fixtures.number };
     this.rl = new ReadlineStub();
     this.number = new NumberPrompt(this.fixture, this.rl);
   });

--- a/packages/inquirer/test/specs/prompts/password.js
+++ b/packages/inquirer/test/specs/prompts/password.js
@@ -1,6 +1,5 @@
 const stripAnsi = require('strip-ansi');
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -20,7 +19,7 @@ function testMasking(rl, mask) {
 
 describe('`password` prompt', () => {
   beforeEach(function () {
-    this.fixture = _.clone(fixtures.password);
+    this.fixture = { ...fixtures.password };
     this.rl = new ReadlineStub();
   });
 

--- a/packages/inquirer/test/specs/prompts/rawlist.js
+++ b/packages/inquirer/test/specs/prompts/rawlist.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const _ = require('lodash');
 const ReadlineStub = require('../../helpers/readline');
 const fixtures = require('../../helpers/fixtures');
 
@@ -8,7 +7,7 @@ const Rawlist = require('../../../lib/prompts/rawlist');
 describe('`rawlist` prompt', () => {
   beforeEach(function () {
     this.rl = new ReadlineStub();
-    this.fixture = _.clone(fixtures.rawlist);
+    this.fixture = { ...fixtures.rawlist };
     this.rawlist = new Rawlist(this.fixture, this.rl);
   });
 
@@ -152,7 +151,7 @@ describe('`rawlist` prompt', () => {
 
     describe('when loop: false', () => {
       beforeEach(function () {
-        this.rawlist = new Rawlist(_.assign(this.fixture, { loop: false }), this.rl);
+        this.rawlist = new Rawlist(Object.assign(this.fixture, { loop: false }), this.rl);
       });
       it('stays at top when too far up', async function () {
         const promise = this.rawlist.run();


### PR DESCRIPTION
There are 3 remaining files after this gets merged.

They are slightly more annoying and harder to refactor out cuz of things like `Lodash 'where' clause` in `_.get` for example.
i would have use optional chaining...

Will leave the rest to you to decide what to do with it:

- [ ] packages/inquirer/lib/ui/prompt.js
- [ ] packages/inquirer/lib/prompts/base.js
- [ ] packages/inquirer/lib/objects/choices.js
- [ ] npm uninstall lodash (from all packages)