### PR TITLE
fix: breakLines regression versus paginated content

### DIFF
--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -10,5 +10,5 @@ const wrapAnsi = require('wrap-ansi');
 exports.breakLines = (content, width) =>
   content
     .split('\n')
-    .map((line) => wrapAnsi(line, width, { trim: false, hard: true }))
+    .map((line) => wrapAnsi(line, width, { trim: false, hard: true }).split('\n'))
     .join('\n');

--- a/packages/inquirer/lib/utils/screen-manager.js
+++ b/packages/inquirer/lib/utils/screen-manager.js
@@ -160,7 +160,9 @@ class ScreenManager {
     // re: trim: false; by default, `wrap-ansi` trims whitespace, which
     // is not what we want.
     // re: hard: true; by default', `wrap-ansi` does soft wrapping
-    return lines.map((line) => wrapAnsi(line, width, { trim: false, hard: true }));
+    return lines.map((line) =>
+      wrapAnsi(line, width, { trim: false, hard: true }).split('\n')
+    );
   }
 
   /**


### PR DESCRIPTION
[This PR](https://github.com/SBoudrias/Inquirer.js/pull/1106) updated `breakLines` to use `wrap-ansi`. However, in doing so, we broke the paginator. It assumes that the return value will be of the same length as the original array, but that broken lines will be subarrays.