### PR TITLE
Adding help information execution from "Nodemon"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ node packages/inquirer/examples/checkbox.js
 # etc...
 ```
 
+** Nodemon **
+
+Executing With [`Nodemon`](https://www.npmjs.com/package/nodemon) use "stdin": false
+```json
+{
+...otherArgs
+"stdin": false
+}
+```
+
 ### Methods
 
 <a name="methods"></a>


### PR DESCRIPTION
Many developers wants hot reload execution using "Nodemon"  
and  ``` "stdin": false ```` is very useful, without stdin property  "list" option not worked properly