### PR TITLE
feat(packages/editor): add flag waitUserInput

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,18 @@ export function useRef<Value>(val: Value): { current: Value } {
   return useState({ current: val })[0];
 }
 
+export function useReadline(
+  userHandler: (rl: InquirerReadline) => void
+) {
+  const rl = sessionRl;
+
+  if (!rl) {
+    throw new Error('useReadline must be used within a prompt');
+  }
+
+  userHandler(rl);
+}
+
 export type AsyncPromptConfig = {
   message: string | Promise<string> | (() => Promise<string>);
   validate?: (value: string) => boolean | string | Promise<string | boolean>;

--- a/packages/editor/demo.ts
+++ b/packages/editor/demo.ts
@@ -2,6 +2,7 @@ import editor from './src/index.js';
 
 (async () => {
   const answer = await editor({
+    waitUserInput: true,
     message: 'Please write a short bio of at least 3 lines.',
     validate(text) {
       if (text.trim().split('\n').length < 3) {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -7,17 +7,50 @@ import {
   usePrefix,
   isEnterKey,
   AsyncPromptConfig,
+  InquirerReadline,
+  useEffect,
+  useReadline,
 } from '@inquirer/core';
 
 type EditorConfig = AsyncPromptConfig & {
   default?: string;
   postfix?: string;
+  waitUserInput?: boolean;
 };
 
 export default createPrompt<string, EditorConfig>((config, done) => {
   const [status, setStatus] = useState<string>('pending');
   const [value, setValue] = useState<string>(config.default || '');
   const [errorMsg, setError] = useState<string | undefined>(undefined);
+  const [firstRender, setFirstRender] = useState<boolean>(true);
+
+  const startExternalEditor = (rl: InquirerReadline) => {
+    rl.pause();
+    editAsync(
+      value,
+      async (error, answer) => {
+        rl.resume();
+        if (error) {
+          setError(error.toString());
+        } else {
+          setStatus('loading');
+          const isValid = await config.validate(answer);
+          if (isValid === true) {
+            setError(undefined);
+            setStatus('done');
+            done(answer);
+          } else {
+            setValue(answer);
+            setError(isValid || 'You must provide a valid value');
+            setStatus('pending');
+          }
+        }
+      },
+      {
+        postfix: config.postfix || '.txt',
+      }
+    );
+  };
 
   useKeypress(async (key, rl) => {
     // Ignore keypress while our prompt is doing other processing.
@@ -26,33 +59,20 @@ export default createPrompt<string, EditorConfig>((config, done) => {
     }
 
     if (isEnterKey(key)) {
-      rl.pause();
-      editAsync(
-        value,
-        async (error, answer) => {
-          rl.resume();
-          if (error) {
-            setError(error.toString());
-          } else {
-            setStatus('loading');
-            const isValid = await config.validate(answer);
-            if (isValid === true) {
-              setError(undefined);
-              setStatus('done');
-              done(answer);
-            } else {
-              setValue(answer);
-              setError(isValid || 'You must provide a valid value');
-              setStatus('pending');
-            }
-          }
-        },
-        {
-          postfix: config.postfix || '.txt',
-        }
-      );
+      startExternalEditor(rl);
     }
   });
+
+  if (config.waitUserInput === false && firstRender) {
+    useEffect(() => {
+      useReadline((rl) => {
+        startExternalEditor(rl);
+        setFirstRender(false);
+      });
+    }, [firstRender]);
+
+    return ['', undefined];
+  }
 
   const isLoading = status === 'loading';
   const prefix = usePrefix(isLoading);


### PR DESCRIPTION
Same change as in #1150 but for rewritten `packages/editor`.

Not sure how you feel about it but I needed to expose the InquirerReadLine object to the prompt to be able to launch the external editor without requiring user input.