### PR TITLE
Use `await setTimeout()` for timeout example

### DIFF
--- a/packages/core/core.test.mts
+++ b/packages/core/core.test.mts
@@ -216,6 +216,27 @@ describe('createPrompt()', () => {
   });
 });
 
+it('allow cancelling the prompt multiple times', async () => {
+  const Prompt = (config: { message: string }, done: (value: string) => void) => {
+    useKeypress((key: KeypressEvent) => {
+      if (isEnterKey(key)) {
+        done('done');
+      }
+    });
+
+    return config.message;
+  };
+
+  const prompt = createPrompt(Prompt);
+  const { answer, events } = await render(prompt, { message: 'Question' });
+
+  answer.cancel();
+  answer.cancel();
+  events.keypress('enter');
+
+  await expect(answer).rejects.toMatchInlineSnapshot('[Error: Prompt was canceled]');
+});
+
 describe('Error handling', () => {
   it('surface errors in render functions', async () => {
     const Prompt = () => {

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -208,7 +208,7 @@ const answer = input(...);
 const defaultValue = setTimeout(5000).then(() => {
   answer.cancel();
   return 'default answer';
-})
+});
 
 const answer = await Promise.race([defaultValue, answer])
 ```

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -200,16 +200,15 @@ if (allowEmail) {
 ## Get default value after timeout
 
 ```js
+import { setTimeout } from 'node:timers/promises';
 import { input } from '@inquirer/prompts';
 
 const answer = input(...);
 
-const defaultValue = new Promise(resolve => {
-	setTimeout(() => {
-		resolve(...);
-		answer.cancel();
-	}, 5000);
-});
+const defaultValue = setTimeout(5000).then(() => {
+  answer.cancel();
+  return 'default answer';
+})
 
 const answer = await Promise.race([defaultValue, answer])
 ```


### PR DESCRIPTION
Related to https://github.com/SBoudrias/Inquirer.js/issues/816#issuecomment-1575193594.

I also added a test case to cover `answer.cancel()` running multiple times.