### PR TITLE
Refactor(@inquirer/core): Streamline exit handlers

### DIFF
--- a/packages/core/src/lib/create-prompt.mts
+++ b/packages/core/src/lib/create-prompt.mts
@@ -83,11 +83,12 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
       rl.on('close', hooksCleanup);
       cleanups.add(() => rl.removeListener('close', hooksCleanup));
 
-      function done(value: Value) {
-        resolve(value);
-      }
+      cycle((delayAfterCycle) => {
+        const done = delayAfterCycle((value: Value) => {
+          hooksCleanup();
+          resolve(value);
+        });
 
-      cycle(() => {
         try {
           const nextView = view(config, done);
 


### PR DESCRIPTION
Alternative answer to #1536.

2 challenges this code brings:

1. Calling done from a hook cleanup can easily lead to an infinite loop (this code handles it, and there's a unit test covering this case already.)
2. The cycle function becomes a bit more complex - might need to revisit this piece.