### PR TITLE
feat(select): the help tip at first render

### DIFF
--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -23,6 +23,7 @@ type SelectConfig = AsyncPromptConfig & {
 export default createPrompt<string, SelectConfig>((config, done) => {
   const [status, setStatus] = useState('pending');
   const [cursorPosition, setCursorPos] = useState(0);
+  const [firstRender, setFirstRender] = useState(true);
   const { choices, pageSize = 7 } = config;
   const paginator = useRef(new Paginator()).current;
   const prefix = usePrefix();
@@ -56,7 +57,12 @@ export default createPrompt<string, SelectConfig>((config, done) => {
     }
   });
 
-  const message = chalk.bold(config.message);
+  let message = chalk.bold(config.message);
+
+  if (firstRender) {
+    message += chalk.dim('(Use arrow keys)');
+    setFirstRender(false);
+  }
 
   if (status === 'done') {
     const choice = choices[cursorPosition]!;

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -3,6 +3,7 @@ import {
   useState,
   useKeypress,
   useRef,
+  useEffect,
   usePrefix,
   isEnterKey,
   isUpKey,
@@ -23,7 +24,6 @@ type SelectConfig = AsyncPromptConfig & {
 export default createPrompt<string, SelectConfig>((config, done) => {
   const [status, setStatus] = useState('pending');
   const [cursorPosition, setCursorPos] = useState(0);
-  const [firstRender, setFirstRender] = useState(true);
   const { choices, pageSize = 7 } = config;
   const paginator = useRef(new Paginator()).current;
   const prefix = usePrefix();
@@ -59,10 +59,9 @@ export default createPrompt<string, SelectConfig>((config, done) => {
 
   let message = chalk.bold(config.message);
 
-  if (firstRender) {
+  useEffect(() => {
     message += chalk.dim('(Use arrow keys)');
-    setFirstRender(false);
-  }
+  }, []);
 
   if (status === 'done') {
     const choice = choices[cursorPosition]!;


### PR DESCRIPTION
The list type in `inquirer@9.0.2` has a help-tip message at first render, while in `@inquirer/select@0.0.22-alpha.0` there is no.

1.The list type in `inquirer@9.0.2`:
![list](https://user-images.githubusercontent.com/44596995/180961727-7008a379-4fe6-48c5-bced-259d41060901.gif)

2.The select type in `@inquirer/select@0.0.22-alpha.0`:
![select](https://user-images.githubusercontent.com/44596995/180961838-49d12b71-32d8-4814-af92-a588883ae75e.gif)

