### PR TITLE
Fix: Open editor with default value

### DIFF
--- a/packages/inquirer/examples/editor.js
+++ b/packages/inquirer/examples/editor.js
@@ -18,6 +18,13 @@ const questions = [
     },
     waitUserInput: true,
   },
+  {
+    type: 'editor',
+    name: 'edition',
+    message: 'Edit the following content.',
+    default: 'Hello, World!',
+    waitUserInput: false,
+  },
 ];
 
 inquirer.prompt(questions).then((answers) => {

--- a/packages/inquirer/lib/prompts/editor.js
+++ b/packages/inquirer/lib/prompts/editor.js
@@ -26,10 +26,6 @@ export default class EditorPrompt extends Base {
     const waitUserInput =
       this.opt.waitUserInput === undefined ? true : this.opt.waitUserInput;
 
-    if (!waitUserInput) {
-      this.startExternalEditor();
-    }
-
     // Trigger Validation when editor closes
     const validation = this.handleSubmitEvents(this.editorResult);
     validation.success.forEach(this.onEnd.bind(this));
@@ -40,7 +36,11 @@ export default class EditorPrompt extends Base {
     this.opt.default = null;
 
     // Init
-    this.render();
+    if (waitUserInput) {
+      this.render();
+    } else {
+      this.startExternalEditor();
+    }
 
     return this;
   }

--- a/packages/inquirer/test/specs/prompts/editor.test.js
+++ b/packages/inquirer/test/specs/prompts/editor.test.js
@@ -9,15 +9,17 @@ const defaultVisual = process.env.VISUAL;
 
 const require = createRequire(import.meta.url);
 const writeBin = require.resolve('../../bin/write.js');
-const expectedAnswer = 'testing';
 
-describe('`editor` prompt', () => {
+describe.each([
+  { message: 'testing', expectedAnswer: 'testing' },
+  { message: '', expectedAnswer: fixtures.editor.default },
+])('`editor` prompt', ({ message, expectedAnswer }) => {
   let fixture;
   let rl;
 
   beforeEach(() => {
-    // Writes the word "testing" to the file
-    process.env.VISUAL = `node ${writeBin} ${expectedAnswer}`;
+    // If supplied, overwrites the file with message
+    process.env.VISUAL = `node ${writeBin} ${message}`;
 
     fixture = { ...fixtures.editor };
     rl = new ReadlineStub();


### PR DESCRIPTION
### Description

Fixes #1405, reverting the bugs introduced in [8328d65](https://github.com/SBoudrias/Inquirer.js/commit/8328d659466cce33f0f9171c9daf30927fa7de0d#diff-479a1e309f0fe42c909aa27d39f3e841147f0ea568e4238bf3635c457171b65aR29-R31) (the editor opens without defaults, and Inquirer renders text on top of in-terminal editors such as `vi`). 

### Changes Made

The editor now opens only after `this.currentText` has been set, and the initial render does not occur if `waitUserInput` is false.

### Testing

The previous tests for the editor prompt do not make use of the `default` property set in the editor fixture.  The message written to the temporary file and its expected contents are turned into test parameters `message` and `expectedAnswer`, respectively. Two additional test cases are added in which the test editor `writeBin` is called without the final argument (`message = ''`), which should leave the contents of the file untouched.  