### PR TITLE
Feat(@inquirer/search): Add autocomplete capacities to the search prompt

### DIFF
--- a/packages/demo/demos/search.mjs
+++ b/packages/demo/demos/search.mjs
@@ -1,9 +1,30 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import * as url from 'node:url';
 import { search } from '@inquirer/prompts';
+
+async function fileExists(filepath) {
+  return fs.access(filepath).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function isDirectory(path) {
+  if (await fileExists(path)) {
+    const stats = await fs.stat(path);
+    return stats.isDirectory();
+  }
+
+  return false;
+}
+
+const root = path.dirname(path.join(url.fileURLToPath(import.meta.url), '../../..'));
 
 const demo = async () => {
   let answer;
 
+  // Demo: Search results from an API
   answer = await search({
     message: 'Select an npm package',
     source: async (input = 'inquirer', { signal }) => {
@@ -19,6 +40,42 @@ const demo = async () => {
         value: pkg.package.name,
         description: pkg.package.description,
       }));
+    },
+  });
+  console.log('Answer:', answer);
+
+  // Demo: Using the search prompt as an autocomplete tool.
+  answer = await search({
+    message: 'Select a file',
+    source: async (term = '') => {
+      let dirPath = path.join(root, term);
+      while (!(await isDirectory(dirPath)) && dirPath !== root) {
+        dirPath = path.dirname(dirPath);
+      }
+
+      const files = await fs.readdir(dirPath, { withFileTypes: true });
+      return files
+        .sort((a, b) => {
+          if (a.isDirectory() === b.isDirectory()) {
+            return a.name.localeCompare(b.name);
+          }
+
+          // Sort dir first
+          return a.isDirectory() ? -1 : 1;
+        })
+        .map((file) => ({
+          name:
+            path.relative(root, path.join(dirPath, file.name)) +
+            (file.isDirectory() ? '/' : ''),
+          value: path.join(file.parentPath, file.name),
+        }))
+        .filter(({ value }) => value.includes(term));
+    },
+    validate: async (filePath) => {
+      if (!(await fileExists(filePath)) || (await isDirectory(filePath))) {
+        return 'You must select a file';
+      }
+      return true;
     },
   });
   console.log('Answer:', answer);

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -76,12 +76,13 @@ const answer = await search({
 
 ## Options
 
-| Property | Type                                          | Required | Description                                                                                                                                 |
-| -------- | --------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| message  | `string`                                      | yes      | The question to ask                                                                                                                         |
-| source   | `(term: string \| void) => Promise<Choice[]>` | yes      | This function returns the choices relevant to the search term.                                                                              |
-| pageSize | `number`                                      | no       | By default, lists of choice longer than 7 will be paginated. Use this option to control how many choices will appear on the screen at once. |
-| theme    | [See Theming](#Theming)                       | no       | Customize look of the prompt.                                                                                                               |
+| Property | Type                                                       | Required | Description                                                                                                                                                                                          |
+| -------- | ---------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| message  | `string`                                                   | yes      | The question to ask                                                                                                                                                                                  |
+| source   | `(term: string \| void) => Promise<Choice[]>`              | yes      | This function returns the choices relevant to the search term.                                                                                                                                       |
+| pageSize | `number`                                                   | no       | By default, lists of choice longer than 7 will be paginated. Use this option to control how many choices will appear on the screen at once.                                                          |
+| validate | `Value => boolean \| string \| Promise<boolean \| string>` | no       | On submit, validate the answer. When returning a string, it'll be used as the error message displayed to the user. Note: returning a rejected promise, we'll assume a code error happened and crash. |
+| theme    | [See Theming](#Theming)                                    | no       | Customize look of the prompt.                                                                                                                                                                        |
 
 ### `source` function
 
@@ -122,6 +123,18 @@ Here's each property:
 - `description`: Option for a longer description string that'll appear under the list when the cursor highlight a given choice.
 - `short`: Once the prompt is done (press enter), we'll use `short` if defined to render next to the question. By default we'll use `name`.
 - `disabled`: Disallow the option from being selected. If `disabled` is a string, it'll be used as a help tip explaining why the choice isn't available.
+
+### Validation & autocomplete interaction
+
+The validation within the search prompt acts as a signal for the autocomplete feature.
+
+When a list value is submitted and fail validation, the prompt will compare it to the search term. If they're the same, the prompt display the error. If they're not the same, we'll autocomplete the search term to match the value. Doing this will trigger a new search.
+
+You can rely on this behavior to implement progressive autocomplete searches. Where you want the user to narrow the search in a progressive manner.
+
+Pressing `tab` also triggers the term autocomplete.
+
+You can see this behavior in action in [our search demo](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/demo/demos/search.mjs).
 
 ## Theming
 


### PR DESCRIPTION
Adding a new feature set to the `search` prompt so it can double as an autocomplete helper. This will make it easier to implement progressive search prompts (like exploring a file system.)

This relies on 2 new behaviour:

1. `tab` key triggers an autocomplete of the selected choice `name` property into the search bar
2. Adding support for `validate` (I tend to stay away from adding validation to list type prompts, but I think this is a neat use-case.)
3. Pressing `enter` doubles as `tab` when the value doesn't match the search string and doesn't pass validation.

There's a demo you can run to try it out locally; run `yarn demo` from the root of the repository. Then select the `Search` demo option.

## TODO

- [x] Add tests covering the new feature
- [x] Add documentation

