### PR TITLE
rfc: multiline input

### DIFF
--- a/packages/core/src/lib/key.ts
+++ b/packages/core/src/lib/key.ts
@@ -1,6 +1,7 @@
 export type KeypressEvent = {
   name: string;
   ctrl: boolean;
+  shift: boolean;
 };
 
 export const isUpKey = (key: KeypressEvent): boolean =>

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -26,6 +26,7 @@ type InputConfig = {
   transformer?: (value: string, { isFinal }: { isFinal: boolean }) => string;
   validate?: (value: string) => boolean | string | Promise<string | boolean>;
   theme?: PartialDeep<Theme<InputTheme>>;
+  multiline?: boolean;
 };
 
 export default createPrompt<string, InputConfig>((config, done) => {
@@ -44,8 +45,8 @@ export default createPrompt<string, InputConfig>((config, done) => {
       return;
     }
 
-    if (isEnterKey(key)) {
-      const answer = value || defaultValue;
+    if (isEnterKey(key) && !key.shift) {
+      const answer = value.replaceAll('\r', '\n') || defaultValue;
       setStatus('loading');
 
       const isValid =
@@ -65,6 +66,9 @@ export default createPrompt<string, InputConfig>((config, done) => {
         setError(isValid || 'You must provide a valid value');
         setStatus('idle');
       }
+    } else if (isEnterKey(key) && key.shift && config.multiline) {
+      setValue(value + '\r');
+      rl.write('\r');
     } else if (isBackspaceKey(key) && !value) {
       setDefaultValue(undefined);
     } else if (key.name === 'tab' && !value) {
@@ -79,7 +83,7 @@ export default createPrompt<string, InputConfig>((config, done) => {
   });
 
   const message = theme.style.message(config.message, status);
-  let formattedValue = value;
+  let formattedValue = value.replaceAll('\r', '\n');
   if (typeof config.transformer === 'function') {
     formattedValue = config.transformer(value, { isFinal: status === 'done' });
   } else if (status === 'done') {


### PR DESCRIPTION
Hi! I'd love to get your thoughts on this. Essentially this should allow for multi-line input. The use case is an application like mine, where a user may want to "Shift+Enter" to start a newline in an input prompt, or paste content that contains newlines. For example, in my `ai` app I want to write a message, "Shift+Enter" to put in a newline, then Paste from my clipboard a code sample. You can roughly see the app in use here: https://github.com/dwmkerr/terminal-ai?tab=readme-ov-file#terminal-ai

The methodology is:

1. Add a new 'multiline' parameter. *None* of the changed logic should run unless this parameter is set, i.e. this is a 'noop' change for most users, unless the opt-in.
2. (When in multiline mode) Shift+Enter inserts a `\r` character.
3. (When in multiline mode) `\r` is rendered as `\n`
4. (When in multiline mode) in the final result, `\r` is rendered as `\n`

However I'm having a few issues with the PR:

1. Where is `ctrl` set on `Keypress`? I want to add a `shift`
2. When I try `yarn dev` I get this forever:

<img width="428" alt="image" src="https://github.com/user-attachments/assets/54ae0b03-42dd-452a-9eba-ac0c6fe96ba1" />

Finally, my use case is that hitting 'paste' when in the input would have some kind of event I can listen to so that in multiline mode I can transform the `\n` to `\r`. I'm not sure if this is possible.

Before I continue I'd love to know if this seems like a useful feature, if possible a hint on the `yarn dev` issue and a couple of pointers. Thanks in advance

### Potential Limitations

- In multiline mode, `\r` characters will not be handled properly, as they essentially become a placeholder for a 'non-input ending newline'
