### PR TITLE
Migrate `.mts` scripts to `.mjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,9 @@
     "integration/*"
   ],
   "scripts": {
-    "ts-node": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm",
     "postinstall": "husky install",
     "prepare": "lerna run tsc",
-    "setup": "yarn ts-node ./tools/setup-packages.mts",
+    "setup": "node ./tools/setup-packages.mjs",
     "pretest": "eslint . && lerna run tsc",
     "test": "vitest --run packages && node --test integration"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -70,7 +70,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -70,8 +70,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -65,8 +65,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -65,7 +65,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,8 +78,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -63,8 +63,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -63,7 +63,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -66,7 +66,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -66,8 +66,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -65,8 +65,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -65,7 +65,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -69,8 +69,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -69,7 +69,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -58,8 +58,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -58,7 +58,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -65,8 +65,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -65,7 +65,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -67,8 +67,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -67,7 +67,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -71,7 +71,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "exports": {
     ".": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -71,8 +71,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "exports": {
     ".": {

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -58,8 +58,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && yarn run fix-ext",
-    "fix-ext": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts"
+    "tsc:cjs": "node ../../tools/fix-ext.mjs"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -58,7 +58,7 @@
     "tsc": "yarn run clean && yarn run tsc:esm && yarn run tsc:cjs",
     "clean": "rm -rf dist",
     "tsc:esm": "tsc -p ./tsconfig.json",
-    "tsc:cjs": "node ../../tools/fix-ext.mjs"
+    "tsc:cjs": "tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs"
   },
   "engines": {
     "node": ">=14.18.0"

--- a/tools/fix-ext.mjs
+++ b/tools/fix-ext.mjs
@@ -1,11 +1,11 @@
-import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import fs from 'node:fs/promises';
 import { globby } from 'globby';
 
 // Because we're using .mts files, TS compiles to .mjs files disregarding the target. So here we
 // manually rename the common.js files and their imports to .js
-const mjsFiles: string[] = await globby(['dist/cjs/**/*.mjs', '!**/node_modules']);
-mjsFiles.forEach(async (pathname: string) => {
+const mjsFiles = await globby(['dist/cjs/**/*.mjs', '!**/node_modules']);
+mjsFiles.forEach(async (pathname) => {
   // 1. Rename imports
   const fileContent = await fs.readFile(pathname, 'utf-8');
   await fs.writeFile(
@@ -26,8 +26,8 @@ mjsFiles.forEach(async (pathname: string) => {
 
 // Similarly, we rename the .d.mts files to .d.ts. This is because Typescript `node16` target will
 // masquerade as ESM otherwise.
-const dmtsFiles: string[] = await globby(['dist/cjs/**/*.d.mts', '!**/node_modules']);
-dmtsFiles.forEach(async (pathname: string) => {
+const dmtsFiles = await globby(['dist/cjs/**/*.d.mts', '!**/node_modules']);
+dmtsFiles.forEach(async (pathname) => {
   // 1. Rename imports from `.mjs` to `.js`
   const fileContent = await fs.readFile(pathname, 'utf-8');
   await fs.writeFile(

--- a/tools/setup-packages.mjs
+++ b/tools/setup-packages.mjs
@@ -80,7 +80,7 @@ paths.forEach(async (pkgPath) => {
       tsc: 'yarn run clean && yarn run tsc:esm && yarn run tsc:cjs',
       clean: 'rm -rf dist',
       'tsc:esm': 'tsc -p ./tsconfig.json',
-      'tsc:cjs': 'node ../../tools/fix-ext.mjs',
+      'tsc:cjs': 'tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs',
     };
 
     // Set ESM tsconfig

--- a/tools/setup-packages.mjs
+++ b/tools/setup-packages.mjs
@@ -1,27 +1,27 @@
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import * as url from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+import url from 'node:url';
 import { globby } from 'globby';
 import prettier from 'prettier';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-function readFile(filepath: string): Promise<string> {
+function readFile(filepath) {
   return fs.promises.readFile(filepath, 'utf-8');
 }
 
-function readJSONFile(filepath: string): Promise<any> {
+function readJSONFile(filepath) {
   return readFile(filepath).then(JSON.parse);
 }
 
-function fileExists(filepath: string): Promise<boolean> {
+function fileExists(filepath) {
   return fs.promises.access(filepath).then(
     () => true,
     () => false,
   );
 }
 
-async function writeFile(filepath: string, content: string): Promise<any> {
+async function writeFile(filepath, content) {
   if ((await fileExists(filepath)) && (await readFile(filepath)) !== content) {
     await fs.promises.writeFile(filepath, content);
   }
@@ -34,7 +34,7 @@ paths.forEach(async (pkgPath) => {
   const dir = path.dirname(pkgPath);
 
   const prettierJsonOption = await prettier.resolveConfig('tsconfig.json');
-  const formatJSON = (content: any) =>
+  const formatJSON = (content) =>
     prettier.format(JSON.stringify(content), { ...prettierJsonOption, parser: 'json' });
 
   // Set multi-module system builds exports
@@ -80,7 +80,7 @@ paths.forEach(async (pkgPath) => {
       tsc: 'yarn run clean && yarn run tsc:esm && yarn run tsc:cjs',
       clean: 'rm -rf dist',
       'tsc:esm': 'tsc -p ./tsconfig.json',
-      'tsc:cjs': 'tsc -p ./tsconfig.cjs.json && yarn run fix-ext',
+      'tsc:cjs': 'node ../../tools/fix-ext.mjs',
       'fix-ext':
         'node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts',
     };

--- a/tools/setup-packages.mjs
+++ b/tools/setup-packages.mjs
@@ -81,8 +81,6 @@ paths.forEach(async (pkgPath) => {
       clean: 'rm -rf dist',
       'tsc:esm': 'tsc -p ./tsconfig.json',
       'tsc:cjs': 'node ../../tools/fix-ext.mjs',
-      'fix-ext':
-        'node --no-warnings=ExperimentalWarning --loader=ts-node/esm ../../tools/fix-ext.mts',
     };
 
     // Set ESM tsconfig

--- a/tools/setup-packages.mjs
+++ b/tools/setup-packages.mjs
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import url from 'node:url';
 import { globby } from 'globby';
 import prettier from 'prettier';
@@ -7,7 +7,7 @@ import prettier from 'prettier';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 function readFile(filepath) {
-  return fs.promises.readFile(filepath, 'utf-8');
+  return fs.readFile(filepath, 'utf-8');
 }
 
 function readJSONFile(filepath) {
@@ -15,7 +15,7 @@ function readJSONFile(filepath) {
 }
 
 function fileExists(filepath) {
-  return fs.promises.access(filepath).then(
+  return fs.access(filepath).then(
     () => true,
     () => false,
   );
@@ -23,7 +23,7 @@ function fileExists(filepath) {
 
 async function writeFile(filepath, content) {
   if ((await fileExists(filepath)) && (await readFile(filepath)) !== content) {
-    await fs.promises.writeFile(filepath, content);
+    await fs.writeFile(filepath, content);
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/SBoudrias/Inquirer.js/pull/1279#issue-1840862449.

Here is the build time difference:

|Before|After|
|:-:|:-:|
|![](https://github.com/SBoudrias/Inquirer.js/assets/8186898/78dd6537-5379-42e7-8bc6-bd5798732915)|![](https://github.com/SBoudrias/Inquirer.js/assets/8186898/69e9615e-1c5b-4441-a973-bd6480466713)|