### PR TITLE
Setup CJS fallback imports for ESM only dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,9 @@
         "no-undef": "off",
         "no-unused-vars": "off",
         "n/no-missing-import": "off",
-        "@typescript-eslint/no-unused-vars": "error"
+        "@typescript-eslint/no-unused-vars": "error",
+        // Turned off due to import maps not being supported yet.
+        "n/no-extraneous-import": "off"
       }
     },
     {

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -61,7 +61,10 @@
     "@inquirer/type": "^1.0.1",
     "ansi-escapes": "^6.2.0",
     "chalk": "^5.2.0",
-    "figures": "^5.0.0"
+    "figures": "^5.0.0",
+    "ansi-escapes-cjs": "npm:ansi-escapes@^4.3.2",
+    "chalk-cjs": "npm:chalk@^4.1.2",
+    "figures-cjs": "npm:figures@^3.2.0"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -82,6 +85,26 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#ansi-escapes": {
+      "node": {
+        "require": "ansi-escapes-cjs",
+        "default": "ansi-escapes"
+      }
+    },
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
+      }
+    },
+    "#figures": {
+      "node": {
+        "require": "figures-cjs",
+        "default": "figures"
       }
     }
   }

--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -12,9 +12,9 @@ import {
   Paginator,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
-import chalk from 'chalk';
-import figures from 'figures';
-import ansiEscapes from 'ansi-escapes';
+import chalk from '#chalk';
+import figures from '#figures';
+import ansiEscapes from '#ansi-escapes';
 
 export type Choice<Value> = {
   name?: string;

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -57,7 +57,8 @@
     "@inquirer/core": "^1.0.2",
     "@inquirer/input": "^1.0.1",
     "@inquirer/type": "^1.0.1",
-    "chalk": "^5.2.0"
+    "chalk": "^5.2.0",
+    "chalk-cjs": "npm:chalk@^4.1.2"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -81,6 +82,14 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
       }
     }
   }

--- a/packages/confirm/src/index.mts
+++ b/packages/confirm/src/index.mts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalk from '#chalk';
 import {
   createPrompt,
   useState,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,7 @@ yarn add @inquirer/core
 # Usage
 
 ```ts
-import chalk from 'chalk';
+import chalk from '#chalk';
 import {
   createPrompt,
   useState,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,12 @@
     "run-async": "^2.3.0",
     "string-width": "^5.1.2",
     "strip-ansi": "^7.0.1",
-    "wrap-ansi": "^8.1.0"
+    "wrap-ansi": "^8.1.0",
+    "ansi-escapes-cjs": "npm:ansi-escapes@^4.3.2",
+    "chalk-cjs": "npm:chalk@^4.1.2",
+    "string-width-cjs": "npm:string-width@^4.2.3",
+    "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+    "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
   },
   "devDependencies": {
     "@inquirer/testing": "^1.0.1"
@@ -91,6 +96,38 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#ansi-escapes": {
+      "node": {
+        "require": "ansi-escapes-cjs",
+        "default": "ansi-escapes"
+      }
+    },
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
+      }
+    },
+    "#string-width": {
+      "node": {
+        "require": "string-width-cjs",
+        "default": "string-width"
+      }
+    },
+    "#strip-ansi": {
+      "node": {
+        "require": "strip-ansi-cjs",
+        "default": "strip-ansi"
+      }
+    },
+    "#wrap-ansi": {
+      "node": {
+        "require": "wrap-ansi-cjs",
+        "default": "wrap-ansi"
       }
     }
   }

--- a/packages/core/src/lib/Paginator.mts
+++ b/packages/core/src/lib/Paginator.mts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalk from '#chalk';
 import cliWidth from 'cli-width';
 import { breakLines } from './utils.mjs';
 

--- a/packages/core/src/lib/prefix.mts
+++ b/packages/core/src/lib/prefix.mts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalk from '#chalk';
 import spinners from 'cli-spinners';
 import { useState, useEffect } from '../index.mjs';
 

--- a/packages/core/src/lib/readline.mts
+++ b/packages/core/src/lib/readline.mts
@@ -1,4 +1,4 @@
-import ansiEscapes from 'ansi-escapes';
+import ansiEscapes from '#ansi-escapes';
 import type { InquirerReadline } from '../index.mjs';
 
 /**

--- a/packages/core/src/lib/screen-manager.mts
+++ b/packages/core/src/lib/screen-manager.mts
@@ -1,7 +1,7 @@
 import cliWidth from 'cli-width';
-import stripAnsi from 'strip-ansi';
-import stringWidth from 'string-width';
-import ansiEscapes from 'ansi-escapes';
+import stripAnsi from '#strip-ansi';
+import stringWidth from '#string-width';
+import ansiEscapes from '#ansi-escapes';
 import * as util from './readline.mjs';
 import { breakLines } from './utils.mjs';
 import { InquirerReadline } from '../index.mjs';

--- a/packages/core/src/lib/utils.mts
+++ b/packages/core/src/lib/utils.mts
@@ -1,4 +1,4 @@
-import wrapAnsi from 'wrap-ansi';
+import wrapAnsi from '#wrap-ansi';
 
 /**
  * Force line returns at specific width. This function is ANSI code friendly and it'll

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -57,7 +57,8 @@
     "@inquirer/core": "^1.0.2",
     "@inquirer/type": "^1.0.1",
     "chalk": "^5.2.0",
-    "external-editor": "^3.0.3"
+    "external-editor": "^3.0.3",
+    "chalk-cjs": "npm:chalk@^4.1.2"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -81,6 +82,14 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
       }
     }
   }

--- a/packages/editor/src/index.mts
+++ b/packages/editor/src/index.mts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalk from '#chalk';
 import { editAsync } from 'external-editor';
 import {
   createPrompt,

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -57,7 +57,9 @@
     "@inquirer/core": "^1.0.2",
     "@inquirer/type": "^1.0.1",
     "chalk": "^5.2.0",
-    "figures": "^5.0.0"
+    "figures": "^5.0.0",
+    "chalk-cjs": "npm:chalk@^4.1.2",
+    "figures-cjs": "npm:figures@^3.2.0"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -81,6 +83,20 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
+      }
+    },
+    "#figures": {
+      "node": {
+        "require": "figures-cjs",
+        "default": "figures"
       }
     }
   }

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -7,7 +7,7 @@ import {
   AsyncPromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
-import chalk from 'chalk';
+import chalk from '#chalk';
 
 type ExpandConfig = AsyncPromptConfig & {
   choices: { key: string; name: string; value?: string }[];

--- a/packages/input/demo.mts
+++ b/packages/input/demo.mts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalk from '#chalk';
 import input from './src/index.mjs';
 
 const hexRegEx = /([0-9]|[a-f])/gim;

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "@inquirer/core": "^1.0.2",
     "@inquirer/type": "^1.0.1",
-    "chalk": "^5.2.0"
+    "chalk": "^5.2.0",
+    "chalk-cjs": "npm:chalk@^4.1.2"
   },
   "devDependencies": {
     "@inquirer/testing": "^1.0.1"
@@ -83,6 +84,14 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
       }
     }
   }

--- a/packages/input/src/index.mts
+++ b/packages/input/src/index.mts
@@ -8,7 +8,7 @@ import {
   AsyncPromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
-import chalk from 'chalk';
+import chalk from '#chalk';
 
 type InputConfig = AsyncPromptConfig & {
   default?: string;

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -81,5 +81,6 @@
     "strip-ansi": "^7.0.1",
     "through": "^2.3.6",
     "wrap-ansi": "^8.1.0"
-  }
+  },
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/inquirer/README.md"
 }

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -59,7 +59,8 @@
   "dependencies": {
     "@inquirer/input": "^1.0.1",
     "@inquirer/type": "^1.0.1",
-    "chalk": "^5.2.0"
+    "chalk": "^5.2.0",
+    "chalk-cjs": "npm:chalk@^4.1.2"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -80,6 +81,14 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
       }
     }
   }

--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -1,6 +1,6 @@
 import type { Prompt } from '@inquirer/type';
 import input from '@inquirer/input';
-import chalk from 'chalk';
+import chalk from '#chalk';
 
 type PasswordConfig = Parameters<typeof input>[0] & {
   mask?: boolean | string;

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -85,5 +85,6 @@
     "@inquirer/password": "^1.0.1",
     "@inquirer/rawlist": "^1.0.1",
     "@inquirer/select": "^1.0.1"
-  }
+  },
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/prompts/README.md"
 }

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "@inquirer/core": "^1.0.2",
     "@inquirer/type": "^1.0.1",
-    "chalk": "^5.2.0"
+    "chalk": "^5.2.0",
+    "chalk-cjs": "npm:chalk@^4.1.2"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -80,6 +81,14 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
       }
     }
   }

--- a/packages/rawlist/src/index.mts
+++ b/packages/rawlist/src/index.mts
@@ -7,7 +7,7 @@ import {
   AsyncPromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
-import chalk from 'chalk';
+import chalk from '#chalk';
 
 const numberRegex = /[0-9]+/;
 

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -58,7 +58,10 @@
     "@inquirer/type": "^1.0.1",
     "ansi-escapes": "^6.2.0",
     "chalk": "^5.2.0",
-    "figures": "^5.0.0"
+    "figures": "^5.0.0",
+    "ansi-escapes-cjs": "npm:ansi-escapes@^4.3.2",
+    "chalk-cjs": "npm:chalk@^4.1.2",
+    "figures-cjs": "npm:figures@^3.2.0"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -82,6 +85,26 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#ansi-escapes": {
+      "node": {
+        "require": "ansi-escapes-cjs",
+        "default": "ansi-escapes"
+      }
+    },
+    "#chalk": {
+      "node": {
+        "require": "chalk-cjs",
+        "default": "chalk"
+      }
+    },
+    "#figures": {
+      "node": {
+        "require": "figures-cjs",
+        "default": "figures"
       }
     }
   }

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -12,9 +12,9 @@ import {
   AsyncPromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
-import chalk from 'chalk';
-import figures from 'figures';
-import ansiEscapes from 'ansi-escapes';
+import chalk from '#chalk';
+import figures from '#figures';
+import ansiEscapes from '#ansi-escapes';
 
 type SelectConfig = AsyncPromptConfig & {
   choices: {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -62,7 +62,8 @@
   "dependencies": {
     "@inquirer/type": "^1.0.1",
     "mute-stream": "^1.0.0",
-    "strip-ansi": "^7.0.1"
+    "strip-ansi": "^7.0.1",
+    "strip-ansi-cjs": "npm:strip-ansi@^6.0.1"
   },
   "scripts": {
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
@@ -80,6 +81,14 @@
       "require": {
         "types": "./dist/cjs/types/index.d.mts",
         "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "imports": {
+    "#strip-ansi": {
+      "node": {
+        "require": "strip-ansi-cjs",
+        "default": "strip-ansi"
       }
     }
   }

--- a/packages/testing/src/index.mts
+++ b/packages/testing/src/index.mts
@@ -1,5 +1,5 @@
 import MuteStream from 'mute-stream';
-import stripAnsi from 'strip-ansi';
+import stripAnsi from '#strip-ansi';
 import { Stream } from 'node:stream';
 import type { Prompt } from '@inquirer/type';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1463,7 +1463,7 @@ ansi-colors@^4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
+"ansi-escapes-cjs@npm:ansi-escapes@^4.3.2", ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -1873,6 +1873,14 @@ chai@^4.3.7:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
+"chalk-cjs@npm:chalk@^4.1.2", chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk-pipe@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/chalk-pipe/-/chalk-pipe-6.0.0.tgz#8d9f26882e55822b5598b6614b1b400b1b78da92"
@@ -1901,14 +1909,6 @@ chalk@^2.0.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^5.0.0:
   version "5.0.1"
@@ -2926,7 +2926,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-figures@3.2.0, figures@^3.0.0:
+"figures-cjs@npm:figures@^3.2.0", figures@3.2.0, figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -6257,7 +6257,7 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.3", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6289,7 +6289,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6941,19 +6941,19 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Quick run at trying to fix fixing #1221.

But somehow can't get the imports map to compile properly. It's a new-ish feature, so not sure if it's just not well supported by the ecosystem 🤔 