### PR TITLE
added transform feature for confirm prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Choices whose property `disabled` is truthy will be unselectable. If `disabled` 
 
 #### Confirm - `{type: 'confirm'}`
 
-Take `type`, `name`, `message`, `transformer`, [`default`] properties. `default` is expected to be a boolean if used.
+Take `type`, `name`, `message`, [`default`, `transformer`] properties. `default` is expected to be a boolean if used.
 
 ![Confirm prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/confirm.svg)
 
@@ -390,7 +390,7 @@ look at issues found on other command line - feel free to report any!
 
 <a name="issues"></a>
 
-- **nodemon** - Makes the arrow keys print gibrish on list prompts. 
+- **nodemon** - Makes the arrow keys print gibrish on list prompts.
 Workaround: Add `{ stdin : false }` in the configuration file or pass `--no-stdin` in the CLI.
 Please refer to [this issue](https://github.com/SBoudrias/Inquirer.js/issues/844#issuecomment-736675867)
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Choices whose property `disabled` is truthy will be unselectable. If `disabled` 
 
 #### Confirm - `{type: 'confirm'}`
 
-Take `type`, `name`, `message`, [`default`] properties. `default` is expected to be a boolean if used.
+Take `type`, `name`, `message`, `transformer`, [`default`] properties. `default` is expected to be a boolean if used.
 
 ![Confirm prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/confirm.svg)
 

--- a/packages/confirm/README.md
+++ b/packages/confirm/README.md
@@ -26,6 +26,7 @@ const answer = await confirm({ message: 'Enter your name' });
 | -------- | --------- | -------- | ------------------------------ |
 | message  | `string`  | yes      | The question to ask            |
 | default  | `boolean` | no       | Default answer (true or false) |
+| transformer | `(boolean) => string`                  | no       | Transform/Format the raw value entered by the user. The function should return the transformed output for both the boolean values: `true` (positive confirmation) and `false` (negative confirmation) by the user |
 
 # License
 

--- a/packages/confirm/README.md
+++ b/packages/confirm/README.md
@@ -26,7 +26,6 @@ const answer = await confirm({ message: 'Enter your name' });
 | -------- | --------- | -------- | ------------------------------ |
 | message  | `string`  | yes      | The question to ask            |
 | default  | `boolean` | no       | Default answer (true or false) |
-| transformer | `(boolean) => string`                  | no       | Transform/Format the raw value entered by the user. The function should return the transformed output for both the boolean values: `true` (positive confirmation) and `false` (negative confirmation) by the user |
 
 # License
 

--- a/packages/inquirer/examples/pizza.js
+++ b/packages/inquirer/examples/pizza.js
@@ -13,6 +13,7 @@ const questions = [
     name: 'toBeDelivered',
     message: 'Is this for delivery?',
     default: false,
+    transform: (answer) => (answer ? '👍' : '👎'),
   },
   {
     type: 'input',

--- a/packages/inquirer/examples/pizza.js
+++ b/packages/inquirer/examples/pizza.js
@@ -13,7 +13,7 @@ const questions = [
     name: 'toBeDelivered',
     message: 'Is this for delivery?',
     default: false,
-    transform: (answer) => (answer ? '👍' : '👎'),
+    transformer: (answer) => (answer ? '👍' : '👎'),
   },
   {
     type: 'input',

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -32,7 +32,7 @@ export default class Prompt {
       when: () => true,
       suffix: '',
       prefix: chalk.green('?'),
-      transform: (val) => val,
+      transformer: (val) => val,
     });
 
     // Make sure name is present

--- a/packages/inquirer/lib/prompts/base.js
+++ b/packages/inquirer/lib/prompts/base.js
@@ -32,6 +32,7 @@ export default class Prompt {
       when: () => true,
       suffix: '',
       prefix: chalk.green('?'),
+      transform: (val) => val,
     });
 
     // Make sure name is present

--- a/packages/inquirer/lib/prompts/confirm.js
+++ b/packages/inquirer/lib/prompts/confirm.js
@@ -24,6 +24,9 @@ export default class ConfirmPrompt extends Base {
       },
     });
 
+    // Attach the transform function if provided
+    if (questions.transform != null) Object.assign(this.opt, questions.transform);
+
     if (this.opt.default != null) {
       rawDefault = Boolean(this.opt.default);
     }
@@ -78,7 +81,9 @@ export default class ConfirmPrompt extends Base {
   onEnd(input) {
     this.status = 'answered';
 
-    const output = this.opt.filter(input);
+    let output = this.opt.filter(input);
+    const transformedOutput = this.opt.transform(output);
+    if (transformedOutput !== output) output = transformedOutput;
     this.render(output);
 
     this.screen.done();

--- a/packages/inquirer/lib/prompts/confirm.js
+++ b/packages/inquirer/lib/prompts/confirm.js
@@ -24,9 +24,6 @@ export default class ConfirmPrompt extends Base {
       },
     });
 
-    // Attach the transform function if provided
-    if (questions.transform != null) Object.assign(this.opt, questions.transform);
-
     if (this.opt.default != null) {
       rawDefault = Boolean(this.opt.default);
     }
@@ -65,6 +62,8 @@ export default class ConfirmPrompt extends Base {
 
     if (typeof answer === 'boolean') {
       message += chalk.cyan(answer ? 'Yes' : 'No');
+    } else if (answer) {
+      message += answer;
     } else {
       message += this.rl.line;
     }
@@ -82,8 +81,9 @@ export default class ConfirmPrompt extends Base {
     this.status = 'answered';
 
     let output = this.opt.filter(input);
-    const transformedOutput = this.opt.transform(output);
-    if (transformedOutput !== output) output = transformedOutput;
+    if (this.opt.transformer) {
+      output = this.opt.transformer(output);
+    }
     this.render(output);
 
     this.screen.done();

--- a/packages/inquirer/test/specs/prompts/confirm.js
+++ b/packages/inquirer/test/specs/prompts/confirm.js
@@ -88,7 +88,7 @@ describe('`confirm` prompt', () => {
   });
 
   it('should tranform the output based on the boolean value', function (done) {
-    this.fixture.transform = (value) => (value ? '👍' : '👎');
+    this.fixture.transformer = (value) => (value ? '👍' : '👎');
     const confirmOutput = new Confirm(this.fixture, this.rl);
     confirmOutput
       .run()

--- a/packages/inquirer/test/specs/prompts/confirm.js
+++ b/packages/inquirer/test/specs/prompts/confirm.js
@@ -86,4 +86,18 @@ describe('`confirm` prompt', () => {
 
     this.rl.emit('line', 'bla bla foo');
   });
+
+  it('should tranform the output based on the boolean value', function (done) {
+    this.fixture.transform = (value) => (value ? '👍' : '👎');
+    const confirmOutput = new Confirm(this.fixture, this.rl);
+    confirmOutput
+      .run()
+      .then((answer) => {
+        expect(answer).to.equal('👍');
+        done();
+      })
+      .catch((err) => console.log(err));
+
+    this.rl.emit('line', 'y');
+  });
 });


### PR DESCRIPTION
PR for the [Feature request: Support for transformer function for confirm type #1207](https://github.com/SBoudrias/Inquirer.js/issues/1207)

The following changes are made:
- Updated the pizza.js file in the examples of confirm prompt.
- Added the transform default function to the Base class to extend this feature to other prompts if and when required. By default, it will return the value as is.
- Updated confirm.js file to allow support of transforming the output, if the user has provided a transformation function.
- Added a test case for this feature as well.
