### PR TITLE
Ignore separators when selecting item with a number key

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -223,10 +223,19 @@ export default createPrompt(
       } else if (key.name === shortcuts.invert) {
         setItems(items.map(toggle));
       } else if (isNumberKey(key)) {
-        // Adjust index to start at 1
-        const position = Number(key.name) - 1;
-        const item = items[position];
-        if (item != null && isSelectable(item)) {
+        const selectedIndex = Number(key.name) - 1;
+
+        // Find the nth item (ignoring separators)
+        let selectableIndex = -1;
+        const position = items.findIndex((item) => {
+          if (Separator.isSeparator(item)) return false;
+
+          selectableIndex++;
+          return selectableIndex === selectedIndex;
+        });
+
+        const selectedItem = items[position];
+        if (selectedItem && isSelectable(selectedItem)) {
           setActive(position);
           setItems(items.map((choice, i) => (i === position ? toggle(choice) : choice)));
         }

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -176,7 +176,17 @@ export default createPrompt(
           setActive(next);
         }
       } else if (isNumberKey(key) && !Number.isNaN(Number(rl.line))) {
-        const position = Number(rl.line) - 1;
+        const selectedIndex = Number(rl.line) - 1;
+
+        // Find the nth item (ignoring separators)
+        let selectableIndex = -1;
+        const position = items.findIndex((item) => {
+          if (Separator.isSeparator(item)) return false;
+
+          selectableIndex++;
+          return selectableIndex === selectedIndex;
+        });
+
         const item = items[position];
         if (item != null && isSelectable(item)) {
           setActive(position);

--- a/packages/select/test/select.test.ts
+++ b/packages/select/test/select.test.ts
@@ -1026,4 +1026,50 @@ describe('select prompt', () => {
     events.keypress('enter');
     await expect(answer).resolves.toEqual(1);
   });
+
+  describe('numeric selection with separators', () => {
+    it('selects the correct item when separators are in the middle', async () => {
+      const { answer, events, getScreen } = await render(select, {
+        message: 'Select a number',
+        choices: [
+          { value: 1, name: 'One' },
+          { value: 2, name: 'Two' },
+          new Separator(),
+          { value: 3, name: 'Three' },
+          { value: 4, name: 'Four' },
+          new Separator('---'),
+          { value: 5, name: 'Five' },
+          { value: 6, name: 'Six' },
+        ],
+      });
+
+      events.type('5');
+      expect(getScreen()).toContain('❯ Five');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(5);
+    });
+
+    it('selects the correct item when separators are at the beginning', async () => {
+      const { answer, events, getScreen } = await render(select, {
+        message: 'Select a number',
+        choices: [
+          new Separator(),
+          new Separator('---'),
+          { value: 1, name: 'One' },
+          { value: 2, name: 'Two' },
+          { value: 3, name: 'Three' },
+          { value: 4, name: 'Four' },
+        ],
+      });
+
+      // Type '3' to select the 3rd selectable item (which is 'Three')
+      events.type('3');
+
+      expect(getScreen()).toContain('❯ Three');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(3);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1786

Fix implemented in both checkbox and select prompts.