### PR TITLE
Support negative float numbers

### DIFF
--- a/packages/inquirer/lib/prompts/number.js
+++ b/packages/inquirer/lib/prompts/number.js
@@ -14,7 +14,7 @@ class NumberPrompt extends Input {
     if (input && typeof input === 'string') {
       input = input.trim();
       // Match a number in the input
-      const numberMatch = input.match(/(^-?\d+|^\d+\.\d*|^\d*\.\d+)(e\d+)?$/);
+      const numberMatch = input.match(/(^-?\d+|^-?\d+\.\d*|^\d*\.\d+)(e\d+)?$/);
       // If a number is found, return that input.
       if (numberMatch) {
         return Number(numberMatch[0]);

--- a/packages/inquirer/test/specs/prompts/number.js
+++ b/packages/inquirer/test/specs/prompts/number.js
@@ -40,7 +40,7 @@ describe('`number` prompt', () => {
     this.rl.emit('line', '42');
   });
 
-  it('should parse negative numbers', function (done) {
+  it('should parse a negative integer', function (done) {
     this.number.run().then((answer) => {
       expect(answer).to.equal(-363);
       done();
@@ -49,13 +49,22 @@ describe('`number` prompt', () => {
     this.rl.emit('line', '-363');
   });
 
-  it('should parse a regular float', function (done) {
+  it('should parse a positive float', function (done) {
     this.number.run().then((answer) => {
       expect(answer).to.be.closeTo(4353.43, ACCEPTABLE_ERROR);
       done();
     });
 
     this.rl.emit('line', '4353.43');
+  });
+
+  it('should parse a negative float', function (done) {
+    this.number.run().then((answer) => {
+      expect(answer).to.be.closeTo(-4353.43, ACCEPTABLE_ERROR);
+      done();
+    });
+
+    this.rl.emit('line', '-4353.43');
   });
 
   it('should parse a float with no digits before the decimal', function (done) {


### PR DESCRIPTION
I added a support for negative float numbers into number prompt by adjusting the regex. Also I added the unit test for this case.