### PR TITLE
fix(select): the first disabled selection can't return result

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ look at issues found on other command line - feel free to report any!
   - Terminal.app
   - iTerm
 - **Windows ([Known issues](#issues))**:
+  - [Windows Terminal](https://github.com/microsoft/terminal)
   - [ConEmu](https://conemu.github.io/)
   - cmd.exe
   - Powershell

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "type": "module",
   "devDependencies": {
     "@jest/globals": "^29.0.3",

--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -45,7 +45,11 @@ export default createPrompt(
       let newCursorPosition = cursorPosition;
       if (isEnterKey(key)) {
         setStatus('done');
-        done(choices.filter((choice) => choice.checked).map((choice) => choice.value));
+        done(
+          choices
+            .filter((choice) => choice.checked && !choice.disabled)
+            .map((choice) => choice.value)
+        );
       } else if (isUpKey(key) || isDownKey(key)) {
         const offset = isUpKey(key) ? -1 : 1;
         let selectedOption;

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -22,18 +22,19 @@ type SelectConfig = AsyncPromptConfig & {
 
 export default createPrompt<string, SelectConfig>((config, done) => {
   const { choices } = config;
+  const startIndex = choices.findIndex(({ disabled }) => !disabled);
 
   const paginator = useRef(new Paginator()).current;
   const firstRender = useRef(true);
 
   const prefix = usePrefix();
   const [status, setStatus] = useState('pending');
-  const [cursorPosition, setCursorPos] = useState(0);
+  const [cursorPosition, setCursorPos] = useState(Math.max(startIndex, 0));
 
   useKeypress((key) => {
     if (isEnterKey(key)) {
       setStatus('done');
-      done(choices[cursorPosition]!.disabled ? '' : choices[cursorPosition]!.value);
+      done(choices[cursorPosition]!.value);
     } else if (isUpKey(key) || isDownKey(key)) {
       let newCursorPosition = cursorPosition;
       const offset = isUpKey(key) ? -1 : 1;
@@ -66,9 +67,6 @@ export default createPrompt<string, SelectConfig>((config, done) => {
   }
 
   if (status === 'done') {
-    if (choices[cursorPosition]!.disabled) {
-      return `${prefix} ${message} ${chalk.cyan('')}`;
-    }
     const choice = choices[cursorPosition]!;
     return `${prefix} ${message} ${chalk.cyan(choice.name || choice.value)}`;
   }


### PR DESCRIPTION
### Reproduction

When key `enter` is pressed, the first disabled selection can also return result.

![GIF 2022-9-28 17-35-38](https://user-images.githubusercontent.com/44596995/192745471-e4b0cd12-7b60-4454-9faa-3ffe8a9d3280.gif)

Reproduction address: https://stackblitz.com/edit/node-xhbjp8?file=index.js