### PR TITLE
Fix: checkbox icon theming

### DIFF
--- a/packages/checkbox/checkbox.test.mts
+++ b/packages/checkbox/checkbox.test.mts
@@ -672,6 +672,59 @@ describe('checkbox prompt', () => {
     await expect(answer).resolves.toEqual([1]);
   });
 
+  describe('theme: icon', () => {
+    it('checked/unchecked', async () => {
+      const { answer, events, getScreen } = await render(checkbox, {
+        message: 'Select a number',
+        choices: numberedChoices,
+        theme: {
+          icon: {
+            checked: '√',
+            unchecked: 'x',
+          },
+        },
+      });
+      events.keypress('space');
+      expect(getScreen()).toMatchInlineSnapshot(`
+        "? Select a number
+        ❯√ 1
+         x 2
+         x 3
+         x 4
+         x 5
+         x 6
+         x 7"
+      `);
+      events.keypress('enter');
+      await answer;
+    });
+
+    it('cursor', async () => {
+      const { answer, events, getScreen } = await render(checkbox, {
+        message: 'Select a number',
+        choices: numberedChoices,
+        theme: {
+          icon: {
+            cursor: '>',
+          },
+        },
+      });
+      events.keypress('space');
+      expect(getScreen()).toMatchInlineSnapshot(`
+        "? Select a number
+        >◉ 1
+         ◯ 2
+         ◯ 3
+         ◯ 4
+         ◯ 5
+         ◯ 6
+         ◯ 7"
+      `);
+      events.keypress('enter');
+      await answer;
+    });
+  });
+
   describe('theme: style.renderSelectedChoices', () => {
     it('renderSelectedChoices', async () => {
       const { answer, events, getScreen } = await render(checkbox, {

--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -103,7 +103,9 @@ export default createPrompt(
       required,
       validate = () => true,
     } = config;
-    const theme = makeTheme<CheckboxTheme>(checkboxTheme, config.theme);
+    const theme = makeTheme<CheckboxTheme>(checkboxTheme, config.theme, {
+      icon: Object.assign({}, checkboxTheme.icon, config.theme?.icon),
+    });
     const prefix = usePrefix({ theme });
     const firstRender = useRef(true);
     const [status, setStatus] = useState('pending');


### PR DESCRIPTION
When setting the icon for a checkbox:
```ts
const { answer, events, getScreen } = await render(checkbox, {
  message: 'Select a number',
  choices: numberedChoices,
  theme: {
    icon: {
      checked: '√',
      unchecked: 'x',
    },
  },
});
```
If only partial values are passed in, it will result in the cursor becoming undefined.
```
? Select a number
undefined√ 1
 x 2
 x 3
 x 4
 x 5
 x 6
 x 7
```
This is primarily because `makeTheme` only performs a deep merge on the `style`.
