### PR TITLE
Fix demo command

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -12,7 +12,7 @@ A collection of common interactive command line user interfaces.
 Give it a try in your own terminal!
 
 ```sh
-npx @inquirer/demo
+npx @inquirer/demo@latest
 ```
 
 # Installation

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -12,7 +12,7 @@ A collection of common interactive command line user interfaces.
 Give it a try in your own terminal!
 
 ```sh
-npx inquirer-demo --package=@inquirer/demo
+npx @inquirer/demo
 ```
 
 # Installation


### PR DESCRIPTION
The `npx inquirer-demo --package=@inquirer/demo` only work when the user is under the project directory and executed `yarn install`.

The `npx @inquirer/demo` will be better. This command can be executed anywhere. The only requirement is the Node.js runtime.

**Hint:**\
The package will be cached to their local when running `npx @inquirer/demo`. So if we want our users always get the latest version of the demo, the command should be `npx @inquirer/demo@latest`.