### PR TITLE
Chore/ansi-escape2

### DIFF
--- a/packages/core/src/lib/ansi.ts
+++ b/packages/core/src/lib/ansi.ts
@@ -1,17 +1,25 @@
+/** ANSI escape sequence introducer */
 const ESC = '\u001B[';
 
+/** Move cursor to first column */
 export const cursorLeft = ESC + 'G';
+/** Hide the cursor */
 export const cursorHide = ESC + '?25l';
+/** Show the cursor */
 export const cursorShow = ESC + '?25h';
 
+/** Move cursor up by count rows */
 export const cursorUp = (count: number): string => (count > 0 ? `${ESC}${count}A` : '');
 
+/** Move cursor down by count rows */
 export const cursorDown = (count: number): string => (count > 0 ? `${ESC}${count}B` : '');
 
-/** Move cursor to column x (1-based). */
+/** Move cursor to column x (1-based) */
 export const cursorToX = (x: number): string => `${ESC}${x + 1}G`;
 
+/** Erase the entire current line */
 const eraseLine = ESC + '2K';
 
+/** Erase the specified number of lines above the cursor */
 export const eraseLines = (count: number): string =>
   count > 0 ? (eraseLine + cursorUp(1)).repeat(count - 1) + eraseLine + cursorLeft : '';

--- a/packages/core/src/lib/ansi.ts
+++ b/packages/core/src/lib/ansi.ts
@@ -1,40 +1,17 @@
 const ESC = '\u001B[';
-const SEP = ';';
 
 export const cursorLeft = ESC + 'G';
 export const cursorHide = ESC + '?25l';
 export const cursorShow = ESC + '?25h';
 
-export const cursorUp = (count = 1): string =>
-  count > 0 ? ESC + String(count) + 'A' : '';
+export const cursorUp = (count: number): string => (count > 0 ? `${ESC}${count}A` : '');
 
-export const cursorDown = (count = 1): string =>
-  count > 0 ? ESC + String(count) + 'B' : '';
+export const cursorDown = (count: number): string => (count > 0 ? `${ESC}${count}B` : '');
 
-export const cursorTo = (x: number, y?: number): string => {
-  if (typeof x !== 'number') {
-    throw new TypeError('The `x` argument is required');
-  }
+/** Move cursor to column x (1-based). */
+export const cursorToX = (x: number): string => `${ESC}${x + 1}G`;
 
-  if (typeof y !== 'number') {
-    return ESC + String(x + 1) + 'G';
-  }
+const eraseLine = ESC + '2K';
 
-  return ESC + String(y + 1) + SEP + String(x + 1) + 'H';
-};
-
-export const eraseLine = ESC + '2K';
-
-export const eraseLines = (count: number): string => {
-  let clear = '';
-
-  for (let i = 0; i < count; i++) {
-    clear += eraseLine + (i < count - 1 ? cursorUp() : '');
-  }
-
-  if (count) {
-    clear += cursorLeft;
-  }
-
-  return clear;
-};
+export const eraseLines = (count: number): string =>
+  count > 0 ? (eraseLine + cursorUp(1)).repeat(count - 1) + eraseLine + cursorLeft : '';

--- a/packages/core/src/lib/screen-manager.ts
+++ b/packages/core/src/lib/screen-manager.ts
@@ -1,6 +1,6 @@
 import stripAnsi from 'strip-ansi';
 import { breakLines, readlineWidth } from './utils.js';
-import { cursorDown, cursorUp, cursorTo, cursorShow, eraseLines } from './ansi.js';
+import { cursorDown, cursorUp, cursorToX, cursorShow, eraseLines } from './ansi.js';
 import type { InquirerReadline } from '@inquirer/type';
 
 const height = (content: string): number => content.split('\n').length;
@@ -69,10 +69,10 @@ export default class ScreenManager {
       promptLineUpDiff + (bottomContent ? height(bottomContent) : 0);
 
     // Return cursor to the input position (on top of the bottomContent)
-    if (bottomContentHeight > 0) output += cursorUp(bottomContentHeight);
+    output += cursorUp(bottomContentHeight);
 
     // Return cursor to the initial left offset.
-    output += cursorTo(this.cursorPos.cols);
+    output += cursorToX(this.cursorPos.cols);
 
     /**
      * Render and store state for future re-rendering
@@ -86,7 +86,7 @@ export default class ScreenManager {
   checkCursorPos() {
     const cursorPos = this.rl.getCursorPos();
     if (cursorPos.cols !== this.cursorPos.cols) {
-      this.write(cursorTo(cursorPos.cols));
+      this.write(cursorToX(cursorPos.cols));
       this.cursorPos = cursorPos;
     }
   }


### PR DESCRIPTION
Improve #1602

- Replaced cursorTo with cursorToX (for horizontal positioning only), as the y argument was never used in practice
  - Removed now unused constants SEP
- Simplified cursorUp, cursorDown, eraseLines implementations
- Updated screen-manager to use cursorToX instead
- Improved code clarity and added comments