### PR TITLE
chore: add rule to avoid importing the whole of lodash

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,13 @@
     "default-param-last": "off",
     "padding-line-between-statements": "off",
     "no-eq-null": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "name": "lodash",
+        "message": "Do not import the whole of 'lodash'. Import the needed function instead e.g `import map from 'lodash/map.js'`"
+      }
+    ],
     "eqeqeq": [
       "error",
       "always",


### PR DESCRIPTION
Adds an eslint rule to avoid importing the whole of lodash

Relates to [comments](https://github.com/SBoudrias/Inquirer.js/pull/1271#issuecomment-1656245120) in #1271