### PR TITLE
Support Node.js 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 20
           - 18
           - 16
           - 14

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -68,7 +68,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -66,7 +66,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -66,7 +66,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -59,7 +59,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -63,7 +63,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -65,7 +65,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -69,7 +69,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "exports": {
     ".": {

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -59,7 +59,7 @@
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.esm.json",
     "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "ts-node ../../tools/rename-ext.mts"
+    "fix-ext": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/tools/setup-packages.mts
+++ b/tools/setup-packages.mts
@@ -66,7 +66,8 @@ paths.forEach(async (pkgPath) => {
       clean: 'rm -rf dist',
       'tsc:esm': 'tsc -p ./tsconfig.esm.json',
       'tsc:cjs': 'tsc -p ./tsconfig.cjs.json && yarn run fix-ext',
-      'fix-ext': 'ts-node ../../tools/rename-ext.mts',
+      'fix-ext':
+        'node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts',
     };
 
     // Set CJS tsconfig


### PR DESCRIPTION
The `yarn test` script will fail on Node.js 20. This is because:

- https://github.com/TypeStrong/ts-node/issues/1997

I changed the command to `node --loader ts-node/esm` for running scripts.

I also added `--no-warnings=ExperimentalWarning` to suppress those experimental warnings.

### Changes

- Add Node.js 20 to GitHub Actions
- Change `fix-ext` to `node --no-warnings=ExperimentalWarning --loader ts-node/esm ../../tools/rename-ext.mts`