### PR TITLE
fix(checkbox): optional when the selection is disabled

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -45,7 +45,11 @@ export default createPrompt(
       let newCursorPosition = cursorPosition;
       if (isEnterKey(key)) {
         setStatus('done');
-        done(choices.filter((choice) => choice.checked).map((choice) => choice.value));
+        done(
+          choices
+            .filter((choice) => choice.checked && !choice.disabled)
+            .map((choice) => choice.value)
+        );
       } else if (isUpKey(key) || isDownKey(key)) {
         const offset = isUpKey(key) ? -1 : 1;
         let selectedOption;


### PR DESCRIPTION
### Reproduction

When key `a` or `i` is pressed, the disabled selection item is also optional.

![GIF 2022-9-28 15-36-43](https://user-images.githubusercontent.com/44596995/192717738-3be11972-7639-436c-ab85-318688d319f6.gif)

Reproduction address: https://stackblitz.com/edit/node-q8w1he?file=index.js
