### PR TITLE
Fix (core): Fix cli-spinner imports with changes to tsconfig.json

### DIFF
--- a/packages/core/src/lib/use-prefix.mts
+++ b/packages/core/src/lib/use-prefix.mts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import * as spinners from 'cli-spinners';
+import spinners from 'cli-spinners';
 import { useState } from './use-state.mjs';
 import { useEffect } from './use-effect.mjs';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "esm": true
   },
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
Typescript 5.2.2 somehow broke the CJS import of cli-spinners. I turned on the es module interop option, and the output seems to mock the `.default` properly.

Fix #1297
Close #1298