### PR TITLE
Fix (Confirm): Set every other string fallback to default value

### DIFF
--- a/packages/confirm/src/index.mts
+++ b/packages/confirm/src/index.mts
@@ -22,7 +22,9 @@ export default createPrompt<boolean, ConfirmConfig>((config, done) => {
 
   useKeypress((key, rl) => {
     if (isEnterKey(key)) {
-      const answer = value ? /^y(es)?/i.test(value) : config.default !== false;
+      let answer = config.default !== false;
+      if (/^(y|yes)?/i.test(value)) answer = true;
+      else if (/^(n|no)?/i.test(value)) answer = false;
       if (typeof config.transformer === 'function') {
         setValue(config.transformer(answer));
       } else {

--- a/packages/inquirer/lib/prompts/confirm.js
+++ b/packages/inquirer/lib/prompts/confirm.js
@@ -15,12 +15,11 @@ export default class ConfirmPrompt extends Base {
 
     Object.assign(this.opt, {
       filter(input) {
-        let value = rawDefault;
         if (input != null && input !== '') {
-          value = /^y(es)?/i.test(input);
+          if (/^y(es)?/i.test(input)) return true;
+          if (/^n(o)?/i.test(input)) return false;
         }
-
-        return value;
+        return rawDefault;
       },
     });
 

--- a/packages/inquirer/test/specs/prompts/confirm.test.js
+++ b/packages/inquirer/test/specs/prompts/confirm.test.js
@@ -75,6 +75,16 @@ describe('`confirm` prompt', () => {
       rl.emit('line', 'Yes');
     }));
 
+  it("should parse 'N' value to boolean false", () =>
+    new Promise((done) => {
+      confirm.run().then((answer) => {
+        expect(answer).toEqual(false);
+        done();
+      });
+
+      rl.emit('line', 'N');
+    }));
+
   it("should parse 'No' value to boolean false", () =>
     new Promise((done) => {
       confirm.run().then((answer) => {
@@ -85,9 +95,35 @@ describe('`confirm` prompt', () => {
       rl.emit('line', 'No');
     }));
 
-  it('should parse every other string value to boolean false', () =>
+  it('should parse every other string value to default (unset)', () =>
     new Promise((done) => {
       confirm.run().then((answer) => {
+        expect(answer).toEqual(true);
+        done();
+      });
+
+      rl.emit('line', 'bla bla foo');
+    }));
+
+  it('should parse every other string value to default (true)', () =>
+    new Promise((done) => {
+      fixture.default = true;
+      const trueConfirm = new Confirm(fixture, rl);
+
+      trueConfirm.run().then((answer) => {
+        expect(answer).toEqual(true);
+        done();
+      });
+
+      rl.emit('line', 'bla bla foo');
+    }));
+
+  it('should parse every other string value to default (false)', () =>
+    new Promise((done) => {
+      fixture.default = false;
+      const falseConfirm = new Confirm(fixture, rl);
+
+      falseConfirm.run().then((answer) => {
         expect(answer).toEqual(false);
         done();
       });


### PR DESCRIPTION
Resolves #1239

I will research how other confirm prompts like `apt` and `ssh` work before marking it as ready.

### Before

|Input|TrueConfirm output|FalseConfirm output|
|:--|:--|:--|
|foo bar|false|false|

### After

|Input|TrueConfirm output|FalseConfirm output|
|:--|:--|:--|
|foo bar|true|false|