### PR TITLE
Support Node's --frozen-intrinsics flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn tsc
       - name: Integration tests
-        run: yarn node --test integration/
+        run: yarn node --test integration/**/*.test.*
 
   e2e:
     name: End to End build tests

--- a/integration/cjs/fixturePrompt.cjs
+++ b/integration/cjs/fixturePrompt.cjs
@@ -1,0 +1,3 @@
+const { createPrompt } = require('@inquirer/core');
+
+module.exports = createPrompt(function fixturePrompt() {});

--- a/integration/cjs/integration.test.cjs
+++ b/integration/cjs/integration.test.cjs
@@ -6,6 +6,7 @@ const { createPrompt } = require('@inquirer/core');
 const defaultInput = require('@inquirer/input').default;
 const inquirer = require('inquirer').default;
 const { createPromptModule } = require('inquirer');
+const fixturePrompt = require('./fixturePrompt.cjs');
 
 describe('CommonJS Integration', () => {
   it('@inquirer/prompts should be exported', () => {
@@ -18,6 +19,12 @@ describe('CommonJS Integration', () => {
 
   it('@inquirer/core should export createPrompt', () => {
     assert(typeof createPrompt === 'function');
+  });
+
+  it('works when prompt throws an error', async () => {
+    await assert.rejects(() => fixturePrompt({}), {
+      message: `Prompt functions must return a string.\n    at ${require.resolve('./fixturePrompt.cjs')}`,
+    });
   });
 
   it('inquirer should be exported', () => {

--- a/integration/esm/fixturePrompt.mjs
+++ b/integration/esm/fixturePrompt.mjs
@@ -1,0 +1,3 @@
+import { createPrompt } from '@inquirer/core';
+
+export default createPrompt(function fixturePrompt() {});

--- a/integration/esm/integration.test.mjs
+++ b/integration/esm/integration.test.mjs
@@ -1,10 +1,14 @@
 /* eslint-disable n/no-unsupported-features/node-builtins */
+import { createRequire } from 'node:module';
 import { describe, it } from 'node:test';
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import { input } from '@inquirer/prompts';
 import defaultInput from '@inquirer/input';
 import { createPrompt } from '@inquirer/core';
 import inquirer, { createPromptModule } from 'inquirer';
+import fixturePrompt from './fixturePrompt.mjs';
+
+const require = createRequire(import.meta.url);
 
 describe('ESM Integration', () => {
   it('@inquirer/prompts should be exported', () => {
@@ -17,6 +21,12 @@ describe('ESM Integration', () => {
 
   it('@inquirer/core should export createPrompt', () => {
     assert.ok(typeof createPrompt === 'function');
+  });
+
+  it('works when prompt throws an error', async () => {
+    await assert.rejects(() => fixturePrompt({}), {
+      message: `Prompt functions must return a string.\n    at file://${require.resolve('./fixturePrompt.mjs')}`,
+    });
   });
 
   it('inquirer should be exported', () => {

--- a/packages/core/src/lib/create-prompt.ts
+++ b/packages/core/src/lib/create-prompt.ts
@@ -16,20 +16,22 @@ type ViewFunction<Value, Config> = (
 
 function getCallSites() {
   const _prepareStackTrace = Error.prepareStackTrace;
+  let result: NodeJS.CallSite[] = [];
   try {
-    let result: NodeJS.CallSite[] = [];
     Error.prepareStackTrace = (_, callSites) => {
       const callSitesWithoutCurrent = callSites.slice(1);
       result = callSitesWithoutCurrent;
       return callSitesWithoutCurrent;
     };
-
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions, unicorn/error-message
     new Error().stack;
+  } catch {
+    // An error will occur if the Node flag --frozen-intrinsics is used.
+    // https://nodejs.org/api/cli.html#--frozen-intrinsics
     return result;
-  } finally {
-    Error.prepareStackTrace = _prepareStackTrace;
   }
+  Error.prepareStackTrace = _prepareStackTrace;
+  return result;
 }
 
 export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {

--- a/packages/core/src/lib/create-prompt.ts
+++ b/packages/core/src/lib/create-prompt.ts
@@ -36,7 +36,6 @@ function getCallSites() {
 
 export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
   const callSites = getCallSites();
-  const callerFilename = callSites[1]?.getFileName?.();
 
   const prompt: Prompt<Value, Config> = (config, context = {}) => {
     // Default `input` to stdin
@@ -100,6 +99,7 @@ export function createPrompt<Value, Config>(view: ViewFunction<Value, Config>) {
           // Typescript won't allow this, but not all users rely on typescript.
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (nextView === undefined) {
+            const callerFilename = callSites[1]?.getFileName?.();
             throw new Error(
               `Prompt functions must return a string.\n    at ${callerFilename}`,
             );


### PR DESCRIPTION
Skip assignment of
```js
Error.prepareStackTrace = _prepareStackTrace
```
when the value hasn't changed to avoid triggering a mutation error when Node flag `--frozen-intrinsics` is used.
https://nodejs.org/api/cli.html#--frozen-intrinsics