### PR TITLE
feat: custom instructions in the checkbox type

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -23,13 +23,14 @@ export type Choice<Value> = {
 type State<Value> = {
   prefix?: string;
   pageSize?: number;
+  instructions?: string | boolean;
   message: string;
   choices: ReadonlyArray<Choice<Value>>;
 };
 
 export default createPrompt(
   <Value>(state: State<Value>, done: (value: Array<Value>) => void): string => {
-    const { prefix, pageSize = 7 } = state;
+    const { prefix, pageSize = 7, instructions } = state;
     const paginator = useRef(new Paginator()).current;
 
     const [status, setStatus] = useState('pending');
@@ -103,13 +104,17 @@ export default createPrompt(
     }
 
     let helpTip = '';
-    if (showHelpTip !== false) {
-      const keys = [
-        `${chalk.cyan.bold('<space>')} to select`,
-        `${chalk.cyan.bold('<a>')} to toggle all`,
-        `${chalk.cyan.bold('<i>')} to invert selection`,
-      ];
-      helpTip = ` (Press ${keys.join(', ')})`;
+    if (showHelpTip && (instructions === undefined || instructions)) {
+      if (typeof instructions === 'string') {
+        helpTip = instructions;
+      } else {
+        const keys = [
+          `${chalk.cyan.bold('<space>')} to select`,
+          `${chalk.cyan.bold('<a>')} to toggle all`,
+          `${chalk.cyan.bold('<i>')} to invert selection`,
+        ];
+        helpTip = ` (Press ${keys.join(', ')})`;
+      }
     }
 
     const allChoices = choices


### PR DESCRIPTION
It is now possible to customize the instructions in the checkbox type, for https://github.com/SBoudrias/Inquirer.js/issues/1138

Instructions support for string or boolean type.

1.When instructions set to false, help tip disappear:
```js
{
      type: 'checkbox',
      message: 'Select a package manager',
      instructions: false,
      choices: [
          { name: 'npm', value: 'npm' },
          { name: 'yarn', value: 'yarn' },
          { name: 'jspm', value: 'jspm', disabled: true },
      ],
}
```
2.When instructions set to string, help tip is customized:
```js
{
      type: 'checkbox',
      message: 'Select a package manager',
      instructions: '空格单选，a键全选，i键取消选择',
      choices: [
          { name: 'npm', value: 'npm' },
          { name: 'yarn', value: 'yarn' },
          { name: 'jspm', value: 'jspm', disabled: true },
      ],
}
```
2.When instructions are not set or set other values, help tip is default:
```js
{
      type: 'checkbox',
      message: 'Select a package manager',
      choices: [
          { name: 'npm', value: 'npm' },
          { name: 'yarn', value: 'yarn' },
          { name: 'jspm', value: 'jspm', disabled: true },
      ],
}
```