### PR TITLE
fix `when` documentation

### DIFF
--- a/packages/inquirer/README.md
+++ b/packages/inquirer/README.md
@@ -143,7 +143,7 @@ A question object is a `hash` containing question related values:
 - **validate**: (Function) Receive the user input and answers hash. Should return `true` if the value is valid, and an error message (`String`) otherwise. If `false` is returned, a default error message is provided.
 - **filter**: (Function) Receive the user input and answers hash. Returns the filtered value to be used inside the program. The value returned will be added to the _Answers_ hash.
 - **transformer**: (Function) Receive the user input, answers hash and option flags, and return a transformed value to display to the user. The transformation only impacts what is shown while editing. It does not modify the answers hash.
-- **when**: (Function, Boolean) Receive the current user answers hash and should return `true` or `false` depending on whether or not this question should be asked. The value can also be a simple boolean.
+- **when**: (Function, Boolean) A function that receives the current user answers hash and should return `true` or `false` depending on whether or not this question should be asked. Alternatively if `false` is specified, the question will not be asked. If anything else is specified (including `true` and `undefined`), the question will be asked.
 - **pageSize**: (Number) Change the number of lines that will be rendered when using `list`, `rawList`, `expand` or `checkbox`.
 - **prefix**: (String) Change the default _prefix_ message.
 - **suffix**: (String) Change the default _suffix_ message.


### PR DESCRIPTION
I found it confusing that `undefined` is the same as `true`, and only `false` will actullay cause it to be skipped, so I think it makes sense to at least document this, maybe a TODO in the future to fix this behaviour (unless it's intended)