### PR TITLE
docs: add npm download count badge

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -3,6 +3,7 @@
 # Inquirer
 
 [![npm](https://badge.fury.io/js/@inquirer%2Fprompts.svg)](https://www.npmjs.com/package/@inquirer/prompts)
+[![@inquirer/prompts downloads](https://img.shields.io/npm/dm/@inquirer/prompts.svg)](https://npm-compare.com/@inquirer/prompts/#timeRange=THREE_YEARS)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FSBoudrias%2FInquirer.js.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FSBoudrias%2FInquirer.js?ref=badge_shield)
 
 A collection of common interactive command line user interfaces.


### PR DESCRIPTION
Hi,
I've added a badge that links to the npm download statistics on npm-compare.com, specifically showing the download count over the past three years.

Here's what the change looks like:

[![@inquirer/prompts downloads](https://img.shields.io/npm/dm/@inquirer/prompts.svg)](https://npm-compare.com/@inquirer/prompts/#timeRange=THREE_YEARS)

Let me know if you have any feedback or if there’s anything else I can do to improve this. Thank you for your time and for maintaining this awesome project!