### PR TITLE
fix(password): ensure consistency in prompt appearence

### DIFF
--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -75,5 +75,5 @@ export default createPrompt<string, PasswordConfig>((config, done) => {
     error = theme.style.error(errorMsg);
   }
 
-  return [[prefix, message, formattedValue, helpTip].filter(Boolean).join(' '), error];
+  return [[prefix, message, config.mask ? formattedValue : helpTip].join(' '), error];
 });


### PR DESCRIPTION
This PR fixes a small inconsistency in the presentation of the password prompt.

In the previous implementation, the prompt was missing a space between the message and the value, when the value was empty.
This fixes that and also makes sure that if you use do not pass a mask there is not an additional space between the message and the helpTip

This ensures that the password prompt is consistent with the input prompt (which already implements a similar fix), and ensures that it is consistent with how the password prompt appeared before the "style customization" update (ex. v1.1.15)