### PR TITLE
@inquirer/rawlist TS migration

### DIFF
--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -12,7 +12,6 @@ import chalk from 'chalk';
 export type InputConfig = AsyncPromptConfig & {
   default?: string;
   transformer?: (value: string, { isFinal }: { isFinal: boolean }) => string;
-  filter?: (input: string) => string 
 };
 
 export default createPrompt<string, InputConfig>((config, done) => {

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -6,13 +6,13 @@ import {
   isEnterKey,
   isBackspaceKey,
   AsyncPromptConfig,
-} from '@inquirer/core/src';
+} from '@inquirer/core';
 import chalk from 'chalk';
 
 export type InputConfig = AsyncPromptConfig & {
   default?: string;
   transformer?: (value: string, { isFinal }: { isFinal: boolean }) => string;
-  filter: (input: string) => string 
+  filter?: (input: string) => string 
 };
 
 export default createPrompt<string, InputConfig>((config, done) => {

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -6,12 +6,13 @@ import {
   isEnterKey,
   isBackspaceKey,
   AsyncPromptConfig,
-} from '@inquirer/core';
+} from '@inquirer/core/src';
 import chalk from 'chalk';
 
 export type InputConfig = AsyncPromptConfig & {
   default?: string;
   transformer?: (value: string, { isFinal }: { isFinal: boolean }) => string;
+  filter: (input: string) => string 
 };
 
 export default createPrompt<string, InputConfig>((config, done) => {

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -5,7 +5,7 @@ type PasswordConfig = InputConfig & {
   mask?: boolean | string;
 };
 
-export default (config: PasswordConfig, stdio: Parameters<typeof input>[1]) => {
+export default (config: PasswordConfig, stdio?: Parameters<typeof input>[1]) => {
   if (config.transformer) {
     throw new Error(
       'Inquirer password prompt do not support custom transformer function. Use the input prompt instead.'

--- a/packages/rawlist/demo.ts
+++ b/packages/rawlist/demo.ts
@@ -1,4 +1,4 @@
-import rawlist from './index.js';
+import rawlist from './src/index.js';
 
 (async () => {
   let answer;

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -3,7 +3,11 @@
   "type": "module",
   "version": "0.0.4-alpha.0",
   "description": "Inquirer rawlist prompt",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "repository": "SBoudrias/Inquirer.js",
   "keywords": [
     "cli",
@@ -21,6 +25,9 @@
   "dependencies": {
     "@inquirer/core": "^0.0.21-alpha.0",
     "chalk": "^5.0.1"
+  },
+  "scripts": {
+    "tsc": "tsc"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rawlist/src/index.ts
+++ b/packages/rawlist/src/index.ts
@@ -4,16 +4,23 @@ import {
   useKeypress,
   usePrefix,
   isEnterKey,
-} from '@inquirer/core';
+  AsyncPromptConfig,
+} from '@inquirer/core/src';
 import chalk from 'chalk';
 
 const numberRegex = /[0-9]+/;
 
-export default createPrompt((config, done) => {
+type RawlistConfig = AsyncPromptConfig & {
+  default?: number;
+  choices: { value: string; name?: string; key?: string }[];
+  filter?: (input: string) => string;
+};
+
+export default createPrompt<string, RawlistConfig>((config, done) => {
   const { choices } = config;
-  const [status, setStatus] = useState('pending');
-  const [value, setValue] = useState('');
-  const [errorMsg, setError] = useState();
+  const [status, setStatus] = useState<string>('pending');
+  const [value, setValue] = useState<string>('');
+  const [errorMsg, setError] = useState<string | undefined>(undefined);
   const prefix = usePrefix();
 
   useKeypress((key, rl) => {
@@ -29,9 +36,9 @@ export default createPrompt((config, done) => {
 
       if (selectedChoice) {
         const finalValue = selectedChoice.value || selectedChoice.name;
-        setValue(finalValue);
+        setValue(finalValue!);
         setStatus('done');
-        done(finalValue);
+        done(finalValue!);
       } else if (value === '') {
         setError('Please input a value');
       } else {

--- a/packages/rawlist/src/index.ts
+++ b/packages/rawlist/src/index.ts
@@ -11,9 +11,7 @@ import chalk from 'chalk';
 const numberRegex = /[0-9]+/;
 
 type RawlistConfig = AsyncPromptConfig & {
-  default?: number;
   choices: { value: string; name?: string; key?: string }[];
-  filter?: (input: string) => string;
 };
 
 export default createPrompt<string, RawlistConfig>((config, done) => {

--- a/packages/rawlist/src/index.ts
+++ b/packages/rawlist/src/index.ts
@@ -5,7 +5,7 @@ import {
   usePrefix,
   isEnterKey,
   AsyncPromptConfig,
-} from '@inquirer/core/src';
+} from '@inquirer/core';
 import chalk from 'chalk';
 
 const numberRegex = /[0-9]+/;

--- a/packages/rawlist/tsconfig.json
+++ b/packages/rawlist/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
#1101 continuation

Some other things to be noted

- stdio in password is now optional

Correct me if I'm wrong but I don't fully understand the difference in the old inquirer and the new separate packages and why do they differ in options available - for example filter doesn't seem to be supported on any prompt types. Is the new core a WIP?