### PR TITLE
Feat: Implement password prompt as a standalone prompt

### DIFF
--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -57,7 +57,7 @@
   "license": "MIT",
   "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/password/README.md",
   "dependencies": {
-    "@inquirer/input": "^1.2.14",
+    "@inquirer/core": "^5.1.1",
     "@inquirer/type": "^1.1.5",
     "ansi-escapes": "^4.3.2",
     "chalk": "^4.1.2"

--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -1,39 +1,73 @@
-import type { Prompt } from '@inquirer/type';
-import input from '@inquirer/input';
+import {
+  createPrompt,
+  useState,
+  useKeypress,
+  usePrefix,
+  isEnterKey,
+  type PromptConfig,
+} from '@inquirer/core';
 import chalk from 'chalk';
 import ansiEscapes from 'ansi-escapes';
 
-type InputConfig = Parameters<typeof input>[0];
-type PasswordConfig = Omit<InputConfig, 'transformer' | 'default'> & {
+type PasswordConfig = PromptConfig<{
   mask?: boolean | string;
-};
+  validate?: (value: string) => boolean | string | Promise<string | boolean>;
+}>;
 
-const password: Prompt<string, PasswordConfig> = (config, context) => {
-  if ('transformer' in config) {
-    throw new Error(
-      'Inquirer password prompt do not support custom transformer function. Use the input prompt instead.',
-    );
+export default createPrompt<string, PasswordConfig>((config, done) => {
+  const { validate = () => true } = config;
+  const [status, setStatus] = useState<string>('pending');
+  const [errorMsg, setError] = useState<string | undefined>(undefined);
+  const [value, setValue] = useState<string>('');
+
+  const isLoading = status === 'loading';
+  const prefix = usePrefix(isLoading);
+
+  useKeypress(async (key, rl) => {
+    // Ignore keypress while our prompt is doing other processing.
+    if (status !== 'pending') {
+      return;
+    }
+
+    if (isEnterKey(key)) {
+      const answer = value;
+      setStatus('loading');
+      const isValid = await validate(answer);
+      if (isValid === true) {
+        setValue(answer);
+        setStatus('done');
+        done(answer);
+      } else {
+        // Reset the readline line value to the previous value. On line event, the value
+        // get cleared, forcing the user to re-enter the value instead of fixing it.
+        rl.write(value);
+        setError(isValid || 'You must provide a valid value');
+        setStatus('pending');
+      }
+    } else {
+      setValue(rl.line);
+      setError(undefined);
+    }
+  });
+
+  const message = chalk.bold(config.message);
+  let formattedValue = '';
+
+  if (config.mask) {
+    const maskChar = typeof config.mask === 'string' ? config.mask : '*';
+    formattedValue = maskChar.repeat(value.length);
+  } else if (status !== 'done') {
+    formattedValue = `${chalk.dim('[input is masked]')}${ansiEscapes.cursorHide}`;
   }
 
-  return input(
-    {
-      ...config, // Make sure we do not display the default password
-      default: undefined,
-      transformer(str: string, { isFinal }: { isFinal: boolean }) {
-        if (config.mask) {
-          const maskChar = typeof config.mask === 'string' ? config.mask : '*';
-          return maskChar.repeat(str.length);
-        }
+  if (status === 'done') {
+    formattedValue = chalk.cyan(formattedValue);
+  }
 
-        if (!isFinal) {
-          return `${chalk.dim('[input is masked]')}${ansiEscapes.cursorHide}`;
-        }
+  let error = '';
+  if (errorMsg) {
+    error = chalk.red(`> ${errorMsg}`);
+  }
 
-        return '';
-      },
-    },
-    context,
-  );
-};
-
-export default password;
+  return [`${prefix} ${message} ${formattedValue}`, error];
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,7 +456,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@inquirer/password@workspace:packages/password"
   dependencies:
-    "@inquirer/input": ^1.2.14
+    "@inquirer/core": ^5.1.1
     "@inquirer/testing": ^2.1.9
     "@inquirer/type": ^1.1.5
     ansi-escapes: ^4.3.2


### PR DESCRIPTION
Extracted the core rewrite from #1334 (cc @matteosacchetto).

Since this other PR is blocked on finding the right key-binding, I want to unblock other work (like the theme branch) I punted upon to not heavily conflict with the rewrite. Separating the rewrite should reduce the friction 🤞🏻 