### PR TITLE
Breaking: Remove async message feature

### DIFF
--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -11,7 +11,6 @@ import {
   isNumberKey,
   isEnterKey,
   Separator,
-  type PromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 import chalk from 'chalk';
@@ -26,7 +25,8 @@ type Choice<Value> = {
   type?: never;
 };
 
-type Config<Value> = PromptConfig<{
+type Config<Value> = {
+  message: string;
   prefix?: string;
   pageSize?: number;
   instructions?: string | boolean;
@@ -36,7 +36,7 @@ type Config<Value> = PromptConfig<{
   validate?: (
     items: ReadonlyArray<Item<Value>>,
   ) => boolean | string | Promise<string | boolean>;
-}>;
+};
 
 type Item<Value> = Separator | Choice<Value>;
 

--- a/packages/confirm/src/index.mts
+++ b/packages/confirm/src/index.mts
@@ -5,14 +5,14 @@ import {
   useKeypress,
   isEnterKey,
   usePrefix,
-  type PromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 
-type ConfirmConfig = PromptConfig<{
+type ConfirmConfig = {
+  message: string;
   default?: boolean;
   transformer?: (value: boolean) => string;
-}>;
+};
 
 export default createPrompt<boolean, ConfirmConfig>((config, done) => {
   const { transformer = (answer) => (answer ? 'yes' : 'no') } = config;

--- a/packages/core/core.test.mts
+++ b/packages/core/core.test.mts
@@ -18,44 +18,6 @@ import {
 } from './src/index.mjs';
 
 describe('createPrompt()', () => {
-  it('handle async function message', async () => {
-    const viewFunction = vi.fn(() => '');
-    const prompt = createPrompt(viewFunction);
-    const promise = Promise.resolve('Async message:');
-    const renderingDone = render(prompt, { message: () => promise });
-
-    // Initially, we leave a few ms for message to resolve
-    expect(viewFunction).not.toHaveBeenCalled();
-
-    const { answer } = await renderingDone;
-    expect(viewFunction).toHaveBeenLastCalledWith(
-      expect.objectContaining({ message: 'Async message:' }),
-      expect.any(Function),
-    );
-
-    answer.cancel();
-    await expect(answer).rejects.toBeInstanceOf(Error);
-  });
-
-  it('handle deferred message', async () => {
-    const viewFunction = vi.fn(() => '');
-    const prompt = createPrompt(viewFunction);
-    const promise = Promise.resolve('Async message:');
-    const renderingDone = render(prompt, { message: promise });
-
-    // Initially, we leave a few ms for message to resolve
-    expect(viewFunction).not.toHaveBeenCalled();
-
-    const { answer } = await renderingDone;
-    expect(viewFunction).toHaveBeenLastCalledWith(
-      expect.objectContaining({ message: 'Async message:' }),
-      expect.any(Function),
-    );
-
-    answer.cancel();
-    await expect(answer).rejects.toBeInstanceOf(Error);
-  });
-
   it('onKeypress: allow to implement custom behavior on keypress', async () => {
     const Prompt = (config: { message: string }, done: (value: string) => void) => {
       const [value, setValue] = useState('');

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -6,10 +6,6 @@ export { useMemo } from './lib/use-memo.mjs';
 export { useRef } from './lib/use-ref.mjs';
 export { useKeypress } from './lib/use-keypress.mjs';
 export { usePagination } from './lib/pagination/use-pagination.mjs';
-export {
-  createPrompt,
-  type PromptConfig,
-  type AsyncPromptConfig,
-} from './lib/create-prompt.mjs';
+export { createPrompt } from './lib/create-prompt.mjs';
 export { Separator } from './lib/Separator.mjs';
 export { type InquirerReadline } from './lib/read-line.type.mjs';

--- a/packages/editor/src/index.mts
+++ b/packages/editor/src/index.mts
@@ -7,17 +7,17 @@ import {
   useKeypress,
   usePrefix,
   isEnterKey,
-  type PromptConfig,
   type InquirerReadline,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 
-type EditorConfig = PromptConfig<{
+type EditorConfig = {
+  message: string;
   default?: string;
   postfix?: string;
   waitForUseInput?: boolean;
   validate?: (value: string) => boolean | string | Promise<string | boolean>;
-}>;
+};
 
 export default createPrompt<string, EditorConfig>((config, done) => {
   const { waitForUseInput = true, validate = () => true } = config;

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -4,7 +4,6 @@ import {
   useKeypress,
   usePrefix,
   isEnterKey,
-  type PromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 import chalk from 'chalk';
@@ -14,11 +13,12 @@ type ExpandChoice =
   | { key: string; value: string }
   | { key: string; name: string; value: string };
 
-type ExpandConfig = PromptConfig<{
+type ExpandConfig = {
+  message: string;
   choices: ReadonlyArray<ExpandChoice>;
   default?: string;
   expanded?: boolean;
-}>;
+};
 
 const helpChoice = {
   key: 'h',

--- a/packages/input/src/index.mts
+++ b/packages/input/src/index.mts
@@ -5,16 +5,16 @@ import {
   usePrefix,
   isEnterKey,
   isBackspaceKey,
-  type PromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 import chalk from 'chalk';
 
-type InputConfig = PromptConfig<{
+type InputConfig = {
+  message: string;
   default?: string;
   transformer?: (value: string, { isFinal }: { isFinal: boolean }) => string;
   validate?: (value: string) => boolean | string | Promise<string | boolean>;
-}>;
+};
 
 export default createPrompt<string, InputConfig>((config, done) => {
   const { validate = () => true } = config;

--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -4,15 +4,15 @@ import {
   useKeypress,
   usePrefix,
   isEnterKey,
-  type PromptConfig,
 } from '@inquirer/core';
 import chalk from 'chalk';
 import ansiEscapes from 'ansi-escapes';
 
-type PasswordConfig = PromptConfig<{
+type PasswordConfig = {
+  message: string;
   mask?: boolean | string;
   validate?: (value: string) => boolean | string | Promise<string | boolean>;
-}>;
+};
 
 export default createPrompt<string, PasswordConfig>((config, done) => {
   const { validate = () => true } = config;

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -234,6 +234,16 @@ exec < /dev/tty
 node my-script.js
 ```
 
+## Wait for config
+
+Maybe some question configuration require to await a value.
+
+```js
+import { confirm } from '@inquirer/prompts';
+
+const answer = await confirm({ message: await getMessage() });
+```
+
 # Community prompts
 
 If you created a cool prompt, [send us a PR adding it](https://github.com/SBoudrias/Inquirer.js/edit/master/README.md) to the list below!

--- a/packages/rawlist/src/index.mts
+++ b/packages/rawlist/src/index.mts
@@ -5,7 +5,6 @@ import {
   usePrefix,
   isEnterKey,
   Separator,
-  type PromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 import chalk from 'chalk';
@@ -18,9 +17,10 @@ type Choice<Value> = {
   key?: string;
 };
 
-type RawlistConfig<Value> = PromptConfig<{
+type RawlistConfig<Value> = {
+  message: string;
   choices: ReadonlyArray<Choice<Value> | Separator>;
-}>;
+};
 
 function isSelectableChoice<T>(
   choice: undefined | Separator | Choice<T>,

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -11,7 +11,6 @@ import {
   isDownKey,
   isNumberKey,
   Separator,
-  type PromptConfig,
 } from '@inquirer/core';
 import type {} from '@inquirer/type';
 import chalk from 'chalk';
@@ -26,12 +25,13 @@ type Choice<Value> = {
   type?: never;
 };
 
-type SelectConfig<Value> = PromptConfig<{
+type SelectConfig<Value> = {
+  message: string;
   choices: ReadonlyArray<Choice<Value> | Separator>;
   pageSize?: number;
   loop?: boolean;
   default?: Value;
-}>;
+};
 
 type Item<Value> = Separator | Choice<Value>;
 


### PR DESCRIPTION
Planning to remove built-in support for async/functions `message`.

The reasons are kinda simple:

1. I don't want to new Inquirer to be a state/flow management library (that's better done elsewhere; usually with simple Node/JS built-in)
2. The UX is bad; and not been a priority to handle due to point 1
3. When starting the rewrite, I had a few more wrapped logic there, but it was slowly all removed to be inside each prompts. So only `message` is left, and shows how it didn't match the design goals of the new API.

Do let me know if you think otherwise. I'll leave this PR open for now and bundle with some other breaking changes.