### PR TITLE
rework prompt lifecycle

### DIFF
--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -1,5 +1,6 @@
 export * from './lib/key.mjs';
 export * from './lib/errors.mjs';
+export { CancelPromptError } from '@inquirer/type';
 export { usePrefix } from './lib/use-prefix.mjs';
 export { useState } from './lib/use-state.mjs';
 export { useEffect } from './lib/use-effect.mjs';

--- a/packages/core/src/lib/create-prompt.mts
+++ b/packages/core/src/lib/create-prompt.mts
@@ -18,7 +18,7 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
   const prompt: Prompt<Value, Config> = (config, context = {}) => {
     // Default `input` to stdin
     const { input = process.stdin, signal: outsideSignal } = context;
-    const { promise, resolve, reject, abort, onFinally } =
+    const { promise, resolve, reject, onFinally } =
       CancelablePromise.withResolver<Value>();
 
     // Add mute capabilities to the output
@@ -39,7 +39,7 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
 
     if (outsideSignal) {
       const outsideAbort = () =>
-        abort(new AbortPromptError({ cause: outsideSignal.reason }));
+        reject(new AbortPromptError({ cause: outsideSignal.reason }));
       if (outsideSignal.aborted) {
         outsideAbort();
         return promise;
@@ -51,7 +51,7 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
     withHooks(rl, (cycle) => {
       onFinally(
         onSignalExit((code, signal) => {
-          abort(
+          reject(
             new ExitPromptError(`User force closed the prompt with ${code} ${signal}`),
           );
         }),
@@ -102,7 +102,7 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
 
           effectScheduler.run();
         } catch (error: unknown) {
-          abort(error);
+          reject(error);
         }
       });
     });

--- a/packages/core/src/lib/errors.mts
+++ b/packages/core/src/lib/errors.mts
@@ -8,11 +8,6 @@ export class AbortPromptError extends Error {
   }
 }
 
-export class CancelPromptError extends Error {
-  override name = 'CancelPromptError';
-  override message = 'Prompt was canceled';
-}
-
 export class ExitPromptError extends Error {
   override name = 'ExitPromptError';
 }

--- a/packages/core/src/lib/utils.mts
+++ b/packages/core/src/lib/utils.mts
@@ -27,3 +27,11 @@ export function breakLines(content: string, width: number): string {
 export function readlineWidth(): number {
   return cliWidth({ defaultWidth: 80, output: readline().output });
 }
+
+export function executeOnce(fn?: () => void) {
+  let once = fn;
+  return () => {
+    once?.();
+    once = undefined;
+  };
+}

--- a/packages/type/src/errors.mts
+++ b/packages/type/src/errors.mts
@@ -1,0 +1,4 @@
+export class CancelPromptError extends Error {
+  override name = 'CancelPromptError';
+  override message = 'Prompt was canceled';
+}

--- a/packages/type/src/index.mts
+++ b/packages/type/src/index.mts
@@ -1,2 +1,3 @@
+export * from './errors.mjs';
 export * from './inquirer.mjs';
 export * from './utils.mjs';

--- a/packages/type/src/inquirer.mts
+++ b/packages/type/src/inquirer.mts
@@ -6,12 +6,6 @@ export class CancelablePromise<T> extends Promise<T> {
   public cancel: () => void = () => {};
 
   static withResolver<T>() {
-    const abortController = new AbortController();
-    const { signal } = abortController;
-    abortController.signal.addEventListener('abort', () => reject(signal.reason), {
-      once: true,
-    });
-
     const finallyCallbacks = new Set<() => void>();
     const onFinally = (onfinally: () => void) => finallyCallbacks.add(onfinally);
 
@@ -33,13 +27,7 @@ export class CancelablePromise<T> extends Promise<T> {
 
     promise.cancel = () => reject(new CancelPromptError());
 
-    return {
-      promise,
-      resolve: resolve!,
-      reject: reject!,
-      signal: abortController.signal,
-      onFinally,
-    };
+    return { promise, resolve: resolve!, reject: reject!, onFinally };
   }
 }
 

--- a/packages/type/src/inquirer.mts
+++ b/packages/type/src/inquirer.mts
@@ -11,7 +11,6 @@ export class CancelablePromise<T> extends Promise<T> {
     abortController.signal.addEventListener('abort', () => reject(signal.reason), {
       once: true,
     });
-    const abort = (error: unknown) => abortController.abort(error);
 
     const finallyCallbacks = new Set<() => void>();
     const onFinally = (onfinally: () => void) => finallyCallbacks.add(onfinally);
@@ -32,7 +31,7 @@ export class CancelablePromise<T> extends Promise<T> {
         });
     });
 
-    promise.cancel = () => abort(new CancelPromptError());
+    promise.cancel = () => reject(new CancelPromptError());
 
     return {
       promise,
@@ -40,7 +39,6 @@ export class CancelablePromise<T> extends Promise<T> {
       reject: reject!,
       signal: abortController.signal,
       onFinally,
-      abort,
     };
   }
 }

--- a/packages/type/src/inquirer.mts
+++ b/packages/type/src/inquirer.mts
@@ -1,18 +1,47 @@
 import * as readline from 'node:readline';
 import MuteStream from 'mute-stream';
+import { CancelPromptError } from './errors.mjs';
 
 export class CancelablePromise<T> extends Promise<T> {
   public cancel: () => void = () => {};
 
   static withResolver<T>() {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    abortController.signal.addEventListener('abort', () => reject(signal.reason), {
+      once: true,
+    });
+    const abort = (error: unknown) => abortController.abort(error);
+
+    const finallyCallbacks = new Set<() => void>();
+    const onFinally = (onfinally: () => void) => finallyCallbacks.add(onfinally);
+
     let resolve: (value: T) => void;
     let reject: (error: unknown) => void;
-    const promise = new CancelablePromise<T>((res, rej) => {
-      resolve = res;
-      reject = rej;
+
+    const promise = new CancelablePromise<T>((outerResolve, outerReject) => {
+      new Promise<T>((innerResolve, innerReject) => {
+        resolve = innerResolve;
+        reject = innerReject;
+      })
+        .then(outerResolve, outerReject)
+        .finally(() => {
+          // Teardown in reverse order
+          [...finallyCallbacks].reverse().forEach((onfinally) => onfinally());
+          finallyCallbacks.clear();
+        });
     });
 
-    return { promise, resolve: resolve!, reject: reject! };
+    promise.cancel = () => abort(new CancelPromptError());
+
+    return {
+      promise,
+      resolve: resolve!,
+      reject: reject!,
+      signal: abortController.signal,
+      onFinally,
+      abort,
+    };
   }
 }
 


### PR DESCRIPTION
It's difficult to understand when cleanup hooks are called.
I've added signal, abort and onFinally support to CancelablePromise.
So the lifecycle is managed by CancelablePromise instead of cleanup callbacks.