### PR TITLE
feat(editor): add flag waitUserInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A question object is a `hash` containing question related values:
 - **suffix**: (String) Change the default _suffix_ message.
 - **askAnswered**: (Boolean) Force to prompt the question if the answer already exists.
 - **loop**: (Boolean) Enable list looping. Defaults: `true`
+- **waitUserInput**: (Boolean) Flag to enable/disable wait for user input before opening system editor - Defaults: `true`
 
 `default`, `choices`(if defined as functions), `validate`, `filter` and `when` functions can be called asynchronously. Either return a promise or use `this.async()` to get a callback you'll call with the final value.
 
@@ -300,7 +301,7 @@ Note that `mask` is required to hide the actual user input.
 
 #### Editor - `{type: 'editor'}`
 
-Take `type`, `name`, `message`[, `default`, `filter`, `validate`, `postfix`] properties
+Take `type`, `name`, `message`[, `default`, `filter`, `validate`, `postfix`, `waitUserInput`] properties
 
 Launches an instance of the users preferred editor on a temporary file. Once the user exits their editor, the contents of the temporary file are read in as the result. The editor to use is determined by reading the $VISUAL or $EDITOR environment variables. If neither of those are present, notepad (on Windows) or vim (Linux or Mac) is used.
 

--- a/packages/inquirer/examples/editor.js
+++ b/packages/inquirer/examples/editor.js
@@ -16,6 +16,7 @@ const questions = [
 
       return true;
     },
+    waitUserInput: true,
   },
 ];
 

--- a/packages/inquirer/lib/prompts/editor.js
+++ b/packages/inquirer/lib/prompts/editor.js
@@ -23,6 +23,12 @@ export default class EditorPrompt extends Base {
     // Open Editor on "line" (Enter Key)
     const events = observe(this.rl);
     this.lineSubscription = events.line.subscribe(this.startExternalEditor.bind(this));
+    const waitUserInput =
+      this.opt.waitUserInput === undefined ? true : this.opt.waitUserInput;
+
+    if (!waitUserInput) {
+      this.startExternalEditor();
+    }
 
     // Trigger Validation when editor closes
     const validation = this.handleSubmitEvents(this.editorResult);

--- a/packages/inquirer/test/specs/prompts/editor.js
+++ b/packages/inquirer/test/specs/prompts/editor.js
@@ -25,4 +25,13 @@ describe('`editor` prompt', () => {
 
     return promise.then((answer) => expect(answer).to.equal('testing'));
   });
+
+  it('should open editor without waiting for the user to press enter', function () {
+    this.fixture.waitUserInput = false;
+    const prompt = new Editor(this.fixture, this.rl);
+
+    const promise = prompt.run();
+
+    return promise.then((answer) => expect(answer).to.equal('testing'));
+  });
 });


### PR DESCRIPTION
As requested in #1149, editor prompt always requires the user to press enter before launching the system editor, this pr adds a flag `waitUserInput` (default: `true`) that if set to `false` skips the user confirmation.