### PR TITLE
added strict equals for null input

### DIFF
--- a/packages/inquirer/lib/prompts/input.js
+++ b/packages/inquirer/lib/prompts/input.js
@@ -72,7 +72,7 @@ export default class InputPrompt extends Base {
 
   filterInput(input) {
     if (!input) {
-      return this.opt.default == null ? '' : this.opt.default;
+      return this.opt.default === null ? '' : this.opt.default;
     }
 
     return input;


### PR DESCRIPTION
Currently any falsy value of a default option will resolve to an empty string. This fixes this behavior.