### PR TITLE
fix: help tip never render in checkbox type

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -38,7 +38,7 @@ export default createPrompt(
       ...state.choices,
     ]);
     const [cursorPosition, setCursorPosition] = useState(0);
-    const [showHelpTip, setShowHelpTip] = useState(false);
+    const [showHelpTip, setShowHelpTip] = useState(true);
 
     useKeypress((key) => {
       let newCursorPosition = cursorPosition;


### PR DESCRIPTION
If the initial value of showHelpTip is set to false, help tip never render in checkbox type.