### PR TITLE
doc: add `@inquirer-cli` mention in readme.

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -348,7 +348,8 @@ A community library, [@inquirer-cli](https://github.com/fishballapp/inquirer-cli
 For example, to prompt for input:
 
 ```bash
-$ npx @inquirer-cli/input 'Enter your name'
+name=$(npx -y @inquirer-cli/input -r "What is your name?")
+echo "Hello, $name!"
 ```
 
 Or to create an interactive version bump:

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -51,6 +51,26 @@ import { input } from '@inquirer/prompts';
 const answer = await input({ message: 'Enter your name' });
 ```
 
+## Usage with `npx`
+
+You can use Inquirer prompts directly in the shell via [`npx`](https://docs.npmjs.com/cli/v8/commands/npx), which is useful for quick scripts or `package.json` commands.
+
+A community library, [@inquirer-cli](https://github.com/fishballapp/inquirer-cli), exposes each prompt as a standalone CLI.
+
+For example, to prompt for input:
+
+```bash
+$ npx @inquirer-cli/input 'Enter your name'
+```
+
+Or to create an interactive version bump:
+
+```bash
+$ npm version $(npx @inquirer-cli/select -c patch -c minor -c major 'Select Version')
+```
+
+Find out more: [@inquirer-cli](https://github.com/fishballapp/inquirer-cli).
+
 # Prompts
 
 ## [Input](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/input)

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -51,26 +51,6 @@ import { input } from '@inquirer/prompts';
 const answer = await input({ message: 'Enter your name' });
 ```
 
-## Usage with `npx`
-
-You can use Inquirer prompts directly in the shell via [`npx`](https://docs.npmjs.com/cli/v8/commands/npx), which is useful for quick scripts or `package.json` commands.
-
-A community library, [@inquirer-cli](https://github.com/fishballapp/inquirer-cli), exposes each prompt as a standalone CLI.
-
-For example, to prompt for input:
-
-```bash
-$ npx @inquirer-cli/input 'Enter your name'
-```
-
-Or to create an interactive version bump:
-
-```bash
-$ npm version $(npx -y @inquirer-cli/select -c patch -c minor -c major 'Select Version')
-```
-
-Find out more: [@inquirer-cli](https://github.com/fishballapp/inquirer-cli).
-
 # Prompts
 
 ## [Input](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/input)
@@ -358,6 +338,26 @@ import { confirm } from '@inquirer/prompts';
 
 const answer = await confirm({ message: await getMessage() });
 ```
+
+## Usage with `npx`
+
+You can use Inquirer prompts directly in the shell via [`npx`](https://docs.npmjs.com/cli/v8/commands/npx), which is useful for quick scripts or `package.json` commands.
+
+A community library, [@inquirer-cli](https://github.com/fishballapp/inquirer-cli), exposes each prompt as a standalone CLI.
+
+For example, to prompt for input:
+
+```bash
+$ npx @inquirer-cli/input 'Enter your name'
+```
+
+Or to create an interactive version bump:
+
+```bash
+$ npm version $(npx -y @inquirer-cli/select -c patch -c minor -c major 'Select Version')
+```
+
+Find out more: [@inquirer-cli](https://github.com/fishballapp/inquirer-cli).
 
 # Community prompts
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -66,7 +66,7 @@ $ npx @inquirer-cli/input 'Enter your name'
 Or to create an interactive version bump:
 
 ```bash
-$ npm version $(npx @inquirer-cli/select -c patch -c minor -c major 'Select Version')
+$ npm version $(npx -y @inquirer-cli/select -c patch -c minor -c major 'Select Version')
 ```
 
 Find out more: [@inquirer-cli](https://github.com/fishballapp/inquirer-cli).

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -339,7 +339,7 @@ import { confirm } from '@inquirer/prompts';
 const answer = await confirm({ message: await getMessage() });
 ```
 
-## Usage with `npx`
+## Usage with `npx` within bash scripts
 
 You can use Inquirer prompts directly in the shell via [`npx`](https://docs.npmjs.com/cli/v8/commands/npx), which is useful for quick scripts or `package.json` commands.
 


### PR DESCRIPTION
Hello 👋

I have added the `@inquirer-cli` mention in the readme. I put it under the `Usage` section as I guess it counts as an alternative usage for `Inquirer.js`?

Happy to be told to move it further down. 😂

Jason