### PR TITLE
Type: password config type

### DIFF
--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -2,12 +2,16 @@ import type { Prompt } from '@inquirer/type';
 import input from '@inquirer/input';
 import chalk from 'chalk';
 
-type PasswordConfig = Parameters<typeof input>[0] & {
+type InputConfig = Parameters<typeof input>[0];
+type PasswordConfig = InputConfig & {
   mask?: boolean | string;
 };
 
-const password: Prompt<string, PasswordConfig> = (config, context) => {
-  if (config.transformer) {
+const password: Prompt<string, Omit<PasswordConfig, 'transformer' | 'default'>> = (
+  config,
+  context,
+) => {
+  if ('transformer' in config) {
     throw new Error(
       'Inquirer password prompt do not support custom transformer function. Use the input prompt instead.',
     );


### PR DESCRIPTION
In the [password config](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/password),  the transformer and default attributes should not be included. 

The original code inherited the type of the input config, I used Omit to remove these two attributes so that users can receive more user-friendly and accurate prompts.
