### PR TITLE
fix(@inquirer/core): Remove vim/emacs easter eggs conflicting with type-to-search

### DIFF
--- a/packages/confirm/src/index.ts
+++ b/packages/confirm/src/index.ts
@@ -3,6 +3,7 @@ import {
   useState,
   useKeypress,
   isEnterKey,
+  isTabKey,
   usePrefix,
   makeTheme,
   type Theme,
@@ -43,7 +44,7 @@ export default createPrompt<boolean, ConfirmConfig>((config, done) => {
       setValue(transformer(answer));
       setStatus('done');
       done(answer);
-    } else if (key.name === 'tab') {
+    } else if (isTabKey(key)) {
       const answer = boolToString(!getBooleanValue(value, config.default));
       rl.clearLine(0); // Remove the tab character.
       rl.write(answer);

--- a/packages/core/src/lib/key.ts
+++ b/packages/core/src/lib/key.ts
@@ -3,25 +3,15 @@ export type KeypressEvent = {
   ctrl: boolean;
 };
 
-export const isUpKey = (key: KeypressEvent): boolean =>
-  // The up key
-  key.name === 'up' ||
-  // Vim keybinding
-  key.name === 'k' ||
-  // Emacs keybinding
-  (key.ctrl && key.name === 'p');
+export const isUpKey = (key: KeypressEvent): boolean => key.name === 'up';
 
-export const isDownKey = (key: KeypressEvent): boolean =>
-  // The down key
-  key.name === 'down' ||
-  // Vim keybinding
-  key.name === 'j' ||
-  // Emacs keybinding
-  (key.ctrl && key.name === 'n');
+export const isDownKey = (key: KeypressEvent): boolean => key.name === 'down';
 
 export const isSpaceKey = (key: KeypressEvent): boolean => key.name === 'space';
 
 export const isBackspaceKey = (key: KeypressEvent): boolean => key.name === 'backspace';
+
+export const isTabKey = (key: KeypressEvent): boolean => key.name === 'tab';
 
 export const isNumberKey = (key: KeypressEvent): boolean =>
   '1234567890'.includes(key.name);

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -4,8 +4,9 @@ import {
   useKeypress,
   useEffect,
   usePrefix,
-  isEnterKey,
   isBackspaceKey,
+  isEnterKey,
+  isTabKey,
   makeTheme,
   type Theme,
   type Status,
@@ -69,7 +70,7 @@ export default createPrompt<string, InputConfig>((config, done) => {
       }
     } else if (isBackspaceKey(key) && !value) {
       setDefaultValue(undefined);
-    } else if (key.name === 'tab' && !value) {
+    } else if (isTabKey(key) && !value) {
       setDefaultValue(undefined);
       rl.clearLine(0); // Remove the tab character.
       rl.write(defaultValue);

--- a/packages/number/src/index.ts
+++ b/packages/number/src/index.ts
@@ -3,8 +3,9 @@ import {
   useState,
   useKeypress,
   usePrefix,
-  isEnterKey,
   isBackspaceKey,
+  isEnterKey,
+  isTabKey,
   makeTheme,
   type Theme,
   type Status,
@@ -113,7 +114,7 @@ export default createPrompt(
         }
       } else if (isBackspaceKey(key) && !value) {
         setDefaultValue(undefined);
-      } else if (key.name === 'tab' && !value) {
+      } else if (isTabKey(key) && !value) {
         setDefaultValue(undefined);
         rl.clearLine(0); // Remove the tab character.
         rl.write(defaultValue);

--- a/packages/rawlist/src/index.ts
+++ b/packages/rawlist/src/index.ts
@@ -4,7 +4,9 @@ import {
   useState,
   useKeypress,
   usePrefix,
+  isDownKey,
   isEnterKey,
+  isUpKey,
   Separator,
   makeTheme,
   type Theme,
@@ -131,22 +133,21 @@ export default createPrompt(
         } else {
           setError(`"${colors.red(value)}" isn't an available option`);
         }
-      } else if (key.name === 'up' || key.name === 'down') {
+      } else if (isUpKey(key) || isDownKey(key)) {
         rl.clearLine(0);
 
         const [selectedChoice, active] = getSelectedChoice(value, choices);
         if (!selectedChoice) {
-          const firstChoice =
-            key.name === 'down'
-              ? choices.find(isSelectableChoice)!
-              : choices.findLast(isSelectableChoice)!;
+          const firstChoice = isDownKey(key)
+            ? choices.find(isSelectableChoice)!
+            : choices.findLast(isSelectableChoice)!;
           setValue(firstChoice.key);
         } else if (
           loop ||
-          (key.name === 'up' && active !== bounds.first) ||
-          (key.name === 'down' && active !== bounds.last)
+          (isUpKey(key) && active !== bounds.first) ||
+          (isDownKey(key) && active !== bounds.last)
         ) {
-          const offset = key.name === 'up' ? -1 : 1;
+          const offset = isUpKey(key) ? -1 : 1;
           let next = active;
           do {
             next = (next + offset + choices.length) % choices.length;

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -7,7 +7,10 @@ import {
   useRef,
   useEffect,
   useMemo,
+  isDownKey,
   isEnterKey,
+  isTabKey,
+  isUpKey,
   Separator,
   makeTheme,
   type Theme,
@@ -195,17 +198,17 @@ export default createPrompt(
           // get cleared, forcing the user to re-enter the value instead of fixing it.
           rl.write(searchTerm);
         }
-      } else if (key.name === 'tab' && selectedChoice) {
+      } else if (isTabKey(key) && selectedChoice) {
         rl.clearLine(0); // Remove the tab character.
         rl.write(selectedChoice.name);
         setSearchTerm(selectedChoice.name);
-      } else if (status !== 'loading' && (key.name === 'up' || key.name === 'down')) {
+      } else if (status !== 'loading' && (isUpKey(key) || isDownKey(key))) {
         rl.clearLine(0);
         if (
-          (key.name === 'up' && active !== bounds.first) ||
-          (key.name === 'down' && active !== bounds.last)
+          (isUpKey(key) && active !== bounds.first) ||
+          (isDownKey(key) && active !== bounds.last)
         ) {
-          const offset = key.name === 'up' ? -1 : 1;
+          const offset = isUpKey(key) ? -1 : 1;
           let next = active;
           do {
             next = (next + offset + searchResults.length) % searchResults.length;


### PR DESCRIPTION
Fix #1819

The vim bindings in particular conflicts with search/select type to search feature; and it's now been inconsistently supported across prompt. As such, I think the best path forward is removal of that "easter egg"/nice to have.