### PR TITLE
feat(select): customize the display text for disabled text

### DIFF
--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -17,7 +17,12 @@ import figures from 'figures';
 import ansiEscapes from 'ansi-escapes';
 
 type SelectConfig = AsyncPromptConfig & {
-  choices: { value: string; name?: string; description?: string; disabled?: boolean }[];
+  choices: {
+    value: string;
+    name?: string;
+    description?: string;
+    disabled?: boolean | string;
+  }[];
   pageSize?: number;
 };
 
@@ -79,7 +84,9 @@ export default createPrompt<string, SelectConfig>((config, done) => {
     .map(({ name, value, disabled }, index) => {
       const line = name || value;
       if (disabled) {
-        return chalk.dim(`- ${line} (disabled)`);
+        return chalk.dim(
+          `- ${line} (${typeof disabled === 'string' ? disabled : 'disabled'})`
+        );
       }
 
       if (index === cursorPosition) {

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -85,7 +85,7 @@ export default createPrompt<string, SelectConfig>((config, done) => {
       const line = name || value;
       if (disabled) {
         return chalk.dim(
-          `- ${line} (${typeof disabled === 'string' ? disabled : 'disabled'})`
+          `- ${line} ${typeof disabled === 'string' ? disabled : '(disabled)'}`
         );
       }
 


### PR DESCRIPTION
I have a project that needs to use a custom disabled text for the `Select` type. As shown below

![image](https://user-images.githubusercontent.com/44596995/225626082-803ca3a0-7b3e-4184-9e56-b55f189301da.png)
