### PR TITLE
chore: replace `through` with `@ljharb/through`

### DIFF
--- a/packages/inquirer/lib/ui/bottom-bar.js
+++ b/packages/inquirer/lib/ui/bottom-bar.js
@@ -2,7 +2,7 @@
  * Sticky bottom bar user interface
  */
 
-import through from 'through';
+import through from '@ljharb/through';
 import Base from './baseUI.js';
 import * as rlUtils from '../utils/readline.js';
 

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -59,6 +59,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@ljharb/through": "^2.3.9",
     "ansi-escapes": "^4.3.2",
     "chalk": "^5.3.0",
     "cli-cursor": "^3.1.0",
@@ -72,7 +73,6 @@
     "rxjs": "^7.8.1",
     "string-width": "^4.2.3",
     "strip-ansi": "^6.0.1",
-    "through": "^2.3.6",
     "wrap-ansi": "^6.0.1"
   },
   "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/inquirer/README.md"

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,11 @@
     validate-npm-package-name "5.0.0"
     yargs-parser "20.2.4"
 
+"@ljharb/through@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@ljharb/through/-/through-2.3.9.tgz#85f221eb82f9d555e180e87d6e50fb154af85408"
+  integrity sha512-yN599ZBuMPPK4tdoToLlvgJB4CLK8fGl7ntfy0Wn7U6ttNvHYurd81bfUiK/6sMkiIwm65R6ck4L6+Y3DfVbNQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
Fixes #1266

`through` is still pulled in via some dev deps, but at least the direct dep is now maintained :-)