### PR TITLE
prompts: Expose all core functions

### DIFF
--- a/packages/prompts/src/index.mts
+++ b/packages/prompts/src/index.mts
@@ -6,6 +6,6 @@ import input from '@inquirer/input';
 import password from '@inquirer/password';
 import rawlist from '@inquirer/rawlist';
 import select from '@inquirer/select';
-import { Separator } from '@inquirer/core';
 
-export { checkbox, confirm, editor, expand, input, password, rawlist, select, Separator };
+export * from '@inquirer/core';
+export { checkbox, confirm, editor, expand, input, password, rawlist, select };


### PR DESCRIPTION
This exposes all core functions to `@inqurier/prompts`.

I believe some people will use our built-in prompts and their self-made prompts at the same time.

In this case, allowing them access to our `core` functions with `inquirer/prompts` is better.

In the future, we can provide and expose more utility functions in this way.