### PR TITLE
Docs(inquirer): Link to new version on old version's README

### DIFF
--- a/packages/inquirer/README.md
+++ b/packages/inquirer/README.md
@@ -7,6 +7,10 @@
 
 A collection of common interactive command line user interfaces.
 
+### Note:
+
+> This is the legacy version of Inquirer.js. While it still receives maintenance, it is not actively developed. For the new Inquirer, see [@inquirer/prompts](https://www.npmjs.com/package/@inquirer/prompts).
+
 ## Table of Contents
 
 1.  [Documentation](#documentation)


### PR DESCRIPTION
The new Inquirer package links to the old one, but as far as I can tell, the old one doesn't link to the new one.

Since the old package is still quite popular, it's probably a good idea to mention it isn't being actively developed anymore.