### PR TITLE
Add `theme.validationFailureMode` option to control behaviour on validation failure

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -87,8 +87,11 @@ type Theme = {
     help: (text: string) => string;
     key: (text: string) => string;
   };
+  validationFailureMode: 'keep' | 'clear';
 };
 ```
+
+`validationFailureMode` defines the behavior of the prompt when the value submitted is invalid. By default, we'll keep the value allowing the user to edit it. When the theme option is set to `clear`, we'll remove and reset to the default value or empty string.
 
 # License
 

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -86,8 +86,11 @@ type Theme = {
     error: (text: string) => string;
     defaultAnswer: (text: string) => string;
   };
+  validationFailureMode: 'keep' | 'clear';
 };
 ```
+
+`validationFailureMode` defines the behavior of the prompt when the value submitted is invalid. By default, we'll keep the value allowing the user to edit it. When the theme option is set to `clear`, we'll remove and reset to an empty string.
 
 # License
 

--- a/packages/input/input.test.ts
+++ b/packages/input/input.test.ts
@@ -63,6 +63,34 @@ describe('input prompt', () => {
     await expect(answer).resolves.toEqual('2');
   });
 
+  it('can clear value when validation fail', async () => {
+    const { answer, events, getScreen } = await render(input, {
+      message: 'Answer 2 ===',
+      validate: (value: string) => value === '2',
+      theme: {
+        validationFailureMode: 'clear',
+      },
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`"? Answer 2 ==="`);
+
+    events.type('1');
+    expect(getScreen()).toMatchInlineSnapshot(`"? Answer 2 === 1"`);
+
+    events.keypress('enter');
+    await Promise.resolve();
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Answer 2 ===
+      > You must provide a valid value"
+    `);
+
+    events.type('2');
+    expect(getScreen()).toMatchInlineSnapshot(`"? Answer 2 === 2"`);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('2');
+  });
+
   it('handle asynchronous validation', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'Answer 2 ===',


### PR DESCRIPTION
Applied to both `input` and `editor` prompts. In both prompt, the `keep` mode was, and stays, the default. The `clear` mode now becomes an option.

Fix #374
Fix #907