### PR TITLE
feat(checkbox): complement the help tip message

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -113,6 +113,7 @@ export default createPrompt(
           `${chalk.cyan.bold('<space>')} to select`,
           `${chalk.cyan.bold('<a>')} to toggle all`,
           `${chalk.cyan.bold('<i>')} to invert selection`,
+          `and ${chalk.cyan.bold('<enter>')} to proceed`,
         ];
         helpTip = ` (Press ${keys.join(', ')})`;
       }


### PR DESCRIPTION
Complement the default help tip message like the old version, as follows:

![old-version](https://user-images.githubusercontent.com/44596995/184110409-b941fd48-58f8-4a2c-9950-ef3b39c952db.png)

