### PR TITLE
BREAKING: Stop exporting core APIs from @inquirer/prompts

### DIFF
--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -78,7 +78,6 @@
   "dependencies": {
     "@inquirer/checkbox": "^2.2.3",
     "@inquirer/confirm": "^3.1.3",
-    "@inquirer/core": "^7.1.3",
     "@inquirer/editor": "^2.1.3",
     "@inquirer/expand": "^2.1.3",
     "@inquirer/input": "^2.1.3",

--- a/packages/prompts/src/index.mts
+++ b/packages/prompts/src/index.mts
@@ -7,5 +7,4 @@ import password from '@inquirer/password';
 import rawlist from '@inquirer/rawlist';
 import select from '@inquirer/select';
 
-export * from '@inquirer/core';
 export { checkbox, confirm, editor, expand, input, password, rawlist, select };

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,7 +498,6 @@ __metadata:
   dependencies:
     "@inquirer/checkbox": "npm:^2.2.3"
     "@inquirer/confirm": "npm:^3.1.3"
-    "@inquirer/core": "npm:^7.1.3"
     "@inquirer/editor": "npm:^2.1.3"
     "@inquirer/expand": "npm:^2.1.3"
     "@inquirer/input": "npm:^2.1.3"


### PR DESCRIPTION
Breaking change to `@inquirer/prompts` to stop exporting the core APIs from it.

This was proposed earlier by a PR, but it's been causing issue. Any breaking change to `@inquirer/core` becomes a breaking change to `@inquirer/prompts`, and for most users they'll only rely on prompts that receive UX upgrade.

So, I'm feeling pretty strongly about keeping both packages separated going forward.

1. Breaking changes to `@inquirer/core` are more frequent (larger API surface.) So they'll just be exposed to prompt authors. (as a proof, we're at v7 of `@inquirer/core`, vs v2 of most prompts)
2. Breaking changes to `@inquirer/prompts` means there's been a non-backward compatible change to a prompt public interface. Those are rare, so most of the time it'll be patch/minor updates to the UX that users will be able to bump worry free.

Leaving open a short while for review, but planning to release next week along #1381 (which introduce a breaking core change, but simple UX upgrade to all prompts.)