### PR TITLE
Fixes a tiny error in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ inquirer
 Inquirer v9 and higher are native esm modules, this mean you cannot use the commonjs syntax `require('inquirer')` anymore. If you want to learn more about using native esm in Node, I'd recommend reading [the following guide](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). Alternatively, you can rely on an older version until you're ready to upgrade your environment:
 
 ```sh
-npm install --save inquirer@^8.0.0
+npm install --save inquirer@8.0.0
 ```
 
 This will then allow import inquirer with the commonjs `require`:


### PR DESCRIPTION
The readme contains the lines:
```sh
npm install --save inquirer@^8.0.0
```
which returns an error when executed, due to the `^`, this pr gets rid of the '^' and make it work like how its supposed to.

```
Running npm install --save inquirer@^8.0.0 returns with error
no matches found: inquirer@^8.0.0
```

Note: this is my first PR so there may be some errors or me not following best practices