### PR TITLE
Chore: Run tsc first and cache on vercel before running tsc dependant jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,21 @@
 name: CI
 on: [push, pull_request]
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 jobs:
-  Linting:
+  Compile:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
@@ -18,8 +26,26 @@ jobs:
         run: yarn tsc
       - name: Typescript - test files
         run: yarn tsc:test
-      - name: Eslint
-        run: yarn eslint .
+
+  Linting:
+    runs-on: ubuntu-latest
+    needs: Compile
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn tsc
+      - run: yarn eslint .
       - name: Validate package setup
         run: |
           yarn setup
@@ -43,13 +69,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn install --immutable --immutable-cache
-      - name: Test packages
-        run: yarn vitest --run --coverage
+      - run: yarn vitest --run --coverage
       - uses: codecov/codecov-action@v4
 
   Integration:
-    name: Typescript & Integration Tests
+    name: Integration Tests
     runs-on: ubuntu-latest
+    needs: Compile
     strategy:
       fail-fast: false
       matrix:
@@ -58,22 +84,34 @@ jobs:
           - 18
     steps:
       - uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn install --immutable --immutable-cache
-      - name: Typescript
-        run: yarn tsc
+      - run: yarn tsc
       - name: Integration tests
         run: yarn node --test integration/
 
   Package:
     name: Are the types wrong?
     runs-on: ubuntu-latest
+    needs: Compile
     steps:
       - uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Hoping cache will reduce duplication of builds.

Results: from ~7m20 to ~3m45 (comparison of 2 full turbo runs. When compiling TS it'll be slightly slower.)