### PR TITLE
Feat (Core): Introduce a useMemo hook

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -104,6 +104,7 @@ Those hooks are matching the React hooks API:
 - `useState`
 - `useRef`
 - `useEffect`
+- `useMemo`
 
 And those are custom utilities from Inquirer:
 

--- a/packages/core/core.test.mts
+++ b/packages/core/core.test.mts
@@ -8,9 +8,11 @@ import {
   useKeypress,
   useState,
   useRef,
+  useMemo,
   isDownKey,
   isUpKey,
   isEnterKey,
+  isSpaceKey,
   Separator,
   type KeypressEvent,
 } from './src/index.mjs';
@@ -323,6 +325,76 @@ describe('createPrompt()', () => {
 
     events.keypress('enter');
     await expect(answer).resolves.toEqual('foo');
+  });
+
+  it('useMemo: can memoize processing heavy tasks', async () => {
+    const renderSpy = vi.fn();
+    const memoSpy = vi.fn();
+    const Prompt = (config: { message: string }, done: (value: string) => void) => {
+      renderSpy();
+      const [lastKeypress, setLastKeypress] = useState('');
+      const [index, setIndex] = useState(0);
+
+      const displayKeypress = useMemo(() => {
+        memoSpy();
+
+        if (!lastKeypress) {
+          return "You haven't pressed any key yet";
+        }
+        return `Last pressed: ${lastKeypress}`;
+      }, [lastKeypress]);
+
+      useKeypress((event: KeypressEvent) => {
+        if (isEnterKey(event)) {
+          done(lastKeypress);
+          return;
+        }
+
+        // Space will just trigger a re-render
+        if (isSpaceKey(event)) {
+          setIndex(index + 1);
+          return;
+        }
+
+        setLastKeypress(event.name);
+      });
+
+      return `${config.message} ${displayKeypress}`;
+    };
+
+    const prompt = createPrompt(Prompt);
+    const { answer, events, getScreen } = await render(prompt, { message: 'Question' });
+
+    expect(memoSpy).toHaveBeenCalledTimes(1);
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(getScreen()).toMatchInlineSnapshot(
+      '"Question You haven\'t pressed any key yet"',
+    );
+
+    events.keypress('a');
+    expect(memoSpy).toHaveBeenCalledTimes(2);
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+    expect(getScreen()).toMatchInlineSnapshot('"Question Last pressed: a"');
+
+    events.keypress('a');
+    expect(memoSpy).toHaveBeenCalledTimes(2);
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+
+    events.keypress('b');
+    expect(memoSpy).toHaveBeenCalledTimes(3);
+    expect(renderSpy).toHaveBeenCalledTimes(3);
+    expect(getScreen()).toMatchInlineSnapshot('"Question Last pressed: b"');
+
+    events.keypress('space');
+    expect(memoSpy).toHaveBeenCalledTimes(3);
+    expect(renderSpy).toHaveBeenCalledTimes(4);
+    events.keypress('space');
+    expect(memoSpy).toHaveBeenCalledTimes(3);
+    expect(renderSpy).toHaveBeenCalledTimes(5);
+    expect(getScreen()).toMatchInlineSnapshot('"Question Last pressed: b"');
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('b');
   });
 
   it('allow cancelling the prompt', async () => {

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -2,6 +2,7 @@ export * from './lib/key.mjs';
 export { usePrefix } from './lib/use-prefix.mjs';
 export { useState } from './lib/use-state.mjs';
 export { useEffect } from './lib/use-effect.mjs';
+export { useMemo } from './lib/use-memo.mjs';
 export { useRef } from './lib/use-ref.mjs';
 export { useKeypress } from './lib/use-keypress.mjs';
 export { usePagination } from './lib/use-pagination.mjs';

--- a/packages/core/src/lib/use-memo.mts
+++ b/packages/core/src/lib/use-memo.mts
@@ -1,0 +1,23 @@
+import { withPointer } from './hook-engine.mjs';
+
+type PointerValue<Value> = {
+  value: Value;
+  dependencies: unknown[];
+};
+
+export function useMemo<Value>(fn: () => Value, dependencies: unknown[]): Value {
+  return withPointer<PointerValue<Value>, Value>((pointer) => {
+    const prev = pointer.get();
+    if (
+      !prev ||
+      prev.dependencies.length !== dependencies.length ||
+      prev.dependencies.some((dep, i) => dep !== dependencies[i])
+    ) {
+      const value = fn();
+      pointer.set({ value, dependencies });
+      return value;
+    }
+
+    return prev.value;
+  });
+}

--- a/packages/core/src/lib/use-state.mts
+++ b/packages/core/src/lib/use-state.mts
@@ -5,26 +5,24 @@ type NotFunction<T> = T extends Function ? never : T;
 export function useState<Value>(
   defaultValue: NotFunction<Value> | (() => Value),
 ): [Value, (newValue: Value) => void] {
-  return withPointer((pointer) => {
-    if (!pointer.initialized) {
-      if (typeof defaultValue === 'function') {
-        pointer.set((defaultValue as () => Value)());
-      } else {
-        pointer.set(defaultValue);
+  return withPointer<Value, [Value, (newValue: Value) => void]>((pointer) => {
+    const setFn = (newValue: Value) => {
+      // Noop if the value is still the same.
+      if (pointer.get() !== newValue) {
+        pointer.set(newValue);
+
+        // Trigger re-render
+        handleChange();
       }
+    };
+
+    if (pointer.initialized) {
+      return [pointer.get(), setFn];
     }
 
-    return [
-      pointer.get(),
-      (newValue) => {
-        // Noop if the value is still the same.
-        if (pointer.get() !== newValue) {
-          pointer.set(newValue);
-
-          // Trigger re-render
-          handleChange();
-        }
-      },
-    ];
+    const value =
+      typeof defaultValue === 'function' ? (defaultValue as () => Value)() : defaultValue;
+    pointer.set(value);
+    return [value, setFn];
   });
 }


### PR DESCRIPTION
Related to #1289; we `useMemo` hook for Inquirer has a use case. So let's add it in!

Internal change: This PR also fixes the typing around the internal `withPointer` utility to increase the core type-safety.