### PR TITLE
Fix(inquirer): Allow string choices (backward compat with v9 & prior)

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -101,13 +101,15 @@ type Choice<Value> = {
 
 Here's each property:
 
-- `value`: The value is what will be returned by `await select()`.
+- `value`: The value is what will be returned by `await checkbox()`.
 - `name`: This is the string displayed in the choice list.
 - `short`: Once the prompt is done (press enter), we'll use `short` if defined to render next to the question. By default we'll use `name`.
 - `checked`: If `true`, the option will be checked by default.
 - `disabled`: Disallow the option from being selected. If `disabled` is a string, it'll be used as a help tip explaining why the choice isn't available.
 
 Also note the `choices` array can contain `Separator`s to help organize long lists.
+
+`choices` can also be an array of string, in which case the string will be used both as the `value` and the `name`.
 
 ## Theming
 

--- a/packages/checkbox/checkbox.test.mts
+++ b/packages/checkbox/checkbox.test.mts
@@ -58,6 +58,34 @@ describe('checkbox prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot('"? Select a number 2, 3"');
   });
 
+  it('works with string choices', async () => {
+    const { answer, events, getScreen } = await render(checkbox, {
+      message: 'Select a number',
+      choices: ['Option A', 'Option B', 'Option C'],
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a number (Press <space> to select, <a> to toggle all, <i> to invert
+      selection, and <enter> to proceed)
+      ❯◯ Option A
+       ◯ Option B
+       ◯ Option C"
+    `);
+
+    events.keypress('down');
+    events.keypress('space');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a number
+       ◯ Option A
+      ❯◉ Option B
+       ◯ Option C"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(['Option B']);
+    expect(getScreen()).toMatchInlineSnapshot(`"? Select a number Option B"`);
+  });
+
   it('does not scroll up beyond first item when not looping', async () => {
     const { answer, events, getScreen } = await render(checkbox, {
       message: 'Select a number',

--- a/packages/core/src/lib/Separator.mts
+++ b/packages/core/src/lib/Separator.mts
@@ -16,9 +16,12 @@ export class Separator {
     }
   }
 
-  static isSeparator(
-    choice: undefined | Separator | Record<string, unknown>,
-  ): choice is Separator {
-    return Boolean(choice && choice.type === 'separator');
+  static isSeparator(choice: unknown): choice is Separator {
+    return Boolean(
+      choice &&
+        typeof choice === 'object' &&
+        'type' in choice &&
+        choice.type === 'separator',
+    );
   }
 }

--- a/packages/expand/README.md
+++ b/packages/expand/README.md
@@ -86,13 +86,31 @@ const answer = await expand({
 
 ## Options
 
-| Property | Type                                                   | Required | Description                                                                               |
-| -------- | ------------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------- |
-| message  | `string`                                               | yes      | The question to ask                                                                       |
-| choices  | `Array<{ key: string, name: string, value?: string }>` | yes      | Array of the different allowed choices. The `h`/help option is always provided by default |
-| default  | `string`                                               | no       | Default choices to be selected. (value must be one of the choices `key`)                  |
-| expanded | `boolean`                                              | no       | Expand the choices by default                                                             |
-| theme    | [See Theming](#Theming)                                | no       | Customize look of the prompt.                                                             |
+| Property | Type                    | Required | Description                                                                               |
+| -------- | ----------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| message  | `string`                | yes      | The question to ask                                                                       |
+| choices  | `Choice[]`              | yes      | Array of the different allowed choices. The `h`/help option is always provided by default |
+| default  | `string`                | no       | Default choices to be selected. (value must be one of the choices `key`)                  |
+| expanded | `boolean`               | no       | Expand the choices by default                                                             |
+| theme    | [See Theming](#Theming) | no       | Customize look of the prompt.                                                             |
+
+### `Choice` object
+
+The `Choice` object is typed as
+
+```ts
+type Choice<Value> = {
+  value: Value;
+  name?: string;
+  key: string;
+};
+```
+
+Here's each property:
+
+- `value`: The value is what will be returned by `await expand()`.
+- `name`: The string displayed in the choice list. It'll default to the stringify `value`.
+- `key`: The input the use must provide to select the choice. Must be a lowercase single alpha-numeric character string.
 
 ## Theming
 

--- a/packages/expand/expand.test.mts
+++ b/packages/expand/expand.test.mts
@@ -72,7 +72,7 @@ describe('expand prompt', () => {
     `);
 
     events.keypress('enter');
-    expect(getScreen()).toMatchInlineSnapshot('"? Overwrite this file? abort"');
+    expect(getScreen()).toMatchInlineSnapshot(`"? Overwrite this file? Abort"`);
 
     await expect(answer).resolves.toEqual('abort');
   });
@@ -139,7 +139,7 @@ describe('expand prompt', () => {
     `);
 
     events.keypress('enter');
-    expect(getScreen()).toMatchInlineSnapshot('"? Overwrite this file? abort"');
+    expect(getScreen()).toMatchInlineSnapshot(`"? Overwrite this file? Abort"`);
 
     await expect(answer).resolves.toEqual('abort');
   });
@@ -245,7 +245,7 @@ describe('expand prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot('"? Overwrite this file? (Yadxh)"');
 
     events.keypress('enter');
-    expect(getScreen()).toMatchInlineSnapshot('"? Overwrite this file? overwrite"');
+    expect(getScreen()).toMatchInlineSnapshot(`"? Overwrite this file? Overwrite"`);
 
     await expect(answer).resolves.toEqual('overwrite');
   });

--- a/packages/expand/expand.test.mts
+++ b/packages/expand/expand.test.mts
@@ -4,22 +4,22 @@ import expand from './src/index.mjs';
 
 const overwriteChoices = [
   {
-    key: 'y',
+    key: 'y' as const,
     name: 'Overwrite',
     value: 'overwrite',
   },
   {
-    key: 'a',
+    key: 'a' as const,
     name: 'Overwrite this one and all next',
     value: 'overwrite_all',
   },
   {
-    key: 'd',
+    key: 'd' as const,
     name: 'Show diff',
     value: 'diff',
   },
   {
-    key: 'x',
+    key: 'x' as const,
     name: 'Abort',
     value: 'abort',
   },

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -11,31 +11,69 @@ import {
 import type { PartialDeep } from '@inquirer/type';
 import colors from 'yoctocolors-cjs';
 
+type Key =
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  // | 'h' // Help is excluded since it's a reserved key
+  | 'i'
+  | 'j'
+  | 'k'
+  | 'l'
+  | 'm'
+  | 'n'
+  | 'o'
+  | 'p'
+  | 'q'
+  | 'r'
+  | 's'
+  | 't'
+  | 'u'
+  | 'v'
+  | 'w'
+  | 'x'
+  | 'y'
+  | 'z'
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9';
+
 type Choice<Value> =
-  | { key: string; value: Value }
-  | { key: string; name: string; value: Value };
+  | { key: Key; value: Value }
+  | { key: Key; name: string; value: Value };
 
 type NormalizedChoice<Value> = {
   value: Value;
   name: string;
-  key: string;
+  key: Key;
 };
 
 type ExpandConfig<
   Value,
-  ChoicesObject = readonly { key: string; name: string }[] | readonly Choice<Value>[],
+  ChoicesObject = readonly { key: Key; name: string }[] | readonly Choice<Value>[],
 > = {
   message: string;
-  choices: ChoicesObject extends readonly { key: string; name: string }[]
+  choices: ChoicesObject extends readonly { key: Key; name: string }[]
     ? ChoicesObject
     : readonly Choice<Value>[];
-  default?: string;
+  default?: Key | 'h';
   expanded?: boolean;
   theme?: PartialDeep<Theme>;
 };
 
 function normalizeChoices<Value>(
-  choices: readonly { key: string; name: string }[] | readonly Choice<Value>[],
+  choices: readonly { key: Key; name: string }[] | readonly Choice<Value>[],
 ): NormalizedChoice<Value>[] {
   return choices.map((choice) => {
     const name: string = 'name' in choice ? choice.name : String(choice.value);
@@ -43,7 +81,7 @@ function normalizeChoices<Value>(
     return {
       value: value as Value,
       name,
-      key: choice.key.toLowerCase(),
+      key: choice.key.toLowerCase() as Key,
     };
   });
 }

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -11,31 +11,37 @@ import {
 import type { PartialDeep } from '@inquirer/type';
 import colors from 'yoctocolors-cjs';
 
-type Choice =
-  | { key: string; name: string }
-  | { key: string; value: string }
-  | { key: string; name: string; value: string };
+type Choice<Value> =
+  | { key: string; value: Value }
+  | { key: string; name: string; value: Value };
 
-type NormalizedChoice = {
-  value: string;
+type NormalizedChoice<Value> = {
+  value: Value;
   name: string;
   key: string;
 };
 
-type ExpandConfig = {
+type ExpandConfig<
+  Value,
+  ChoicesObject = readonly { key: string; name: string }[] | readonly Choice<Value>[],
+> = {
   message: string;
-  choices: ReadonlyArray<Choice>;
+  choices: ChoicesObject extends readonly { key: string; name: string }[]
+    ? ChoicesObject
+    : readonly Choice<Value>[];
   default?: string;
   expanded?: boolean;
   theme?: PartialDeep<Theme>;
 };
 
-function normalizeChoices(choices: readonly Choice[]): NormalizedChoice[] {
+function normalizeChoices<Value>(
+  choices: readonly { key: string; name: string }[] | readonly Choice<Value>[],
+): NormalizedChoice<Value>[] {
   return choices.map((choice) => {
     const name: string = 'name' in choice ? choice.name : String(choice.value);
     const value = 'value' in choice ? choice.value : name;
     return {
-      value,
+      value: value as Value,
       name,
       key: choice.key.toLowerCase(),
     };
@@ -48,91 +54,95 @@ const helpChoice = {
   value: undefined,
 };
 
-export default createPrompt<string, ExpandConfig>((config, done) => {
-  const { default: defaultKey = 'h' } = config;
-  const choices = useMemo(() => normalizeChoices(config.choices), [config.choices]);
-  const [status, setStatus] = useState<string>('pending');
-  const [value, setValue] = useState<string>('');
-  const [expanded, setExpanded] = useState<boolean>(config.expanded ?? false);
-  const [errorMsg, setError] = useState<string>();
-  const theme = makeTheme(config.theme);
-  const prefix = usePrefix({ theme });
+export default createPrompt(
+  <Value,>(config: ExpandConfig<Value>, done: (value: Value) => void) => {
+    const { default: defaultKey = 'h' } = config;
+    const choices = useMemo(() => normalizeChoices(config.choices), [config.choices]);
+    const [status, setStatus] = useState<string>('pending');
+    const [value, setValue] = useState<string>('');
+    const [expanded, setExpanded] = useState<boolean>(config.expanded ?? false);
+    const [errorMsg, setError] = useState<string>();
+    const theme = makeTheme(config.theme);
+    const prefix = usePrefix({ theme });
 
-  useKeypress((event, rl) => {
-    if (isEnterKey(event)) {
-      const answer = (value || defaultKey).toLowerCase();
-      if (answer === 'h' && !expanded) {
-        setExpanded(true);
-      } else {
-        const selectedChoice = choices.find(({ key }) => key === answer);
-        if (selectedChoice) {
-          setStatus('done');
-          // Set the value as we might've selected the default one.
-          setValue(answer);
-          done(selectedChoice.value);
-        } else if (value === '') {
-          setError('Please input a value');
+    useKeypress((event, rl) => {
+      if (isEnterKey(event)) {
+        const answer = (value || defaultKey).toLowerCase();
+        if (answer === 'h' && !expanded) {
+          setExpanded(true);
         } else {
-          setError(`"${colors.red(value)}" isn't an available option`);
+          const selectedChoice = choices.find(({ key }) => key === answer);
+          if (selectedChoice) {
+            setStatus('done');
+            // Set the value as we might've selected the default one.
+            setValue(answer);
+            done(selectedChoice.value);
+          } else if (value === '') {
+            setError('Please input a value');
+          } else {
+            setError(`"${colors.red(value)}" isn't an available option`);
+          }
         }
+      } else {
+        setValue(rl.line);
+        setError(undefined);
       }
-    } else {
-      setValue(rl.line);
-      setError(undefined);
+    });
+
+    const message = theme.style.message(config.message);
+
+    if (status === 'done') {
+      // If the prompt is done, it's safe to assume there is a selected value.
+      const selectedChoice = choices.find(
+        ({ key }) => key === value,
+      ) as NormalizedChoice<Value>;
+      return `${prefix} ${message} ${theme.style.answer(selectedChoice.name)}`;
     }
-  });
 
-  const message = theme.style.message(config.message);
+    const allChoices = expanded ? choices : [...choices, helpChoice];
 
-  if (status === 'done') {
-    // If the prompt is done, it's safe to assume there is a selected value.
-    const selectedChoice = choices.find(({ key }) => key === value) as NormalizedChoice;
-    return `${prefix} ${message} ${theme.style.answer(selectedChoice.name)}`;
-  }
-
-  const allChoices = expanded ? choices : [...choices, helpChoice];
-
-  // Collapsed display style
-  let longChoices = '';
-  let shortChoices = allChoices
-    .map((choice) => {
-      if (choice.key === defaultKey) {
-        return choice.key.toUpperCase();
-      }
-
-      return choice.key;
-    })
-    .join('');
-  shortChoices = ` ${theme.style.defaultAnswer(shortChoices)}`;
-
-  // Expanded display style
-  if (expanded) {
-    shortChoices = '';
-    longChoices = allChoices
+    // Collapsed display style
+    let longChoices = '';
+    let shortChoices = allChoices
       .map((choice) => {
-        const line = `  ${choice.key}) ${choice.name}`;
-        if (choice.key === value.toLowerCase()) {
-          return theme.style.highlight(line);
+        if (choice.key === defaultKey) {
+          return choice.key.toUpperCase();
         }
 
-        return line;
+        return choice.key;
       })
-      .join('\n');
-  }
+      .join('');
+    shortChoices = ` ${theme.style.defaultAnswer(shortChoices)}`;
 
-  let helpTip = '';
-  const currentOption = allChoices.find(({ key }) => key === value.toLowerCase());
-  if (currentOption) {
-    helpTip = `${colors.cyan('>>')} ${currentOption.name}`;
-  }
+    // Expanded display style
+    if (expanded) {
+      shortChoices = '';
+      longChoices = allChoices
+        .map((choice) => {
+          const line = `  ${choice.key}) ${choice.name}`;
+          if (choice.key === value.toLowerCase()) {
+            return theme.style.highlight(line);
+          }
 
-  let error = '';
-  if (errorMsg) {
-    error = theme.style.error(errorMsg);
-  }
+          return line;
+        })
+        .join('\n');
+    }
 
-  return [
-    `${prefix} ${message}${shortChoices} ${value}`,
-    [longChoices, helpTip, error].filter(Boolean).join('\n'),
-  ];
-});
+    let helpTip = '';
+    const currentOption = allChoices.find(({ key }) => key === value.toLowerCase());
+    if (currentOption) {
+      helpTip = `${colors.cyan('>>')} ${currentOption.name}`;
+    }
+
+    let error = '';
+    if (errorMsg) {
+      error = theme.style.error(errorMsg);
+    }
+
+    return [
+      `${prefix} ${message}${shortChoices} ${value}`,
+      [longChoices, helpTip, error].filter(Boolean).join('\n'),
+    ];
+  },
+);

--- a/packages/rawlist/README.md
+++ b/packages/rawlist/README.md
@@ -90,10 +90,12 @@ type Choice<Value> = {
 
 Here's each property:
 
-- `value`: The value is what will be returned by `await select()`.
+- `value`: The value is what will be returned by `await rawlist()`.
 - `name`: This is the string displayed in the choice list.
 - `short`: Once the prompt is done (press enter), we'll use `short` if defined to render next to the question. By default we'll use `name`.
 - `key`: The key of the choice. Displayed as `key) name`.
+
+`choices` can also be an array of string, in which case the string will be used both as the `value` and the `name`.
 
 ## Theming
 

--- a/packages/rawlist/rawlist.test.mts
+++ b/packages/rawlist/rawlist.test.mts
@@ -33,6 +33,28 @@ describe('rawlist prompt', () => {
     await expect(answer).resolves.toEqual(4);
   });
 
+  it('works with string choices', async () => {
+    const { answer, events, getScreen } = await render(rawlist, {
+      message: 'Select a number',
+      choices: ['1', '2', '3', '4', '5'],
+    });
+
+    events.type('4');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a number 4
+        1) 1
+        2) 2
+        3) 3
+        4) 4
+        5) 5"
+    `);
+
+    events.keypress('enter');
+    expect(getScreen()).toMatchInlineSnapshot('"? Select a number 4"');
+
+    await expect(answer).resolves.toEqual('4');
+  });
+
   it('uses custom `key`, and `short` once a value is selected', async () => {
     const { answer, events, getScreen } = await render(rawlist, {
       message: 'Select a country',

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -124,6 +124,8 @@ Here's each property:
 - `short`: Once the prompt is done (press enter), we'll use `short` if defined to render next to the question. By default we'll use `name`.
 - `disabled`: Disallow the option from being selected. If `disabled` is a string, it'll be used as a help tip explaining why the choice isn't available.
 
+Choices can also be an array of string, in which case the string will be used both as the `value` and the `name`.
+
 ### Validation & autocomplete interaction
 
 The validation within the search prompt acts as a signal for the autocomplete feature.

--- a/packages/search/search.test.mts
+++ b/packages/search/search.test.mts
@@ -73,6 +73,61 @@ describe('search prompt', () => {
     );
   });
 
+  it('works with string results', async () => {
+    const choices = [
+      'Stark',
+      'Lannister',
+      'Targaryen',
+      'Baratheon',
+      'Greyjoy',
+      'Martell',
+      'Tyrell',
+      'Arryn',
+      'Tully',
+    ];
+
+    const { answer, events, getScreen } = await render(search, {
+      message: 'Select a family',
+      source: (term: string = '') => {
+        return choices.filter((choice) => choice.includes(term));
+      },
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a family 
+      ❯ Stark
+        Lannister
+        Targaryen
+        Baratheon
+        Greyjoy
+        Martell
+        Tyrell
+      (Use arrow keys to reveal more choices)"
+    `);
+
+    events.keypress('down');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a family 
+        Stark
+      ❯ Lannister
+        Targaryen
+        Baratheon
+        Greyjoy
+        Martell
+        Tyrell"
+    `);
+
+    events.type('Targ');
+    await Promise.resolve();
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a family Targ
+      ❯ Targaryen"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('Targaryen');
+  });
+
   it('allows to search and navigate the list', async () => {
     const { answer, events, getScreen } = await render(search, {
       message: 'Select a Canadian province',

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -118,6 +118,8 @@ Here's each property:
 - `short`: Once the prompt is done (press enter), we'll use `short` if defined to render next to the question. By default we'll use `name`.
 - `disabled`: Disallow the option from being selected. If `disabled` is a string, it'll be used as a help tip explaining why the choice isn't available.
 
+`choices` can also be an array of string, in which case the string will be used both as the `value` and the `name`.
+
 ## Theming
 
 You can theme a prompt by passing a `theme` object option. The theme object only need to includes the keys you wish to modify, we'll fallback on the defaults for the rest.

--- a/packages/select/select.test.mts
+++ b/packages/select/select.test.mts
@@ -79,6 +79,25 @@ describe('select prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot('"? Select a number 1"');
   });
 
+  it('allow passing strings as choices', async () => {
+    const { answer, events, getScreen } = await render(select, {
+      message: 'Select one',
+      choices: ['Option A', 'Option B', 'Option C'],
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select one (Use arrow keys)
+      ❯ Option A
+        Option B
+        Option C"
+    `);
+
+    events.keypress('enter');
+    expect(getScreen()).toMatchInlineSnapshot(`"? Select one Option A"`);
+
+    await expect(answer).resolves.toEqual('Option A');
+  });
+
   it('use number key to select an option', async () => {
     const { answer, events, getScreen } = await render(select, {
       message: 'Select a number',


### PR DESCRIPTION
Ref #1527

Inquirer v9 & prior allowed choices to be array of strings. Given how widespread that pattern is, we should maintain this backward compatibility. It'll also simplify the work of folks migrating from `inquirer` to `@inquirer/prompts` with less code change.

### TODO

- [x] Select prompt
- [x] Checkbox prompt
- [x] Search prompt
- [x] Rawlist prompt
- [x] Documentation