### PR TITLE
docs(@inquirer/select): Rename disabled to description in usage example

### DIFF
--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -87,7 +87,7 @@ const answer = await select({
     {
       name: 'pnpm',
       value: 'pnpm',
-      disabled: '(pnpm is not available)',
+      description: '(pnpm is not available)',
     },
   ],
 });


### PR DESCRIPTION
Maybe it is a typo. The `disabled` option type is `boolean`, not `string`, so it should be `description`