### PR TITLE
fix: unable to install dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "type": "module",
   "devDependencies": {
     "@jest/globals": "^29.0.3",


### PR DESCRIPTION
If don‘t add "private": true, won't be able to install the dependencies.

![1664349708995](https://user-images.githubusercontent.com/44596995/192714475-136e63f3-4769-4795-8d00-8ca9777d750b.png)