### PR TITLE
Fix done!  prevented Separator from counted in indexMode: number

### DIFF
--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -231,7 +231,7 @@ export default createPrompt(
         );
       }
     }
-
+    let visibleIndex = 0;
     const page = usePagination({
       items,
       active,
@@ -240,7 +240,7 @@ export default createPrompt(
           return ` ${item.separator}`;
         }
 
-        const indexLabel = theme.indexMode === 'number' ? `${index + 1}. ` : '';
+        const indexLabel = theme.indexMode === 'number' ? `${++visibleIndex}. ` : '';
         if (item.disabled) {
           const disabledLabel =
             typeof item.disabled === 'string' ? item.disabled : '(disabled)';

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -141,16 +141,12 @@ export default createPrompt(
       return { first, last };
     }, [items]);
 
-    const defaultItemIndex = useMemo(() => {
-      if (!('default' in config)) return -1;
-      return items.findIndex(
-        (item) => isSelectable(item) && item.value === config.default,
-      );
-    }, [config.default, items]);
-
-    const [active, setActive] = useState(
-      defaultItemIndex === -1 ? bounds.first : defaultItemIndex,
-    );
+    const [active, setActive] = useState(() => {
+      const index = 'default' in config
+        ? items.findIndex((item) => isSelectable(item) && item.value === config.default)
+        : -1;
+      return index !== -1 ? index : bounds.first;
+    });
 
     // Safe to assume the cursor position always point to a Choice.
     const selectedChoice = items[active] as NormalizedChoice<Value>;
@@ -231,7 +227,7 @@ export default createPrompt(
         );
       }
     }
-    let visibleIndex = 0;
+
     const page = usePagination({
       items,
       active,
@@ -240,7 +236,7 @@ export default createPrompt(
           return ` ${item.separator}`;
         }
 
-        const indexLabel = theme.indexMode === 'number' ? `${++visibleIndex}. ` : '';
+        const indexLabel = theme.indexMode === 'number' ? `${index + 1}. ` : '';
         if (item.disabled) {
           const disabledLabel =
             typeof item.disabled === 'string' ? item.disabled : '(disabled)';

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -142,9 +142,10 @@ export default createPrompt(
     }, [items]);
 
     const [active, setActive] = useState(() => {
-      const index = 'default' in config
-        ? items.findIndex((item) => isSelectable(item) && item.value === config.default)
-        : -1;
+      const index =
+        'default' in config
+          ? items.findIndex((item) => isSelectable(item) && item.value === config.default)
+          : -1;
       return index !== -1 ? index : bounds.first;
     });
 


### PR DESCRIPTION
`indexMode: 'number'`, this fix makes sure that `Separator` entries don't increment numbered index. This will behave as intended by displaying numeric indices only for selectable choices. I am still a beginner in open source - Please review and let me know if any changes are needed. Thank you! Still a small error to fix!