### PR TITLE
fix input of "rawlist"

### DIFF
--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -18,7 +18,6 @@ class RawListPrompt extends Base {
     this.hiddenLine = '';
     this.lastKey = '';
 
-
     if (!this.opt.choices) {
       this.throwParamError('choices');
     }
@@ -153,8 +152,7 @@ class RawListPrompt extends Base {
 
     if (this.lastKey === 'arrow') {
       index = this.hiddenLine.length ? Number(this.hiddenLine) - 1 : 0;
-    }
-    else {
+    } else {
       index = this.rl.line.length ? Number(this.rl.line) - 1 : 0;
     }
     this.lastKey = '';

--- a/packages/inquirer/lib/prompts/rawlist.js
+++ b/packages/inquirer/lib/prompts/rawlist.js
@@ -15,6 +15,10 @@ class RawListPrompt extends Base {
   constructor(questions, rl, answers) {
     super(questions, rl, answers);
 
+    this.hiddenLine = '';
+    this.lastKey = '';
+
+
     if (!this.opt.choices) {
       this.throwParamError('choices');
     }
@@ -145,7 +149,15 @@ class RawListPrompt extends Base {
    */
 
   onKeypress() {
-    const index = this.rl.line.length ? Number(this.rl.line) - 1 : 0;
+    let index;
+
+    if (this.lastKey === 'arrow') {
+      index = this.hiddenLine.length ? Number(this.hiddenLine) - 1 : 0;
+    }
+    else {
+      index = this.rl.line.length ? Number(this.rl.line) - 1 : 0;
+    }
+    this.lastKey = '';
 
     if (this.opt.choices.getChoice(index)) {
       this.selected = index;
@@ -178,7 +190,9 @@ class RawListPrompt extends Base {
 
   onArrowKey(type) {
     this.selected = incrementListIndex(this.selected, type, this.opt);
-    this.rl.line = String(this.selected + 1);
+    this.hiddenLine = String(this.selected + 1);
+    this.rl.line = '';
+    this.lastKey = 'arrow';
   }
 }
 


### PR DESCRIPTION
This fixes a bug in the input processing of "rawlist". To reproduce the bug:

- Run a rawlist configuration
- Use the arrow keys to select an item
- Then use the number keys to enter a specific item, and press enter
- Get an "invalid option" error

Because the arrow keys record the selected index on the input line, when the user enters a specific index, an ultimately invalid index is processed by the code.

This works around that by not using the input line to record the selected index when using arrow keys. Instead it records the selected index in a private variable.