### PR TITLE
Feat (testing: add support for testing key combinations

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -31,6 +31,7 @@ describe('input prompt', () => {
 
     events.type('ohn');
     events.keypress('enter');
+    // or events.keypress({ name: 'enter' })
 
     await expect(answer).resolves.toEqual('John');
     expect(getScreen()).toMatchInlineSnapshot(`"? What is your name John"`);
@@ -51,7 +52,7 @@ The core utility of `@inquirer/testing` is the `render()` function. This `render
 
 1. `answer` (`Promise`) This is the promise that'll be resolved once an answer is provided and valid.
 2. `getScreen` (`({ raw: boolean }) => string`) This function returns the state of what is printed on the command line screen at any given time. You can use its return value to validate your prompt is properly rendered. By default this function will strip the ANSI codes (used for colors.)
-3. `events` (`{ keypress: (name) => void, type: (string) => void }`) Is the utilities allowing you to interact with the prompt. Use it to trigger keypress events, or typing any input.
+3. `events` (`{ keypress: (name | Key) => void, type: (string) => void }`) Is the utilities allowing you to interact with the prompt. Use it to trigger keypress events, or typing any input.
 4. `getFullOutput` (`() => string`) Return a raw dump of everything that got sent on the output stream.
 
 You can refer to [the `@inquirer/input` prompt test suite](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/input/input.test.mts) as a practical example.

--- a/packages/testing/src/index.mts
+++ b/packages/testing/src/index.mts
@@ -59,8 +59,21 @@ export async function render<TestedPrompt extends Prompt<any, any>>(
   await Promise.resolve();
 
   const events = {
-    keypress(name: string) {
-      input.emit('keypress', null, { name });
+    keypress(
+      key:
+        | string
+        | {
+            name?: string | undefined;
+            ctrl?: boolean | undefined;
+            meta?: boolean | undefined;
+            shift?: boolean | undefined;
+          },
+    ) {
+      if (typeof key === 'string') {
+        input.emit('keypress', null, { name: key });
+      } else {
+        input.emit('keypress', null, key);
+      }
     },
     type(text: string) {
       input.write(text);


### PR DESCRIPTION
Updated the `keypress` function to support emitting key combinations (e.g. CTRL+Space, CTRL+SHIFT+D, ...)

I also updated the README to illustrate its updated type and updated the example