### PR TITLE
Feat(core): Allow useState/useRef to initialize empty

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
       }
     ],
     "no-eq-null": "off",
+    "no-redeclare": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -126,7 +126,7 @@ export default createPrompt(
 
     const [active, setActive] = useState(bounds.first);
     const [showHelpTip, setShowHelpTip] = useState(true);
-    const [errorMsg, setError] = useState<string | undefined>(undefined);
+    const [errorMsg, setError] = useState<string>();
 
     useKeypress(async (key) => {
       if (isEnterKey(key)) {

--- a/packages/core/src/lib/use-ref.mts
+++ b/packages/core/src/lib/use-ref.mts
@@ -1,5 +1,7 @@
 import { useState } from './use-state.mjs';
 
-export function useRef<Value>(val: Value): { current: Value } {
+export function useRef<Value>(val: Value): { current: Value };
+export function useRef<Value>(val?: Value): { current: Value | undefined };
+export function useRef<Value>(val: Value) {
   return useState({ current: val })[0];
 }

--- a/packages/core/src/lib/use-state.mts
+++ b/packages/core/src/lib/use-state.mts
@@ -4,7 +4,11 @@ type NotFunction<T> = T extends Function ? never : T;
 
 export function useState<Value>(
   defaultValue: NotFunction<Value> | (() => Value),
-): [Value, (newValue: Value) => void] {
+): [Value, (newValue: Value) => void];
+export function useState<Value>(
+  defaultValue?: NotFunction<Value> | (() => Value),
+): [Value | undefined, (newValue?: Value | undefined) => void];
+export function useState<Value>(defaultValue: NotFunction<Value> | (() => Value)) {
   return withPointer<Value, [Value, (newValue: Value) => void]>((pointer) => {
     const setFn = (newValue: Value) => {
       // Noop if the value is still the same.

--- a/packages/editor/src/index.mts
+++ b/packages/editor/src/index.mts
@@ -28,7 +28,7 @@ export default createPrompt<string, EditorConfig>((config, done) => {
 
   const [status, setStatus] = useState<string>('pending');
   const [value, setValue] = useState<string>(config.default || '');
-  const [errorMsg, setError] = useState<string | undefined>(undefined);
+  const [errorMsg, setError] = useState<string>();
 
   const isLoading = status === 'loading';
   const prefix = usePrefix({ isLoading, theme });

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -48,7 +48,7 @@ export default createPrompt<string, ExpandConfig>((config, done) => {
   const [status, setStatus] = useState<string>('pending');
   const [value, setValue] = useState<string>('');
   const [expanded, setExpanded] = useState<boolean>(defaultExpandState);
-  const [errorMsg, setError] = useState<string | undefined>(undefined);
+  const [errorMsg, setError] = useState<string>();
   const theme = makeTheme(config.theme);
   const prefix = usePrefix({ theme });
 

--- a/packages/input/src/index.mts
+++ b/packages/input/src/index.mts
@@ -22,10 +22,8 @@ export default createPrompt<string, InputConfig>((config, done) => {
   const { validate = () => true } = config;
   const theme = makeTheme(config.theme);
   const [status, setStatus] = useState<string>('pending');
-  const [defaultValue = '', setDefaultValue] = useState<string | undefined>(
-    config.default,
-  );
-  const [errorMsg, setError] = useState<string | undefined>(undefined);
+  const [defaultValue = '', setDefaultValue] = useState<string>(config.default);
+  const [errorMsg, setError] = useState<string>();
   const [value, setValue] = useState<string>('');
 
   const isLoading = status === 'loading';

--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -22,7 +22,7 @@ export default createPrompt<string, PasswordConfig>((config, done) => {
   const theme = makeTheme(config.theme);
 
   const [status, setStatus] = useState<string>('pending');
-  const [errorMsg, setError] = useState<string | undefined>(undefined);
+  const [errorMsg, setError] = useState<string>();
   const [value, setValue] = useState<string>('');
 
   const isLoading = status === 'loading';

--- a/packages/rawlist/src/index.mts
+++ b/packages/rawlist/src/index.mts
@@ -36,7 +36,7 @@ export default createPrompt(
     const { choices } = config;
     const [status, setStatus] = useState<string>('pending');
     const [value, setValue] = useState<string>('');
-    const [errorMsg, setError] = useState<string | undefined>(undefined);
+    const [errorMsg, setError] = useState<string>();
     const theme = makeTheme(config.theme);
     const prefix = usePrefix({ theme });
 

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -63,7 +63,7 @@ export default createPrompt(
     const theme = makeTheme<SelectTheme>(selectTheme, config.theme);
     const prefix = usePrefix({ theme });
     const [status, setStatus] = useState('pending');
-    const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
     const bounds = useMemo(() => {
       const first = items.findIndex(isSelectable);


### PR DESCRIPTION
Review the typing of `useState` and `useRef` to handle being implicitly empty. Empty initialization will not raise errors anymore, and it'll automatically assume the value can be undefined.

This allow to reduce boilerplate, and arguably leads to more idiomatic code.