### PR TITLE
Paginator.js migrated to Paginator.ts

### DIFF
--- a/packages/core/src/lib/Paginator.ts
+++ b/packages/core/src/lib/Paginator.ts
@@ -1,3 +1,4 @@
+import * as readline from 'readline';
 import chalk from 'chalk';
 import cliWidth from 'cli-width';
 import { breakLines } from './utils';
@@ -8,13 +9,17 @@ import { breakLines } from './utils';
  */
 
 class Paginator {
-  constructor(rl) {
+  pointer: number;
+  lastIndex: number;
+  rl: readline.ReadLine;
+  
+  constructor(rl: readline.ReadLine) {
     this.pointer = 0;
     this.lastIndex = 0;
     this.rl = rl;
   }
 
-  paginate(output, active, pageSize) {
+  paginate(output: string, active: number, pageSize: number | undefined) {
     pageSize = pageSize || 7;
     const middleOfList = Math.floor(pageSize / 2);
 

--- a/packages/core/src/lib/index.d.ts
+++ b/packages/core/src/lib/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'cli-width';


### PR DESCRIPTION
index.d.ts was added for the library **cli-width** which does not provide types (no @types/cli-width package present either). 
Not sure if this is the way to go.

Looking for feedback on this, so I can start migrating other files too. Thanks.

PS - While tinkering with files with export, building with tsc packages/core/src/lib/key.ts and running node packages/core/src/lib/key.js throws 
`exports.__esModule = true;`
`ReferenceError: exports is not defined`
Any idea on how I should go about tackling this (or ignoring it)?