### PR TITLE
Fix regex and documentation issues with confirm prompt

### DIFF
--- a/packages/confirm/README.md
+++ b/packages/confirm/README.md
@@ -17,7 +17,7 @@ yarn add @inquirer/confirm
 ```js
 import confirm from '@inquirer/confirm';
 
-const answer = await confirm({ message: 'Enter your name' });
+const answer = await confirm({ message: 'Continue?' });
 ```
 
 ## Options

--- a/packages/confirm/src/index.mts
+++ b/packages/confirm/src/index.mts
@@ -23,8 +23,8 @@ export default createPrompt<boolean, ConfirmConfig>((config, done) => {
   useKeypress((key, rl) => {
     if (isEnterKey(key)) {
       let answer = config.default !== false;
-      if (/^(y|yes)?/i.test(value)) answer = true;
-      else if (/^(n|no)?/i.test(value)) answer = false;
+      if (/^(y|yes)/i.test(value)) answer = true;
+      else if (/^(n|no)/i.test(value)) answer = false;
       if (typeof config.transformer === 'function') {
         setValue(config.transformer(answer));
       } else {


### PR DESCRIPTION
### 1. Regex always returning true
Not sure how this issue hasn't been raised yet, but the regex in the confirm prompt is matching *any* input because of the question mark.

**With question mark (current):**
<img width="275" alt="Input of the word no incorrectly evaluates to true" src="https://github.com/SBoudrias/Inquirer.js/assets/47499684/6dd50a53-26fb-449d-a783-a3f4df96d419">

With the question mark, the regex matches the beginning of a line and the pattern `y|yes` 0 or 1 times. Since there will always be the beginning of a line and the `y|yes` pattern is optional, it is always `true`.

**Without question mark (fixed):**
<img width="284" alt="Input of the word no correctly evaluates to false" src="https://github.com/SBoudrias/Inquirer.js/assets/47499684/9d24f5eb-d66a-4da6-a929-864e918c52fd">

With*out* the question mark, the regex matches the beginning of a line followed by the **required** pattern `y|yes`, which properly returns the right value.

### 2. Bad example in documentation
Additionally, the message in the example - `"Enter your name"` - makes no sense for a confirm prompt. I just went for `"Continue?"` instead.