### PR TITLE
Chore(documentation): Update install and usage instructions to suggest @inquirer/prompts first

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -15,6 +15,25 @@ Simple interactive command line prompt to display a list of checkboxes (multi se
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/checkbox
 ```
 
@@ -32,7 +51,9 @@ yarn add @inquirer/checkbox
 # Usage
 
 ```js
-import checkbox, { Separator } from '@inquirer/checkbox';
+import { checkbox, Separator } from '@inquirer/prompts';
+// Or
+// import checkbox, { Separator } from '@inquirer/checkbox';
 
 const answer = await checkbox({
   message: 'Select a package manager',

--- a/packages/confirm/README.md
+++ b/packages/confirm/README.md
@@ -15,6 +15,25 @@ Simple interactive command line prompt to gather boolean input from users.
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/confirm
 ```
 
@@ -32,7 +51,9 @@ yarn add @inquirer/confirm
 # Usage
 
 ```js
-import confirm from '@inquirer/confirm';
+import { confirm } from '@inquirer/prompts';
+// Or
+// import confirm from '@inquirer/confirm';
 
 const answer = await confirm({ message: 'Continue?' });
 ```

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -13,6 +13,25 @@ Prompt that'll open the user preferred editor with default content and allow for
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/editor
 ```
 
@@ -30,7 +49,9 @@ yarn add @inquirer/editor
 # Usage
 
 ```js
-import editor from '@inquirer/editor';
+import { editor } from '@inquirer/prompts';
+// Or
+// import editor from '@inquirer/editor';
 
 const answer = await editor({
   message: 'Enter a description',

--- a/packages/expand/README.md
+++ b/packages/expand/README.md
@@ -16,6 +16,25 @@ Compact single select prompt. Every option is assigned a shortcut key, and selec
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/expand
 ```
 
@@ -33,7 +52,9 @@ yarn add @inquirer/expand
 # Usage
 
 ```js
-import expand from '@inquirer/expand';
+import { expand } from '@inquirer/prompts';
+// Or
+// import expand from '@inquirer/expand';
 
 const answer = await expand({
   message: 'Conflict on file.js',

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -15,6 +15,25 @@ Interactive free text input component for command line interfaces. Supports vali
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/input
 ```
 
@@ -32,7 +51,9 @@ yarn add @inquirer/input
 # Usage
 
 ```js
-import input from '@inquirer/input';
+import { input } from '@inquirer/prompts';
+// Or
+// import input from '@inquirer/input';
 
 const answer = await input({ message: 'Enter your name' });
 ```

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -13,6 +13,25 @@ Interactive free number input component for command line interfaces. Supports va
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/number
 ```
 
@@ -30,7 +49,9 @@ yarn add @inquirer/number
 # Usage
 
 ```js
-import number from '@inquirer/number';
+import { number } from '@inquirer/prompts';
+// Or
+// import number from '@inquirer/number';
 
 const answer = await number({ message: 'Enter your age' });
 ```

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -15,6 +15,25 @@ Interactive password input component for command line interfaces. Supports input
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/password
 ```
 
@@ -32,7 +51,9 @@ yarn add @inquirer/password
 # Usage
 
 ```js
-import password from '@inquirer/password';
+import { password } from '@inquirer/prompts';
+// Or
+// import password from '@inquirer/password';
 
 const answer = await password({ message: 'Enter your name' });
 ```

--- a/packages/rawlist/README.md
+++ b/packages/rawlist/README.md
@@ -15,6 +15,25 @@ Simple interactive command line prompt to display a raw list of choices (single 
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/rawlist
 ```
 
@@ -32,7 +51,9 @@ yarn add @inquirer/rawlist
 # Usage
 
 ```js
-import rawlist from '@inquirer/rawlist';
+import { rawlist } from '@inquirer/prompts';
+// Or
+// import rawlist from '@inquirer/rawlist';
 
 const answer = await rawlist({
   message: 'Select a package manager',

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -15,6 +15,25 @@ Simple interactive command line prompt to display a list of choices (single sele
 <td>
 
 ```sh
+npm install @inquirer/prompts
+```
+
+</td>
+<td>
+
+```sh
+yarn add @inquirer/prompts
+```
+
+</td>
+</tr>
+<tr>
+<td colSpan="2" align="center">Or</td>
+</tr>
+<tr>
+<td>
+
+```sh
 npm install @inquirer/select
 ```
 
@@ -32,7 +51,9 @@ yarn add @inquirer/select
 # Usage
 
 ```js
-import select, { Separator } from '@inquirer/select';
+import { select, Separator } from '@inquirer/prompts';
+// Or
+// import select, { Separator } from '@inquirer/select';
 
 const answer = await select({
   message: 'Select a package manager',


### PR DESCRIPTION
Making this change since `@inquirer/prompts` is the preferred option. And saw in the wild people potentially overcomplicating their setup using 4-5 individual packages.