### PR TITLE
fix: message renders repeatedly when text spans lines

### DIFF
--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -12,4 +12,5 @@ export const breakLines = (content: string, width: number): string =>
     .split('\n')
     // @ts-expect-error broken type check from library
     .map((line) => wrapAnsi(line, width, { trim: false, hard: true }).split('\n'))
+    .flat()
     .join('\n');


### PR DESCRIPTION
When the text is too long and spans lines, all keys that can cause interaction will cause the message to be displayed repeatedly.
The bottom is a reproduction of the bug:

1.checkbox(version: `@inquirer/checkbox@0.0.23-alpha.0`):
![checkbox-repeat-render](https://user-images.githubusercontent.com/44596995/180348477-fa59ff54-4fc3-4608-842e-d28896b39fce.gif)

2.select(version: `@inquirer/select@0.0.22-alpha.0`):
![select-repeat-render](https://user-images.githubusercontent.com/44596995/180348489-a437691f-2747-4e69-a320-c91fa4722f2d.gif)

The rest also have this bug, I didn't record it as a gif.

System Info:
NodeJS 16.10.0
windows 10