### PR TITLE
Fix(sponsorship): <a> HTML tags stripped on npmjs.com

### DIFF
--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -6,22 +6,13 @@ Simple interactive command line prompt to display a list of checkboxes (multi se
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/confirm/README.md
+++ b/packages/confirm/README.md
@@ -6,22 +6,13 @@ Simple interactive command line prompt to gather boolean input from users.
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,22 +6,13 @@ It aims to implements a lightweight API similar to React hooks - but without JSX
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -4,22 +4,13 @@ Prompt that'll open the user preferred editor with default content and allow for
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/expand/README.md
+++ b/packages/expand/README.md
@@ -7,22 +7,13 @@ Compact single select prompt. Every option is assigned a shortcut key, and selec
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -6,22 +6,13 @@ Interactive free text input component for command line interfaces. Supports vali
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/inquirer/README.md
+++ b/packages/inquirer/README.md
@@ -46,22 +46,13 @@ A collection of common interactive command line user interfaces.
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 ## [Documentation](#documentation)

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -4,22 +4,13 @@ Interactive free number input component for command line interfaces. Supports va
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -6,22 +6,13 @@ Interactive password input component for command line interfaces. Supports input
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -17,22 +17,13 @@ npx @inquirer/demo@latest
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/rawlist/README.md
+++ b/packages/rawlist/README.md
@@ -6,22 +6,13 @@ Simple interactive command line prompt to display a raw list of choices (single 
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -6,22 +6,13 @@ Interactive search prompt component for command line interfaces.
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -6,22 +6,13 @@ Simple interactive command line prompt to display a list of choices (single sele
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -4,22 +4,13 @@ The `@inquirer/testing` package is Inquirer's answer to testing prompts [built w
 
 # Special Thanks
 
-<div align="center">
-<br>
-<br>
-<a href="https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer">
-<div>
-  <picture>
-    <img alt="Warp" width="400" src="https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c">
-  </picture>
-</div>
-  <b>Warp, the intelligent terminal for developers</b>
-  <div>
-    <sup>Available for MacOS and Linux<br>
-Visit warp.dev to learn more
-    </sup>
-  </div>
-</a>
+<div align="center" markdown="1">
+
+[![Warp](https://github.com/user-attachments/assets/2bda420d-4211-4900-a37e-e3c7056d799c)](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+**[Warp, the intelligent terminal for developers](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)**<br>
+[Available for MacOS and Linux](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)<br>
+[Visit warp.dev to learn more](https://www.warp.dev/?utm_source=github&utm_medium=referral&utm_campaign=inquirer)
+
 </div>
 
 # Installation


### PR DESCRIPTION
Proposal to replace HTML with only markdown.

Links in markdown do work on NPM, but can't test exactly the extent of their HTML support easily (also couldn't find specific documentation as to what's supported 😞)

[Changes visible here](https://github.com/SBoudrias/Inquirer.js/blob/sponsorship/links-for-npm/packages/prompts/README.md); main change is loosing the center alignment.

cc @ericdachen