### PR TITLE
chore(deps): Upgrade wrap-ansi to 9.0.0, remove @types/wrap-ansi

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,6 @@
     "@inquirer/type": "^1.3.1",
     "@types/mute-stream": "^0.0.4",
     "@types/node": "^20.12.8",
-    "@types/wrap-ansi": "^3.0.0",
     "ansi-escapes": "^4.3.2",
     "chalk": "^4.1.2",
     "cli-spinners": "^2.9.2",
@@ -69,7 +68,7 @@
     "mute-stream": "^1.0.0",
     "signal-exit": "^4.1.0",
     "strip-ansi": "^6.0.1",
-    "wrap-ansi": "^6.2.0"
+    "wrap-ansi": "^9.0.0"
   },
   "devDependencies": {
     "@inquirer/testing": "^2.1.18"

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -73,7 +73,7 @@
     "rxjs": "^7.8.1",
     "string-width": "^4.2.3",
     "strip-ansi": "^6.0.1",
-    "wrap-ansi": "^6.2.0"
+    "wrap-ansi": "^9.0.0"
   },
   "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/inquirer/README.md"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,7 +436,6 @@ __metadata:
     "@inquirer/type": "npm:^1.3.1"
     "@types/mute-stream": "npm:^0.0.4"
     "@types/node": "npm:^20.12.8"
-    "@types/wrap-ansi": "npm:^3.0.0"
     ansi-escapes: "npm:^4.3.2"
     chalk: "npm:^4.1.2"
     cli-spinners: "npm:^2.9.2"
@@ -444,7 +443,7 @@ __metadata:
     mute-stream: "npm:^1.0.0"
     signal-exit: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.1"
-    wrap-ansi: "npm:^6.2.0"
+    wrap-ansi: "npm:^9.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1463,13 +1462,6 @@ __metadata:
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
   checksum: 10/3496808818ddb36deabfe4974fd343a78101fa242c4690044ccdc3b95dcf8785b494f5d628f2f47f38a702f8db9c53c67f47d7818f2be1b79f2efb09692e1178
-  languageName: node
-  linkType: hard
-
-"@types/wrap-ansi@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/wrap-ansi@npm:3.0.0"
-  checksum: 10/8aa644946ca4e859668c36b8e2bcf2ac4bdee59dac760414730ea57be8a93ae9166ebd40a088f2ab714843aaea2a2a67f0e6e6ec11cfc9c8701b2466ca1c4089
   languageName: node
   linkType: hard
 
@@ -4395,7 +4387,7 @@ __metadata:
     string-width: "npm:^4.2.3"
     strip-ansi: "npm:^6.0.1"
     terminal-link: "npm:^3.0.0"
-    wrap-ansi: "npm:^6.2.0"
+    wrap-ansi: "npm:^9.0.0"
   languageName: unknown
   linkType: soft
 
@@ -8424,17 +8416,6 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10/cebdaeca3a6880da410f75209e68cd05428580de5ad24535f22696d7d9cab134d1f8498599f344c3cf0fb37c1715807a183778d8c648d6cc0cb5ff2bb4236540
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "wrap-ansi@npm:6.2.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10/0d64f2d438e0b555e693b95aee7b2689a12c3be5ac458192a1ce28f542a6e9e59ddfecc37520910c2c88eb1f82a5411260566dba5064e8f9895e76e169e76187
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates `wrap-ansi` to the latest version, which includes types, and removes `@types/wrap-ansi`. 

Context: https://github.com/donmccurdy/glTF-Transform/issues/1201

Thank you!