### PR TITLE
Fix(@inquirer/core): Destroy output stream on exit.

### DIFF
--- a/packages/core/src/lib/create-prompt.mts
+++ b/packages/core/src/lib/create-prompt.mts
@@ -59,6 +59,7 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
           removeExitListener();
           rl.input.removeListener('keypress', checkCursorPos);
           rl.removeListener('close', hooksCleanup);
+          output.destroy();
         }
 
         cancel = () => {


### PR DESCRIPTION
This PR fixes the memory leak warning below

```
(node:2670733) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 drain listeners added to [WriteStream]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 drain listeners added to [WriteStream]. Use emitter.setMaxListeners() to increase limit

    at _addListener (node:events:591:17)
    at WriteStream.addListener (node:events:609:10)
    at WriteStream.Readable.on (node:internal/streams/readable:928:35)
    at MuteStream.Stream.pipe (node:internal/streams/legacy:33:8)
    at MuteStream.pipe (/xxxxx/node_modules/mute-stream/lib/index.js:73:18)
    at Object.prompt (/xxxxx/node_modules/@inquirer/core/dist/cjs/lib/create-prompt.js:46:16)
    at ProgramsInterface.<anonymous> (/xxxxx/xxxxx/xxxxx:24:40)
    at Generator.next (<anonymous>)
    at /xxxxx/xxxxx/xxxxx/xxxxx:14:71
```