### PR TITLE
fix(checkbox): press up or down key will cause an infinite loop while

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -47,6 +47,10 @@ export default createPrompt(
         setStatus('done');
         done(choices.filter((choice) => choice.checked).map((choice) => choice.value));
       } else if (isUpKey(key) || isDownKey(key)) {
+        const realChoices = choices.find((choice) => !choice.disabled);
+        if (!realChoices) {
+          return;
+        }
         const offset = isUpKey(key) ? -1 : 1;
         let selectedOption;
 


### PR DESCRIPTION
### Reproduction

Press `up` or `down` key will cause an infinite loop while when all selections are disabled and also cause the command line to get stuck.

![GIF 2022-9-28 19-15-51](https://user-images.githubusercontent.com/44596995/192766283-64b1241b-cf71-46ba-8bbc-d69febb88226.gif)

Reproduction address: https://stackblitz.com/edit/node-8cbusm?file=index.js