### PR TITLE
Call stream end to trigger cleanup

### DIFF
--- a/packages/core/src/lib/screen-manager.ts
+++ b/packages/core/src/lib/screen-manager.ts
@@ -94,6 +94,7 @@ export default class ScreenManager {
     this.rl.output.unmute();
     this.rl.output.write('\n');
     this.rl.output.write(ansiEscapes.cursorShow);
+    this.rl.output.end();
     this.rl.close();
   }
 }


### PR DESCRIPTION
Getting a similar issue to #62 for the new Inquirer.
Calling `end()` like before seems to fix it.
