### PR TITLE
nit: enforce adding the rule to disable via unicorn no-abusive-eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
       }
     ],
     "prettier/prettier": "error",
+    "unicorn/no-abusive-eslint-disable": "error",
     "unicorn/prefer-module": "error",
     "unicorn/prefer-node-protocol": "error"
   },

--- a/packages/inquirer/test/helpers/readline.js
+++ b/packages/inquirer/test/helpers/readline.js
@@ -26,7 +26,7 @@ Object.assign(stub, {
 const ReadlineStub = function () {
   this.line = '';
   this.input = new EventEmitter();
-  // eslint-disable-next-line
+  // eslint-disable-next-line prefer-rest-params
   EventEmitter.apply(this, arguments);
 };
 


### PR DESCRIPTION
Enforce that every-time we disable a rule to specify what rule it is for better legibility.

Also enforce this with the unicorn rule -> https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-abusive-eslint-disable.md