### PR TITLE
Fix input's cursor start

### DIFF
--- a/packages/input/src/index.mts
+++ b/packages/input/src/index.mts
@@ -83,5 +83,10 @@ export default createPrompt<string, InputConfig>((config, done) => {
     error = theme.style.error(errorMsg);
   }
 
-  return [[prefix, message, defaultStr, formattedValue].filter(Boolean).join(' '), error];
+  return [
+    [prefix, message, defaultStr, formattedValue]
+      .filter((v) => v !== undefined)
+      .join(' '),
+    error,
+  ];
 });


### PR DESCRIPTION
The cursor positions for inputs without a current value are incorrect.

Before:

https://github.com/SBoudrias/Inquirer.js/assets/8485687/66cf88b4-51dc-4d50-b32d-4237597c8659

After:

https://github.com/SBoudrias/Inquirer.js/assets/8485687/e1f60c5c-b3ac-4244-9092-d449c7b08294