### PR TITLE
Fix references to default branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,10 +8,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ['master']
+    branches: ['main']
   schedule:
     - cron: '35 6 * * 0'
 

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -55,7 +55,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/checkbox/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/checkbox/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/figures": "^1.0.4",

--- a/packages/confirm/package.json
+++ b/packages/confirm/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/confirm/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/confirm/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -79,14 +79,14 @@ const answer = await confirm({ message: 'Do you want to continue?' });
 
 See more examples:
 
-- [Confirm Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/confirm/src/index.mts)
-- [Input Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/input/src/index.mts)
-- [Password Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/password/src/index.mts)
-- [Editor Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/editor/src/index.mts)
-- [Select Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/select/src/index.mts)
-- [Checkbox Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/checkbox/src/index.mts)
-- [Rawlist Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/rawlist/src/index.mts)
-- [Expand Prompt](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/expand/src/index.mts)
+- [Confirm Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/confirm/src/index.mts)
+- [Input Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/input/src/index.mts)
+- [Password Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/password/src/index.mts)
+- [Editor Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/editor/src/index.mts)
+- [Select Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/select/src/index.mts)
+- [Checkbox Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/checkbox/src/index.mts)
+- [Rawlist Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/rawlist/src/index.mts)
+- [Expand Prompt](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/expand/src/index.mts)
 
 ## API
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/core/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/core/README.md",
   "dependencies": {
     "@inquirer/figures": "^1.0.4",
     "@inquirer/type": "^1.5.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/editor/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/editor/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0",

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/expand/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/expand/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/input/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/input/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0"

--- a/packages/inquirer/README.md
+++ b/packages/inquirer/README.md
@@ -1,4 +1,4 @@
-<img width="75px" height="75px" align="right" alt="Inquirer Logo" src="https://raw.githubusercontent.com/SBoudrias/Inquirer.js/master/assets/inquirer_readme.svg?sanitize=true" title="Inquirer.js"/>
+<img width="75px" height="75px" align="right" alt="Inquirer Logo" src="https://raw.githubusercontent.com/SBoudrias/Inquirer.js/main/assets/inquirer_readme.svg?sanitize=true" title="Inquirer.js"/>
 
 # Inquirer.js
 
@@ -98,7 +98,7 @@ inquirer
 
 ### Examples (Run it and see it)
 
-Check out the [`packages/inquirer/examples/`](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/inquirer/examples) folder for code and interface examples.
+Check out the [`packages/inquirer/examples/`](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/inquirer/examples) folder for code and interface examples.
 
 ```shell
 yarn node packages/inquirer/examples/pizza.js
@@ -421,7 +421,7 @@ Licensed under the MIT license.
 
 <a name="plugins"></a>
 
-You can build custom prompts, or use open sourced ones. See [`@inquirer/core` documentation for building custom prompts](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/core).
+You can build custom prompts, or use open sourced ones. See [`@inquirer/core` documentation for building custom prompts](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/core).
 
 You can either call the custom prompts directly (preferred), or you can register them (depreciated):
 

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -63,7 +63,7 @@
     "run-async": "^3.0.0",
     "rxjs": "^7.8.1"
   },
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/inquirer/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/inquirer/README.md",
   "sideEffects": false,
   "scripts": {
     "tsc": "yarn run tsc:esm && yarn run tsc:cjs",

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/number/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/number/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -55,7 +55,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/password/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/password/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0",

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -1,4 +1,4 @@
-<img width="75px" height="75px" align="right" alt="Inquirer Logo" src="https://raw.githubusercontent.com/SBoudrias/Inquirer.js/master/assets/inquirer_readme.svg?sanitize=true" title="Inquirer.js"/>
+<img width="75px" height="75px" align="right" alt="Inquirer Logo" src="https://raw.githubusercontent.com/SBoudrias/Inquirer.js/main/assets/inquirer_readme.svg?sanitize=true" title="Inquirer.js"/>
 
 # Inquirer
 
@@ -41,7 +41,7 @@ yarn add @inquirer/prompts
 </table>
 
 > [!NOTE]
-> Inquirer recently underwent a rewrite from the ground up to reduce the package size and improve performance. The previous version of the package is still maintained (though not actively developed), and offered hundreds of community contributed prompts that might not have been migrated to the latest API. If this is what you're looking for, the [previous package is over here](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/inquirer).
+> Inquirer recently underwent a rewrite from the ground up to reduce the package size and improve performance. The previous version of the package is still maintained (though not actively developed), and offered hundreds of community contributed prompts that might not have been migrated to the latest API. If this is what you're looking for, the [previous package is over here](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/inquirer).
 
 # Usage
 
@@ -53,7 +53,7 @@ const answer = await input({ message: 'Enter your name' });
 
 # Prompts
 
-## [Input](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/input)
+## [Input](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/input)
 
 ![Input prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/input.svg)
 
@@ -61,9 +61,9 @@ const answer = await input({ message: 'Enter your name' });
 import { input } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/input) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/input) for usage example and options documentation.
 
-## [Select](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/select)
+## [Select](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/select)
 
 ![Select prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/list.svg)
 
@@ -71,9 +71,9 @@ import { input } from '@inquirer/prompts';
 import { select } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/select) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/select) for usage example and options documentation.
 
-## [Checkbox](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/checkbox)
+## [Checkbox](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/checkbox)
 
 ![Checkbox prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/checkbox.svg)
 
@@ -81,9 +81,9 @@ import { select } from '@inquirer/prompts';
 import { checkbox } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/checkbox) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/checkbox) for usage example and options documentation.
 
-## [Confirm](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/confirm)
+## [Confirm](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/confirm)
 
 ![Confirm prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/confirm.svg)
 
@@ -91,9 +91,9 @@ import { checkbox } from '@inquirer/prompts';
 import { confirm } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/confirm) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/confirm) for usage example and options documentation.
 
-## [Password](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/password)
+## [Password](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/password)
 
 ![Password prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/password.svg)
 
@@ -101,9 +101,9 @@ import { confirm } from '@inquirer/prompts';
 import { password } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/password) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/password) for usage example and options documentation.
 
-## [Expand](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/expand)
+## [Expand](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/expand)
 
 ![Expand prompt closed](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/expand-y.svg)
 ![Expand prompt expanded](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/expand-d.svg)
@@ -112,9 +112,9 @@ import { password } from '@inquirer/prompts';
 import { expand } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/expand) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/expand) for usage example and options documentation.
 
-## [Editor](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/editor)
+## [Editor](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/editor)
 
 Launches an instance of the users preferred editor on a temporary file. Once the user exits their editor, the content of the temporary file is read as the answer. The editor used is determined by reading the $VISUAL or $EDITOR environment variables. If neither of those are present, the OS default is used (notepad on Windows, vim on Mac or Linux.)
 
@@ -122,9 +122,9 @@ Launches an instance of the users preferred editor on a temporary file. Once the
 import { editor } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/editor) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/editor) for usage example and options documentation.
 
-## [Number](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/number)
+## [Number](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/number)
 
 Very similar to the `input` prompt, but with built-in number validation configuration option.
 
@@ -132,9 +132,9 @@ Very similar to the `input` prompt, but with built-in number validation configur
 import { number } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/number) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/number) for usage example and options documentation.
 
-## [Raw List](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/rawlist)
+## [Raw List](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/rawlist)
 
 ![Raw list prompt](https://cdn.rawgit.com/SBoudrias/Inquirer.js/28ae8337ba51d93e359ef4f7ee24e79b69898962/assets/screenshots/rawlist.svg)
 
@@ -142,11 +142,11 @@ import { number } from '@inquirer/prompts';
 import { rawlist } from '@inquirer/prompts';
 ```
 
-[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/rawlist) for usage example and options documentation.
+[See documentation](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/rawlist) for usage example and options documentation.
 
 # Create your own prompts
 
-The [API documentation is over here](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/core), and our [testing utilities here](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/testing).
+The [API documentation is over here](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/core), and our [testing utilities here](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/testing).
 
 # Advanced usage
 
@@ -284,7 +284,7 @@ const answer = await confirm({ message: await getMessage() });
 
 # Community prompts
 
-If you created a cool prompt, [send us a PR adding it](https://github.com/SBoudrias/Inquirer.js/edit/master/README.md) to the list below!
+If you created a cool prompt, [send us a PR adding it](https://github.com/SBoudrias/Inquirer.js/edit/main/README.md) to the list below!
 
 [**Interactive List Prompt**](https://github.com/pgibler/inquirer-interactive-list-prompt)<br/>
 Select a choice either with arrow keys + Enter or by pressing a key associated with a choice.

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -90,6 +90,6 @@
   "devDependencies": {
     "@inquirer/type": "^1.5.0"
   },
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/prompts/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/prompts/README.md",
   "sideEffects": false
 }

--- a/packages/rawlist/package.json
+++ b/packages/rawlist/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/rawlist/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/rawlist/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/type": "^1.5.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -52,7 +52,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/select/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/select/README.md",
   "dependencies": {
     "@inquirer/core": "^9.0.3",
     "@inquirer/figures": "^1.0.4",

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,6 +1,6 @@
 # `@inquirer/testing`
 
-The `@inquirer/testing` package is Inquirer's answer to testing prompts [built with `@inquirer/core`](https://github.com/SBoudrias/Inquirer.js/tree/master/packages/core).
+The `@inquirer/testing` package is Inquirer's answer to testing prompts [built with `@inquirer/core`](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/core).
 
 # Installation
 
@@ -72,7 +72,7 @@ The core utility of `@inquirer/testing` is the `render()` function. This `render
 3. `events` (`{ keypress: (name | Key) => void, type: (string) => void }`) Is the utilities allowing you to interact with the prompt. Use it to trigger keypress events, or typing any input.
 4. `getFullOutput` (`() => string`) Return a raw dump of everything that got sent on the output stream.
 
-You can refer to [the `@inquirer/input` prompt test suite](https://github.com/SBoudrias/Inquirer.js/blob/master/packages/input/input.test.mts) as a practical example.
+You can refer to [the `@inquirer/input` prompt test suite](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/input/input.test.mts) as a practical example.
 
 # License
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -58,7 +58,7 @@
   ],
   "author": "Simon Boudrias <admin@simonboudrias.com>",
   "license": "MIT",
-  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/master/packages/testing/README.md",
+  "homepage": "https://github.com/SBoudrias/Inquirer.js/blob/main/packages/testing/README.md",
   "dependencies": {
     "@inquirer/type": "^1.5.0",
     "@types/mute-stream": "^0.0.4",

--- a/tools/setup-packages.mjs
+++ b/tools/setup-packages.mjs
@@ -49,7 +49,7 @@ paths.forEach(async (pkgPath) => {
 
   if (hasReadme) {
     const repoPath = dir.split('/').slice(-2).join('/');
-    pkg.homepage = `https://github.com/SBoudrias/Inquirer.js/blob/master/${repoPath}/README.md`;
+    pkg.homepage = `https://github.com/SBoudrias/Inquirer.js/blob/main/${repoPath}/README.md`;
   }
 
   if (!('sideEffects' in pkg)) {


### PR DESCRIPTION
# What

Replace references to master branch with main branch.

# Why

The default branch seems to have been renamed from master branch to main branch. However, some references are untouched and broken (e.g., "send us a PR adding it" link). This change replaces all occurrences of "master" with "main" except for other projects in ./packages/inquirer/README.md and screenshots under ./assets/screenshots.

# How tested

- [x] No master branch URL.

```bash
$ git grep -e 'SBoudrias/Inquirer.js/.*/main' --name-only /workspaces/Inquirer.js | wc -l
18

$ git grep -e 'SBoudrias/Inquirer.js/.*/master' --name-only /workspaces/Inquirer.js | wc -l
0
```

- [x] All remaining "master" refer to other projects.

```bash
$ git grep -e 'master' /workspaces/Inquirer.js ':!*.svg' | cat 
packages/inquirer/README.md:![autocomplete prompt](https://raw.githubusercontent.com/mokkabonna/inquirer-autocomplete-prompt/master/packages/inquirer-autocomplete-prompt/inquirer.gif)
packages/inquirer/README.md:![checkbox-plus](https://github.com/faressoft/inquirer-checkbox-plus-prompt/raw/master/demo.gif)
packages/inquirer/README.md:![Date Prompt](https://github.com/haversnail/inquirer-date-prompt/raw/master/examples/demo.gif)
packages/inquirer/README.md:![Datetime Prompt](https://github.com/DerekTBrown/inquirer-datepicker-prompt/raw/master/example/datetime-prompt.png)
packages/inquirer/README.md:![inquirer-fuzzy-path](https://raw.githubusercontent.com/adelsz/inquirer-fuzzy-path/master/recording.gif)
packages/inquirer/README.md:![inquirer-emoji](https://github.com/tannerntannern/inquirer-emoji/raw/master/demo.gif)
packages/inquirer/README.md:![inquirer-search-checkbox](https://github.com/clinyong/inquirer-search-checkbox/blob/master/screenshot.png)
packages/inquirer/README.md:![inquirer-search-list](https://github.com/robin-rpr/inquirer-search-list/blob/master/preview.gif)
packages/inquirer/README.md:![inquirer-s3](https://github.com/HQarroum/inquirer-s3/raw/master/docs/inquirer-screenshot.png)
packages/inquirer/README.md:![inquirer-file-tree-selection-prompt](https://github.com/anc95/inquirer-file-tree-selection/blob/master/example/screenshot.gif)
packages/inquirer/README.md:![inquirer-table-prompt](https://raw.githubusercontent.com/eduardoboucas/inquirer-table-prompt/master/screen-capture.gif)
packages/inquirer/README.md:![inquirer-table-prompt](https://raw.githubusercontent.com/edelciomolina/inquirer-table-input/master/screen-capture.gif)
packages/inquirer/README.md:![inquirer-interrupted-prompt](https://raw.githubusercontent.com/lnquy065/inquirer-interrupted-prompt/master/example/demo-menu.gif)
```