### PR TITLE
Refactor select

### DIFF
--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -81,7 +81,7 @@ export default createPrompt(
         const offset = isUpKey(key) ? -1 : 1;
         let next = active;
         do {
-          next = (((next + offset) % items.length) + items.length) % items.length;
+          next = (next + offset + items.length) % items.length;
         } while (!selectable(items[next]!));
         setActive(next);
       } else if (isNumberKey(key)) {

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -27,7 +27,7 @@ type Choice<Value> = {
 
 type Item<Value> = Separator | Choice<Value>;
 
-function isSelectable<Value>(item: Item<Value>): item is Choice<Value> {
+function isSelectableChoice<Value>(item: Item<Value>): item is Choice<Value> {
   return !Separator.isSeparator(item) && !item.disabled;
 }
 
@@ -63,7 +63,7 @@ export default createPrompt(
     const prefix = usePrefix();
     const [status, setStatus] = useState('pending');
     const [active, setActive] = useState<number>(() => {
-      const selected = items.findIndex(isSelectable);
+      const selected = items.findIndex(isSelectableChoice);
       if (selected < 0)
         throw new Error(
           '[select prompt] No selectable choices. All choices are disabled.',
@@ -83,12 +83,12 @@ export default createPrompt(
         let next = active;
         do {
           next = (next + offset + items.length) % items.length;
-        } while (!isSelectable(items[next]!));
+        } while (!isSelectableChoice(items[next]!));
         setActive(next);
       } else if (isNumberKey(key)) {
         const position = Number(key.name) - 1;
         const item = items[position];
-        if (item == null || !isSelectable(item)) return;
+        if (item == null || !isSelectableChoice(item)) return;
         setActive(position);
       }
     });

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -27,10 +27,11 @@ type Choice<Value> = {
 
 type Item<Value> = Separator | Choice<Value>;
 
-const selectable = <Value,>(item: Item<Value>): item is Choice<Value> =>
-  !Separator.isSeparator(item) && !item.disabled;
+function isSelectable<Value>(item: Item<Value>): item is Choice<Value> {
+  return !Separator.isSeparator(item) && !item.disabled;
+}
 
-const render = <Value,>({ item, active }: { item: Item<Value>; active: boolean }) => {
+function renderItem<Value>({ item, active }: { item: Item<Value>; active: boolean }) {
   if (Separator.isSeparator(item)) {
     return ` ${item.separator}`;
   }
@@ -45,7 +46,7 @@ const render = <Value,>({ item, active }: { item: Item<Value>; active: boolean }
   const color = active ? chalk.cyan : (x: string) => x;
   const prefix = active ? figures.pointer : ` `;
   return color(`${prefix} ${line}`);
-};
+}
 
 type SelectConfig<Value> = PromptConfig<{
   choices: ReadonlyArray<Choice<Value> | Separator>;
@@ -62,7 +63,7 @@ export default createPrompt(
     const prefix = usePrefix();
     const [status, setStatus] = useState('pending');
     const [active, setActive] = useState<number>(() => {
-      const selected = items.findIndex(selectable);
+      const selected = items.findIndex(isSelectable);
       if (selected < 0)
         throw new Error(
           '[select prompt] No selectable choices. All choices are disabled.',
@@ -82,12 +83,12 @@ export default createPrompt(
         let next = active;
         do {
           next = (next + offset + items.length) % items.length;
-        } while (!selectable(items[next]!));
+        } while (!isSelectable(items[next]!));
         setActive(next);
       } else if (isNumberKey(key)) {
         const position = Number(key.name) - 1;
         const item = items[position];
-        if (item == null || !selectable(item)) return;
+        if (item == null || !isSelectable(item)) return;
         setActive(position);
       }
     });
@@ -99,7 +100,7 @@ export default createPrompt(
     }
 
     const lines = items
-      .map((item, index) => render({ item, active: index === active }))
+      .map((item, index) => renderItem({ item, active: index === active }))
       .join('\n');
 
     const page = usePagination(lines, {

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -25,99 +25,86 @@ type Choice<Value> = {
   type?: never;
 };
 
+type Item<Value> = Separator | Choice<Value>;
+
+const selectable = <Value,>(item: Item<Value>): item is Choice<Value> =>
+  !Separator.isSeparator(item) && !item.disabled;
+
+const render = <Value,>({ item, active }: { item: Item<Value>; active: boolean }) => {
+  if (Separator.isSeparator(item)) {
+    return ` ${item.separator}`;
+  }
+
+  const line = item.name || item.value;
+  if (item.disabled) {
+    const disabledLabel =
+      typeof item.disabled === 'string' ? item.disabled : '(disabled)';
+    return chalk.dim(`- ${line} ${disabledLabel}`);
+  }
+
+  const color = active ? chalk.cyan : (x: string) => x;
+  const prefix = active ? figures.pointer : ` `;
+  return color(`${prefix} ${line}`);
+};
+
 type SelectConfig<Value> = PromptConfig<{
   choices: ReadonlyArray<Choice<Value> | Separator>;
   pageSize?: number;
 }>;
-
-function isSelectableChoice<T>(
-  choice: undefined | Separator | Choice<T>,
-): choice is Choice<T> {
-  return choice != null && !Separator.isSeparator(choice) && !choice.disabled;
-}
 
 export default createPrompt(
   <Value extends unknown>(
     config: SelectConfig<Value>,
     done: (value: Value) => void,
   ): string => {
-    const { choices } = config;
+    const { choices: items, pageSize } = config;
     const firstRender = useRef(true);
-
     const prefix = usePrefix();
     const [status, setStatus] = useState('pending');
-    const [cursorPosition, setCursorPos] = useState(() => {
-      const startIndex = choices.findIndex(isSelectableChoice);
-      if (startIndex < 0) {
+    const [active, setActive] = useState<number>(() => {
+      const selected = items.findIndex(selectable);
+      if (selected < 0)
         throw new Error(
           '[select prompt] No selectable choices. All choices are disabled.',
         );
-      }
-
-      return startIndex;
+      return selected;
     });
 
     // Safe to assume the cursor position always point to a Choice.
-    const selectedChoice = choices[cursorPosition] as Choice<Value>;
+    const selectedChoice = items[active] as Choice<Value>;
 
     useKeypress((key) => {
       if (isEnterKey(key)) {
         setStatus('done');
         done(selectedChoice.value);
       } else if (isUpKey(key) || isDownKey(key)) {
-        let newCursorPosition = cursorPosition;
         const offset = isUpKey(key) ? -1 : 1;
-        let selectedOption;
-
-        while (!isSelectableChoice(selectedOption)) {
-          newCursorPosition =
-            (newCursorPosition + offset + choices.length) % choices.length;
-          selectedOption = choices[newCursorPosition];
-        }
-
-        setCursorPos(newCursorPosition);
+        let next = active;
+        do {
+          next = (((next + offset) % items.length) + items.length) % items.length;
+        } while (!selectable(items[next]!));
+        setActive(next);
       } else if (isNumberKey(key)) {
-        // Adjust index to start at 1
-        const newCursorPosition = Number(key.name) - 1;
-
-        // Abort if the choice doesn't exists or if disabled
-        if (!isSelectableChoice(choices[newCursorPosition])) {
-          return;
-        }
-
-        setCursorPos(newCursorPosition);
+        const position = Number(key.name) - 1;
+        const item = items[position];
+        if (item == null || !selectable(item)) return;
+        setActive(position);
       }
     });
 
     let message = chalk.bold(config.message);
     if (firstRender.current) {
-      message += chalk.dim(' (Use arrow keys)');
       firstRender.current = false;
+      message += chalk.dim(' (Use arrow keys)');
     }
 
-    const allChoices = choices
-      .map((choice, index): string => {
-        if (Separator.isSeparator(choice)) {
-          return ` ${choice.separator}`;
-        }
-
-        const line = choice.name || choice.value;
-        if (choice.disabled) {
-          const disabledLabel =
-            typeof choice.disabled === 'string' ? choice.disabled : '(disabled)';
-          return chalk.dim(`- ${line} ${disabledLabel}`);
-        }
-
-        if (index === cursorPosition) {
-          return chalk.cyan(`${figures.pointer} ${line}`);
-        }
-
-        return `  ${line}`;
-      })
+    const lines = items
+      .map((item, index) => render({ item, active: index === active }))
       .join('\n');
-    const windowedChoices = usePagination(allChoices, {
-      active: cursorPosition,
-      pageSize: config.pageSize,
+
+    const page = usePagination(lines, {
+      active,
+      pageSize,
     });
 
     if (status === 'done') {
@@ -130,7 +117,7 @@ export default createPrompt(
       ? `\n${selectedChoice.description}`
       : ``;
 
-    return `${prefix} ${message}\n${windowedChoices}${choiceDescription}${ansiEscapes.cursorHide}`;
+    return `${prefix} ${message}\n${page}${choiceDescription}${ansiEscapes.cursorHide}`;
   },
 );
 

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -25,9 +25,14 @@ type Choice<Value> = {
   type?: never;
 };
 
+type SelectConfig<Value> = PromptConfig<{
+  choices: ReadonlyArray<Choice<Value> | Separator>;
+  pageSize?: number;
+}>;
+
 type Item<Value> = Separator | Choice<Value>;
 
-function isSelectableChoice<Value>(item: Item<Value>): item is Choice<Value> {
+function isSelectable<Value>(item: Item<Value>): item is Choice<Value> {
   return !Separator.isSeparator(item) && !item.disabled;
 }
 
@@ -48,11 +53,6 @@ function renderItem<Value>({ item, active }: { item: Item<Value>; active: boolea
   return color(`${prefix} ${line}`);
 }
 
-type SelectConfig<Value> = PromptConfig<{
-  choices: ReadonlyArray<Choice<Value> | Separator>;
-  pageSize?: number;
-}>;
-
 export default createPrompt(
   <Value extends unknown>(
     config: SelectConfig<Value>,
@@ -63,7 +63,7 @@ export default createPrompt(
     const prefix = usePrefix();
     const [status, setStatus] = useState('pending');
     const [active, setActive] = useState<number>(() => {
-      const selected = items.findIndex(isSelectableChoice);
+      const selected = items.findIndex(isSelectable);
       if (selected < 0)
         throw new Error(
           '[select prompt] No selectable choices. All choices are disabled.',
@@ -83,12 +83,12 @@ export default createPrompt(
         let next = active;
         do {
           next = (next + offset + items.length) % items.length;
-        } while (!isSelectableChoice(items[next]!));
+        } while (!isSelectable(items[next]!));
         setActive(next);
       } else if (isNumberKey(key)) {
         const position = Number(key.name) - 1;
         const item = items[position];
-        if (item == null || !isSelectableChoice(item)) return;
+        if (item == null || !isSelectable(item)) return;
         setActive(position);
       }
     });


### PR DESCRIPTION
This is tied to refactors related to #1289

In this PR, we disambiguate between a choice and an item in the list, and between the cursor position and the active index, and add utility methods. We also extract out the render function. In addition, we simplify isSelectableChoice into selectable, a refinement function which does not work on undefined, and instead handle undefined in the more idiomatic way (which doesn't need comments).