### PR TITLE
Chore(testing): Typecheck test files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,10 @@ jobs:
           node-version: 20
           cache: 'yarn'
       - run: yarn install --immutable --immutable-cache
-      - name: Typescript
-        run: yarn turbo tsc
+      - name: Typescript - packages
+        run: yarn tsc
+      - name: Typescript - test files
+        run: yarn tsc:test
       - name: Eslint
         run: yarn eslint .
       - name: Validate package setup
@@ -63,7 +65,7 @@ jobs:
           cache: 'yarn'
       - run: yarn install --immutable --immutable-cache
       - name: Typescript
-        run: yarn turbo tsc
+        run: yarn tsc
       - name: Integration tests
         run: yarn node --test integration/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,14 +56,14 @@ yarn prettier --write .
 ## Type checking
 
 ```sh
-yarn turbo tsc
+yarn tsc
 ```
 
 ## Running demos
 
 ```sh
-# First you need to build the prompts; and every time you change code.
-yarn turbo tsc
+# This command will launch tsc in watch mode
+yarn dev
 
 # Then run the demos
 yarn node packages/demo

--- a/package.json
+++ b/package.json
@@ -82,7 +82,11 @@
     "prepare": "husky && turbo tsc attw",
     "setup": "node ./tools/setup-packages.mjs",
     "pretest": "eslint . && turbo tsc",
-    "test": "vitest --run packages && node --test integration/**/*.test.*"
+    "test": "vitest --run packages && node --test integration/**/*.test.*",
+    "dev": "turbo tsc:watch --concurrency 17",
+    "tsc": "turbo tsc",
+    "tsc:test": "tsc -p tsconfig.test.json",
+    "tsc:watch": "tsc -p tsconfig.test.json --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/checkbox/checkbox.test.mts
+++ b/packages/checkbox/checkbox.test.mts
@@ -644,7 +644,7 @@ describe('checkbox prompt', () => {
     const { answer, events, getScreen } = await render(checkbox, {
       message: 'Select a number',
       choices: numberedChoices,
-      validate(items: ReadonlyArray<unknown>) {
+      validate: (items: ReadonlyArray<unknown>) => {
         if (items.length !== 1) {
           return 'Please select only one choice';
         }
@@ -732,9 +732,9 @@ describe('checkbox prompt', () => {
         choices: numberedChoices,
         theme: {
           style: {
-            renderSelectedChoices(selected: { value: number }[]) {
+            renderSelectedChoices: (selected: { value: number }[]) => {
               if (selected.length > 1) {
-                return `You have selected ${selected[0].value} and ${selected.length - 1} more.`;
+                return `You have selected ${(selected[0] as { value: number }).value} and ${selected.length - 1} more.`;
               }
               return `You have selected ${selected
                 .slice(0, 1)
@@ -764,10 +764,10 @@ describe('checkbox prompt', () => {
         choices: numberedChoices,
         theme: {
           style: {
-            renderSelectedChoices(
+            renderSelectedChoices: (
               selected: { value: number }[],
               all: ({ value: number } | Separator)[],
-            ) {
+            ) => {
               return `You have selected ${selected.length} out of ${all.length} options.`;
             },
           },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -70,7 +70,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/confirm/confirm.test.mts
+++ b/packages/confirm/confirm.test.mts
@@ -113,7 +113,7 @@ describe('confirm prompt', () => {
   it('supports transformer option', async () => {
     const { answer, events, getScreen } = await render(confirm, {
       message: 'Do you want to proceed?',
-      transformer: (value) => (value ? 'Oui!' : 'Oh non!'),
+      transformer: (value: boolean) => (value ? 'Oui!' : 'Oh non!'),
     });
 
     expect(getScreen()).toMatchInlineSnapshot('"? Do you want to proceed? (Y/n)"');

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -64,7 +64,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/core/core.test.mts
+++ b/packages/core/core.test.mts
@@ -54,7 +54,7 @@ describe('createPrompt()', () => {
   });
 
   it('useEffect: works with setting state at once with objects', async () => {
-    const Prompt = (config: { message: string }, done: (value: string) => void) => {
+    const Prompt = (_config: { message: string }, done: (value: string) => void) => {
       const [value, setValue] = useState([1, 2]);
 
       useEffect(() => {
@@ -518,7 +518,7 @@ describe('Error handling', () => {
   });
 
   it('surface errors in useEffect cleanup functions', async () => {
-    const Prompt = (config: object, done: (value: string) => void) => {
+    const Prompt = (_config: object, done: (value: string) => void) => {
       useEffect(() => {
         done('done');
 
@@ -537,7 +537,7 @@ describe('Error handling', () => {
   });
 
   it('prevent returning promises from useEffect hook', async () => {
-    const Prompt = (config: object, done: (value: string) => void) => {
+    const Prompt = (_config: object, done: (value: string) => void) => {
       // @ts-expect-error: Testing an invalid behavior.
       useEffect(async () => {
         done('done');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/core/src/lib/pagination/lines.test.mts
+++ b/packages/core/src/lib/pagination/lines.test.mts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { lines } from './lines.mjs';
 
-function renderResult(result) {
+function renderResult(result: string[]) {
   return `\n${result.join('\n')}\n`;
 }
 

--- a/packages/editor/editor.test.mts
+++ b/packages/editor/editor.test.mts
@@ -73,7 +73,7 @@ describe('editor prompt', () => {
   it('handles validation', async () => {
     const { answer, events, getScreen } = await render(editor, {
       message: 'Add a description',
-      validate(value) {
+      validate: (value: string) => {
         switch (value) {
           case '1': {
             return true;

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -65,7 +65,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -65,7 +65,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/figures/package.json
+++ b/packages/figures/package.json
@@ -58,7 +58,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "engines": {

--- a/packages/input/input.test.mts
+++ b/packages/input/input.test.mts
@@ -23,7 +23,8 @@ describe('input prompt', () => {
   it('handle transformer', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'What is your name',
-      transformer: (value, { isFinal }) => (isFinal ? 'Transformed' : `t+${value}`),
+      transformer: (value: string, { isFinal }: { isFinal: boolean }) =>
+        isFinal ? 'Transformed' : `t+${value}`,
     });
 
     expect(getScreen()).toMatchInlineSnapshot(`"? What is your name t+"`);
@@ -39,7 +40,7 @@ describe('input prompt', () => {
   it('handle synchronous validation', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'Answer 2 ===',
-      validate: (value) => value === '2',
+      validate: (value: string) => value === '2',
     });
 
     expect(getScreen()).toMatchInlineSnapshot(`"? Answer 2 ==="`);
@@ -65,8 +66,8 @@ describe('input prompt', () => {
   it('handle asynchronous validation', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'Answer 2 ===',
-      validate(value) {
-        return new Promise((resolve) => {
+      validate: (value: string) => {
+        return new Promise<string | boolean>((resolve) => {
           if (value === '2') {
             resolve(true);
           } else {
@@ -198,13 +199,13 @@ describe('input prompt', () => {
   it('is theme-able', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'Answer must be: 2',
-      validate: (value) => value === '2',
+      validate: (value?: string) => value === '2',
       theme: {
         prefix: 'Q:',
         style: {
-          message: (text) => `${text} ===`,
-          error: (text) => `!! ${text} !!`,
-          answer: (text) => `_${text}_`,
+          message: (text: string) => `${text} ===`,
+          error: (text: string) => `!! ${text} !!`,
+          answer: (text: string) => `_${text}_`,
         },
       },
     });

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -64,7 +64,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -69,7 +69,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "exports": {

--- a/packages/number/number.test.mts
+++ b/packages/number/number.test.mts
@@ -156,7 +156,7 @@ describe('number prompt', () => {
   it('handle synchronous validation', async () => {
     const { answer, events, getScreen } = await render(number, {
       message: 'Answer 2 ===',
-      validate: (value) => value === 2,
+      validate: (value?: number) => value === 2,
     });
 
     expect(getScreen()).toMatchInlineSnapshot(`"? Answer 2 ==="`);
@@ -182,8 +182,8 @@ describe('number prompt', () => {
   it('handle asynchronous validation', async () => {
     const { answer, events, getScreen } = await render(number, {
       message: 'Answer 2 ===',
-      validate(value) {
-        return new Promise((resolve) => {
+      validate: (value?: number) => {
+        return new Promise<string | boolean>((resolve) => {
           if (value === 2) {
             resolve(true);
           } else {
@@ -320,13 +320,13 @@ describe('number prompt', () => {
   it('is theme-able', async () => {
     const { answer, events, getScreen } = await render(number, {
       message: 'Answer must be: 2',
-      validate: (value) => value === 2,
+      validate: (value?: number) => value === 2,
       theme: {
         prefix: 'Q:',
         style: {
-          message: (text) => `${text} ===`,
-          error: (text) => `!! ${text} !!`,
-          answer: (text) => `_${text}_`,
+          message: (text: string) => `${text} ===`,
+          error: (text: string) => `!! ${text} !!`,
+          answer: (text: string) => `_${text}_`,
         },
       },
     });

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -64,7 +64,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -68,7 +68,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/password/password.test.mts
+++ b/packages/password/password.test.mts
@@ -64,7 +64,7 @@ describe('password prompt', () => {
     const { answer, events, getScreen } = await render(password, {
       message: 'Enter your password',
       mask: true,
-      validate: (value) => value.length >= 8,
+      validate: (value: string) => value.length >= 8,
     });
 
     expect(getScreen()).toMatchInlineSnapshot(`"? Enter your password"`);

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -58,7 +58,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "engines": {

--- a/packages/prompts/prompts.test.mts
+++ b/packages/prompts/prompts.test.mts
@@ -29,9 +29,11 @@ describe('@inquirer/prompts', () => {
 /**
  * Type assertions to validate the interfaces.
  */
-Expect<
-  Equal<
-    Parameters<typeof checkbox>[0]['theme']['helpMode'],
-    Parameters<typeof select>[0]['theme']['helpMode']
-  >
->;
+export interface Test {
+  1: Expect<
+    Equal<
+      NonNullable<Parameters<typeof checkbox>[0]['theme']>['helpMode'],
+      NonNullable<Parameters<typeof select>[0]['theme']>['helpMode']
+    >
+  >;
+}

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -65,7 +65,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -67,7 +67,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "publishConfig": {

--- a/packages/select/select.test.mts
+++ b/packages/select/select.test.mts
@@ -16,7 +16,7 @@ const numberedChoices = [
   { value: 10 },
   { value: 11 },
   { value: 12 },
-];
+] as const;
 
 afterEach(() => {
   vi.useRealTimers();

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -71,7 +71,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "exports": {

--- a/packages/testing/src/index.mts
+++ b/packages/testing/src/index.mts
@@ -2,7 +2,7 @@ import { Stream } from 'node:stream';
 import MuteStream from 'mute-stream';
 import stripAnsi from 'strip-ansi';
 import ansiEscapes from 'ansi-escapes';
-import type { Prompt } from '@inquirer/type';
+import type { Prompt, Context } from '@inquirer/type';
 
 const ignoredAnsi = new Set([ansiEscapes.cursorHide, ansiEscapes.cursorShow]);
 
@@ -42,11 +42,11 @@ class BufferedStream extends Stream.Writable {
   }
 }
 
-export async function render<TestedPrompt extends Prompt<unknown, unknown>>(
-  prompt: TestedPrompt,
-  props: Parameters<TestedPrompt>[0],
-  options?: Parameters<TestedPrompt>[1],
-) {
+export async function render<
+  const Props,
+  const Value,
+  const TestedPrompt extends Prompt<Value, Props>,
+>(prompt: TestedPrompt, props: Props, options?: Context) {
   const input = new MuteStream();
   input.unmute();
 

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -61,7 +61,7 @@
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",
     "tsc:esm": "rm -rf dist/esm && tsc -p ./tsconfig.json",
     "tsc:cjs": "rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs",
-    "dev": "tsc -p ./tsconfig.json --watch",
+    "tsc:watch": "tsc -p ./tsconfig.json --watch",
     "attw": "attw --pack"
   },
   "engines": {

--- a/tools/setup-packages.mjs
+++ b/tools/setup-packages.mjs
@@ -94,7 +94,7 @@ paths.forEach(async (pkgPath) => {
       'tsc:esm': 'rm -rf dist/esm && tsc -p ./tsconfig.json',
       'tsc:cjs':
         'rm -rf dist/cjs && tsc -p ./tsconfig.cjs.json && node ../../tools/fix-ext.mjs',
-      dev: 'tsc -p ./tsconfig.json --watch',
+      'tsc:watch': 'tsc -p ./tsconfig.json --watch',
       attw: emitDeclaration ? 'attw --pack' : undefined,
     };
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.test.mts"],
+  "exclude": ["packages/inquirer/test/**"],
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "target": "es2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true,
+    "noEmit": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,16 +1,20 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
+    "attw": {
+      "dependsOn": ["tsc"],
+      "outputs": []
+    },
     "tsc": {
       "dependsOn": ["^tsc"],
       "outputs": ["dist/**"],
       "inputs": ["$TURBO_DEFAULT$", "../../tools/fix-ext.mjs", "../../tsconfig.json"]
     },
-    "attw": {
-      "dependsOn": ["tsc"],
-      "outputs": []
+    "tsc:watch": {
+      "cache": false,
+      "persistent": true
     },
-    "dev": {
+    "//#tsc:watch": {
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
Updating build to include typecheck of test files. Fix type errors.

Also fix `@inquirer/testing` to use const types generic (making it much easier to pass in partial themes arguments.)

Lastly, added utility `yarn dev` to watch types while working.