### PR TITLE
fix: bump engines field to Node.js>=12

### DIFF
--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -17,7 +17,7 @@
     "menu"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
Hello 👋 

I noticed the engines field doesn't match the latest release https://github.com/SBoudrias/Inquirer.js/releases/tag/inquirer%408.0.0