### PR TITLE
Fix/issue-1537

### DIFF
--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -151,7 +151,7 @@ export default createPrompt(
       validate = () => true,
     } = config;
     const theme = makeTheme<CheckboxTheme>(checkboxTheme, config.theme);
-    const prefix = usePrefix({ theme });
+    const prefix = usePrefix({ status, theme });
     const firstRender = useRef(true);
     const [status, setStatus] = useState('pending');
     const [items, setItems] = useState<ReadonlyArray<Item<Value>>>(

--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -220,7 +220,7 @@ export default createPrompt(
       }
     });
 
-    const message = theme.style.message(config.message);
+    const message = theme.style.message(config.message, status);
 
     let description;
     const page = usePagination({

--- a/packages/confirm/src/index.mts
+++ b/packages/confirm/src/index.mts
@@ -21,7 +21,7 @@ export default createPrompt<boolean, ConfirmConfig>((config, done) => {
   const [status, setStatus] = useState('pending');
   const [value, setValue] = useState('');
   const theme = makeTheme(config.theme);
-  const prefix = usePrefix({ theme });
+  const prefix = usePrefix({ status, theme });
 
   useKeypress((key, rl) => {
     if (isEnterKey(key)) {

--- a/packages/confirm/src/index.mts
+++ b/packages/confirm/src/index.mts
@@ -47,6 +47,6 @@ export default createPrompt<boolean, ConfirmConfig>((config, done) => {
     )}`;
   }
 
-  const message = theme.style.message(config.message);
+  const message = theme.style.message(config.message, status);
   return `${prefix} ${message}${defaultValue} ${formattedValue}`;
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -154,7 +154,7 @@ All default prompts, and most custom ones, uses a prefix at the beginning of the
 
 ```ts
 const input = createPrompt((config, done) => {
-  const prefix = usePrefix({ isLoading });
+  const prefix = usePrefix({ status, theme });
 
   return `${prefix} My question`;
 });
@@ -265,7 +265,7 @@ type PromptConfig = {
 export default createPrompt<string, PromptConfig>((config, done) => {
   const theme = makeTheme(config.theme);
 
-  const prefix = usePrefix({ isLoading, theme });
+  const prefix = usePrefix({ status, theme });
 
   return `${prefix} ${theme.style.highlight('hello')}`;
 });
@@ -290,7 +290,7 @@ type PromptConfig = {
 export default createPrompt<string, PromptConfig>((config, done) => {
   const theme = makeTheme(promptTheme, config.theme);
 
-  const prefix = usePrefix({ isLoading, theme });
+  const prefix = usePrefix({ status, theme });
 
   return `${prefix} ${theme.icon}`;
 });

--- a/packages/core/core.test.mts
+++ b/packages/core/core.test.mts
@@ -371,8 +371,8 @@ describe('createPrompt()', () => {
 
     const Prompt = (config: { message: string }, done: (value: string) => void) => {
       const [status, setStatus] = useState('loading');
-      const prefix = usePrefix({ isLoading: status === 'loading' });
-
+      const prefix = usePrefix({ status });
+  
       useEffect(() => {
         setTimeout(
           AsyncResource.bind(() => {

--- a/packages/core/src/lib/theme.mts
+++ b/packages/core/src/lib/theme.mts
@@ -3,7 +3,7 @@ import spinners from 'cli-spinners';
 import type { Prettify } from '@inquirer/type';
 
 type DefaultTheme = {
-  prefix: string;
+  prefix: string | ((status: string) => string);
   spinner: {
     interval: number;
     frames: string[];

--- a/packages/core/src/lib/theme.mts
+++ b/packages/core/src/lib/theme.mts
@@ -10,7 +10,7 @@ type DefaultTheme = {
   };
   style: {
     answer: (text: string) => string;
-    message: (text: string) => string;
+    message: (text: string, status: string) => string;
     error: (text: string) => string;
     defaultAnswer: (text: string) => string;
     help: (text: string) => string;

--- a/packages/core/src/lib/use-prefix.mts
+++ b/packages/core/src/lib/use-prefix.mts
@@ -5,10 +5,10 @@ import { makeTheme } from './make-theme.mjs';
 import { type Theme } from './theme.mjs';
 
 export function usePrefix({
-  isLoading = false,
+  status = 'pending',
   theme,
 }: {
-  isLoading?: boolean;
+  status?: string;
   theme?: Theme;
 }): string {
   const [showLoader, setShowLoader] = useState(false);
@@ -16,7 +16,7 @@ export function usePrefix({
   const { prefix, spinner } = makeTheme(theme);
 
   useEffect((): void | (() => unknown) => {
-    if (isLoading) {
+    if (status === 'loading') {
       let tickInterval: NodeJS.Timeout | undefined;
       let inc = -1;
       // Delay displaying spinner by 300ms, to avoid flickering
@@ -42,11 +42,11 @@ export function usePrefix({
     } else {
       setShowLoader(false);
     }
-  }, [isLoading]);
+  }, [status]);
 
   if (showLoader) {
     return spinner.frames[tick]!;
   }
 
-  return prefix;
+  return typeof prefix === 'string' ? prefix : prefix(status);
 }

--- a/packages/demo/demos/loader.mjs
+++ b/packages/demo/demos/loader.mjs
@@ -2,7 +2,7 @@ import * as url from 'node:url';
 import { createPrompt, useKeypress, usePrefix, isEnterKey } from '@inquirer/core';
 
 const loader = createPrompt((config, done) => {
-  const prefix = usePrefix({ isLoading: true });
+  const prefix = usePrefix({ status: 'loading' });
 
   useKeypress((key) => {
     if (isEnterKey(key)) {

--- a/packages/editor/src/index.mts
+++ b/packages/editor/src/index.mts
@@ -75,7 +75,7 @@ export default createPrompt<string, EditorConfig>((config, done) => {
     }
   });
 
-  const message = theme.style.message(config.message);
+  const message = theme.style.message(config.message, status);
   let helpTip = '';
   if (status === 'loading') {
     helpTip = theme.style.help('Received');

--- a/packages/editor/src/index.mts
+++ b/packages/editor/src/index.mts
@@ -29,8 +29,7 @@ export default createPrompt<string, EditorConfig>((config, done) => {
   const [value, setValue] = useState<string>(config.default || '');
   const [errorMsg, setError] = useState<string>();
 
-  const isLoading = status === 'loading';
-  const prefix = usePrefix({ isLoading, theme });
+  const prefix = usePrefix({ status, theme });
 
   function startEditor(rl: InquirerReadline) {
     rl.pause();

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -108,7 +108,7 @@ export default createPrompt(
     const [expanded, setExpanded] = useState<boolean>(config.expanded ?? false);
     const [errorMsg, setError] = useState<string>();
     const theme = makeTheme(config.theme);
-    const prefix = usePrefix({ theme });
+    const prefix = usePrefix({ theme, status });
 
     useKeypress((event, rl) => {
       if (isEnterKey(event)) {

--- a/packages/expand/src/index.mts
+++ b/packages/expand/src/index.mts
@@ -137,8 +137,8 @@ export default createPrompt(
       }
     });
 
-    const message = theme.style.message(config.message);
-
+    const message = theme.style.message(config.message, status);
+    
     if (status === 'done') {
       // If the prompt is done, it's safe to assume there is a selected value.
       const selectedChoice = choices.find(

--- a/packages/input/src/index.mts
+++ b/packages/input/src/index.mts
@@ -27,8 +27,7 @@ export default createPrompt<string, InputConfig>((config, done) => {
   const [errorMsg, setError] = useState<string>();
   const [value, setValue] = useState<string>('');
 
-  const isLoading = status === 'loading';
-  const prefix = usePrefix({ isLoading, theme });
+  const prefix = usePrefix({ status, theme });
 
   useKeypress(async (key, rl) => {
     // Ignore keypress while our prompt is doing other processing.
@@ -67,7 +66,7 @@ export default createPrompt<string, InputConfig>((config, done) => {
   });
 
   const message = theme.style.message(config.message, status);
-  
+
   let formattedValue = value;
   if (typeof config.transformer === 'function') {
     formattedValue = config.transformer(value, { isFinal: status === 'done' });

--- a/packages/input/src/index.mts
+++ b/packages/input/src/index.mts
@@ -66,7 +66,8 @@ export default createPrompt<string, InputConfig>((config, done) => {
     }
   });
 
-  const message = theme.style.message(config.message);
+  const message = theme.style.message(config.message, status);
+  
   let formattedValue = value;
   if (typeof config.transformer === 'function') {
     formattedValue = config.transformer(value, { isFinal: status === 'done' });

--- a/packages/number/src/index.mts
+++ b/packages/number/src/index.mts
@@ -72,8 +72,7 @@ export default createPrompt<number | undefined, NumberConfig>((config, done) => 
   const [defaultValue = '', setDefaultValue] = useState<string>(validDefault);
   const [errorMsg, setError] = useState<string>();
 
-  const isLoading = status === 'loading';
-  const prefix = usePrefix({ isLoading, theme });
+  const prefix = usePrefix({ status, theme });
 
   useKeypress(async (key, rl) => {
     // Ignore keypress while our prompt is doing other processing.
@@ -119,7 +118,7 @@ export default createPrompt<number | undefined, NumberConfig>((config, done) => 
   });
 
   const message = theme.style.message(config.message, status);
-  
+
   let formattedValue = value;
   if (status === 'done') {
     formattedValue = theme.style.answer(value);

--- a/packages/number/src/index.mts
+++ b/packages/number/src/index.mts
@@ -118,7 +118,8 @@ export default createPrompt<number | undefined, NumberConfig>((config, done) => 
     }
   });
 
-  const message = theme.style.message(config.message);
+  const message = theme.style.message(config.message, status);
+  
   let formattedValue = value;
   if (status === 'done') {
     formattedValue = theme.style.answer(value);

--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -55,7 +55,7 @@ export default createPrompt<string, PasswordConfig>((config, done) => {
     }
   });
 
-  const message = theme.style.message(config.message);
+  const message = theme.style.message(config.message, status);
 
   let formattedValue = '';
   let helpTip;

--- a/packages/password/src/index.mts
+++ b/packages/password/src/index.mts
@@ -25,8 +25,7 @@ export default createPrompt<string, PasswordConfig>((config, done) => {
   const [errorMsg, setError] = useState<string>();
   const [value, setValue] = useState<string>('');
 
-  const isLoading = status === 'loading';
-  const prefix = usePrefix({ isLoading, theme });
+  const prefix = usePrefix({ status, theme });
 
   useKeypress(async (key, rl) => {
     // Ignore keypress while our prompt is doing other processing.

--- a/packages/rawlist/src/index.mts
+++ b/packages/rawlist/src/index.mts
@@ -81,7 +81,7 @@ export default createPrompt(
     const [value, setValue] = useState<string>('');
     const [errorMsg, setError] = useState<string>();
     const theme = makeTheme(config.theme);
-    const prefix = usePrefix({ theme });
+    const prefix = usePrefix({ status, theme });
 
     useKeypress((key, rl) => {
       if (isEnterKey(key)) {
@@ -113,7 +113,7 @@ export default createPrompt(
     });
 
     const message = theme.style.message(config.message, status);
-    
+
     if (status === 'done') {
       return `${prefix} ${message} ${theme.style.answer(value)}`;
     }

--- a/packages/rawlist/src/index.mts
+++ b/packages/rawlist/src/index.mts
@@ -112,8 +112,8 @@ export default createPrompt(
       }
     });
 
-    const message = theme.style.message(config.message);
-
+    const message = theme.style.message(config.message, status);
+    
     if (status === 'done') {
       return `${prefix} ${message} ${theme.style.answer(value)}`;
     }

--- a/packages/search/src/index.mts
+++ b/packages/search/src/index.mts
@@ -208,8 +208,8 @@ export default createPrompt(
       }
     });
 
-    const message = theme.style.message(config.message);
-
+    const message = theme.style.message(config.message, status);
+    
     if (active > 0) {
       firstRender.current = false;
     }

--- a/packages/search/src/index.mts
+++ b/packages/search/src/index.mts
@@ -116,8 +116,7 @@ export default createPrompt(
     const [searchResults, setSearchResults] = useState<ReadonlyArray<Item<Value>>>([]);
     const [searchError, setSearchError] = useState<string>();
 
-    const isLoading = status === 'loading' || status === 'searching';
-    const prefix = usePrefix({ isLoading, theme });
+    const prefix = usePrefix({ status, theme });
 
     const bounds = useMemo(() => {
       const first = searchResults.findIndex(isSelectable);
@@ -209,7 +208,7 @@ export default createPrompt(
     });
 
     const message = theme.style.message(config.message, status);
-    
+
     if (active > 0) {
       firstRender.current = false;
     }

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -110,7 +110,7 @@ export default createPrompt(
     const { loop = true, pageSize = 7 } = config;
     const firstRender = useRef(true);
     const theme = makeTheme<SelectTheme>(selectTheme, config.theme);
-    const prefix = usePrefix({ theme });
+    const prefix = usePrefix({ status, theme });
     const [status, setStatus] = useState('pending');
     const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -199,7 +199,7 @@ export default createPrompt(
     );
 
     const message = theme.style.message(config.message, status);
-    
+
     let helpTipTop = '';
     let helpTipBottom = '';
     if (

--- a/packages/select/src/index.mts
+++ b/packages/select/src/index.mts
@@ -198,8 +198,8 @@ export default createPrompt(
       [],
     );
 
-    const message = theme.style.message(config.message);
-
+    const message = theme.style.message(config.message, status);
+    
     let helpTipTop = '';
     let helpTipBottom = '';
     if (


### PR DESCRIPTION
d0fd699 - Pass status to usePrefix instead of isLoading. Also updates references to isLoading in README. This allows for behavior like the one described in issue #1537. 

a159e18 - Pass status to style.message function as a second argument. This allows for behavior like the one described, "it could be really nice to be able to get an additional argument for the style.message function in theme objects; currently, it receives only the message string, but if it also received, e.g., a second argument status: 'pending' | 'done', users could, e.g., dim questions that have already been answered, or make the currently pending question brighter", to be implemented by the user.