### PR TITLE
Chore: Update timeout example

### DIFF
--- a/packages/demo/demos/timeout.mjs
+++ b/packages/demo/demos/timeout.mjs
@@ -1,0 +1,34 @@
+import * as url from 'node:url';
+import { setTimeout } from 'node:timers/promises';
+import { input } from '@inquirer/prompts';
+
+async function demo() {
+  const ac = new AbortController();
+  const prompt = input({
+    message: 'Enter a value (timing out in 5 seconds)',
+  });
+
+  prompt
+    .finally(() => {
+      ac.abort();
+    })
+    // Silencing the cancelation error.
+    .catch(() => {});
+
+  const defaultValue = setTimeout(5000, 'timeout', { signal: ac.signal }).then(() => {
+    prompt.cancel();
+    return 'Timed out!';
+  });
+
+  const answer = await Promise.race([defaultValue, prompt]);
+  console.log('Answer:', answer);
+}
+
+if (import.meta.url.startsWith('file:')) {
+  const modulePath = url.fileURLToPath(import.meta.url);
+  if (process.argv[1] === modulePath) {
+    demo();
+  }
+}
+
+export default demo;

--- a/packages/demo/demos/timeout.mjs
+++ b/packages/demo/demos/timeout.mjs
@@ -12,7 +12,7 @@ async function demo() {
     .finally(() => {
       ac.abort();
     })
-    // Silencing the cancelation error.
+    // Silencing the cancellation error.
     .catch(() => {});
 
   const defaultValue = setTimeout(5000, 'timeout', { signal: ac.signal }).then(() => {

--- a/packages/demo/index.mjs
+++ b/packages/demo/index.mjs
@@ -10,6 +10,7 @@ import inputDemo from './demos/input.mjs';
 import passwordDemo from './demos/password.mjs';
 import rawlistDemo from './demos/rawlist.mjs';
 import selectDemo from './demos/select.mjs';
+import timeoutDemo from './demos/timeout.mjs';
 
 const demos = {
   checkbox: checkboxDemo,
@@ -20,10 +21,11 @@ const demos = {
   password: passwordDemo,
   rawlist: rawlistDemo,
   select: selectDemo,
+  timeout: timeoutDemo,
 };
 
-function askNextDemo() {
-  return select({
+async function askNextDemo() {
+  let selectedDemo = await select({
     message: 'Which prompt demo do you want to run?',
     choices: [
       { name: 'Input', value: 'input' },
@@ -34,9 +36,26 @@ function askNextDemo() {
       { name: 'Expand', value: 'expand' },
       { name: 'Rawlist', value: 'rawlist' },
       { name: 'Editor', value: 'editor' },
+      { name: 'Advanced demos', value: 'advanced' },
       { name: "Exit (I'm done)", value: 'exit' },
     ],
   });
+
+  if (selectedDemo === 'advanced') {
+    selectedDemo = await select({
+      message: 'Which demo do you want to run?',
+      choices: [
+        { name: 'Default value after timeout', value: 'timeout' },
+        { name: 'Go back', value: 'back' },
+      ],
+    });
+  }
+
+  if (selectedDemo === 'back') {
+    return askNextDemo();
+  }
+
+  return selectedDemo;
 }
 
 (async () => {

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -205,18 +205,20 @@ import { input } from '@inquirer/prompts';
 
 const ac = new AbortController();
 const {signal} = ac;
-const answer = input(...);
+const prompt = input(...);
+
+let answer;
 
 setTimeout(5000, 'timeout', {signal})
   .catch(() => {})
   .then(() => {
-    answer.cancel();
-    return defaultValue;
+    prompt.cancel();
+    answer = defaultValue;
   })
 
-return answer.then((value) => {
+await prompt.then((value) => {
   ac.abort()
-  return value
+  answer = value
 })
 ```
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -203,14 +203,21 @@ if (allowEmail) {
 import { setTimeout } from 'node:timers/promises';
 import { input } from '@inquirer/prompts';
 
+const ac = new AbortController();
+const {signal} = ac;
 const answer = input(...);
 
-const defaultValue = setTimeout(5000).then(() => {
-  answer.cancel();
-  return 'default answer';
-});
+setTimeout(5000, 'timeout', {signal})
+  .catch(() => {})
+  .then(() => {
+    answer.cancel();
+    return defaultValue;
+  })
 
-const answer = await Promise.race([defaultValue, answer])
+return answer.then((value) => {
+  ac.abort()
+  return value
+})
 ```
 
 ## Using as pre-commit/git hooks, or scripts


### PR DESCRIPTION
The [Get Default Value After Timeout](https://github.com/SBoudrias/Inquirer.js/?tab=readme-ov-file#get-default-value-after-timeout) recipe didn't work for me since the process would wait until the timeout completed to exit.

I've updated the recipe to abort the timeout once the prompt has been answered.