### PR TITLE
 Add optional support for vim and emac bindings 

### DIFF
--- a/packages/core/core.test.ts
+++ b/packages/core/core.test.ts
@@ -479,6 +479,7 @@ describe('createPrompt()', () => {
       message: 'Question',
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     answer.cancel();
     events.keypress('enter');
 
@@ -599,8 +600,10 @@ it('allow cancelling the prompt multiple times', async () => {
   const prompt = createPrompt(Prompt);
   const { answer, events } = await render(prompt, { message: 'Question' });
 
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   answer.cancel();
 
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   answer.cancel();
   events.keypress('enter');
 

--- a/packages/core/core.test.ts
+++ b/packages/core/core.test.ts
@@ -479,7 +479,6 @@ describe('createPrompt()', () => {
       message: 'Question',
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     answer.cancel();
     events.keypress('enter');
 
@@ -600,10 +599,8 @@ it('allow cancelling the prompt multiple times', async () => {
   const prompt = createPrompt(Prompt);
   const { answer, events } = await render(prompt, { message: 'Question' });
 
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   answer.cancel();
 
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   answer.cancel();
   events.keypress('enter');
 
@@ -767,5 +764,27 @@ describe('Separator', () => {
       '"──────────────"',
     );
     expect(new Separator('===').separator).toEqual('===');
+  });
+});
+
+describe('vim emacs bindings', () => {
+  it('supports vim and emac bindings when option passed in', () => {
+    expect(isUpKey({ name: 'up' }, true)).toBeTruthy();
+    expect(isUpKey({ name: 'k' }, true)).toBeTruthy();
+    expect(isUpKey({ name: 'p', ctrl: true }, true)).toBeTruthy();
+
+    expect(isDownKey({ name: 'down' }, true)).toBeTruthy();
+    expect(isDownKey({ name: 'j' }, true)).toBeTruthy();
+    expect(isDownKey({ name: 'n', ctrl: true }, true)).toBeTruthy();
+  });
+
+  it('does not support vim and emac bindings by default', () => {
+    expect(isUpKey({ name: 'up' })).toBeTruthy();
+    expect(isUpKey({ name: 'k' })).toBeFalsy();
+    expect(isUpKey({ name: 'p', ctrl: true })).toBeFalsy();
+
+    expect(isDownKey({ name: 'down' })).toBeTruthy();
+    expect(isDownKey({ name: 'j' })).toBeFalsy();
+    expect(isDownKey({ name: 'n', ctrl: true })).toBeFalsy();
   });
 });

--- a/packages/core/src/lib/key.ts
+++ b/packages/core/src/lib/key.ts
@@ -3,9 +3,21 @@ export type KeypressEvent = {
   ctrl: boolean;
 };
 
-export const isUpKey = (key: KeypressEvent): boolean => key.name === 'up';
+export const isUpKey = (key: KeypressEvent, vimEmacsBindings: boolean = false): boolean =>
+  // The up key
+  key.name === 'up' ||
+  // Vim keybinding
+  (vimEmacsBindings && key.name === 'k') ||
+  // Emacs keybinding
+  (vimEmacsBindings && key.ctrl && key.name === 'p');
 
-export const isDownKey = (key: KeypressEvent): boolean => key.name === 'down';
+export const isDownKey = (key: KeypressEvent, vimEmacsBindings: boolean = false): boolean =>
+  // The down key
+  key.name === 'down' ||
+  // Vim keybinding
+  (vimEmacsBindings && key.name === 'j') ||
+  // Emacs keybinding
+  (vimEmacsBindings && key.ctrl && key.name === 'n');
 
 export const isSpaceKey = (key: KeypressEvent): boolean => key.name === 'space';
 

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -60,12 +60,7 @@ type NormalizedChoice<Value> = {
   disabled: boolean | string;
 };
 
-type SelectConfig<
-  Value,
-  ChoicesObject =
-    | ReadonlyArray<string | Separator>
-    | ReadonlyArray<Choice<Value> | Separator>,
-> = {
+type SelectConfig<Value, ChoicesObject = ReadonlyArray<string | Separator>> = {
   message: string;
   choices: ChoicesObject extends ReadonlyArray<string | Separator>
     ? ChoicesObject
@@ -78,6 +73,7 @@ type SelectConfig<
     pager: string;
   };
   theme?: PartialDeep<Theme<SelectTheme>>;
+  vimEmacsBindings?: boolean;
 };
 
 function isSelectable<Value>(
@@ -87,7 +83,7 @@ function isSelectable<Value>(
 }
 
 function normalizeChoices<Value>(
-  choices: ReadonlyArray<string | Separator> | ReadonlyArray<Choice<Value> | Separator>,
+  choices: ReadonlyArray<string | Separator>,
 ): Array<NormalizedChoice<Value> | Separator> {
   return choices.map((choice) => {
     if (Separator.isSeparator(choice)) return choice;
@@ -161,18 +157,21 @@ export default createPrompt(
       if (isEnterKey(key)) {
         setStatus('done');
         done(selectedChoice.value);
-      } else if (isUpKey(key) || isDownKey(key)) {
+      } else if (
+        isUpKey(key, config.vimEmacsBindings) ||
+        isDownKey(key, config.vimEmacsBindings)
+      ) {
         rl.clearLine(0);
         if (
           loop ||
-          (isUpKey(key) && active !== bounds.first) ||
-          (isDownKey(key) && active !== bounds.last)
+          (isUpKey(key, config.vimEmacsBindings) && active !== bounds.first) ||
+          (isDownKey(key, config.vimEmacsBindings) && active !== bounds.last)
         ) {
-          const offset = isUpKey(key) ? -1 : 1;
+          const offset = isUpKey(key, config.vimEmacsBindings) ? -1 : 1;
           let next = active;
           do {
             next = (next + offset + items.length) % items.length;
-          } while (!isSelectable(items[next]!));
+          } while (!isSelectable(items[next]));
           setActive(next);
         }
       } else if (isNumberKey(key) && !Number.isNaN(Number(rl.line))) {

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -60,7 +60,13 @@ type NormalizedChoice<Value> = {
   disabled: boolean | string;
 };
 
-type SelectConfig<Value, ChoicesObject = ReadonlyArray<string | Separator>> = {
+
+type SelectConfig<
+  Value,
+  ChoicesObject =
+    | ReadonlyArray<string | Separator>
+    | ReadonlyArray<Choice<Value> | Separator>,
+> = {
   message: string;
   choices: ChoicesObject extends ReadonlyArray<string | Separator>
     ? ChoicesObject
@@ -83,7 +89,7 @@ function isSelectable<Value>(
 }
 
 function normalizeChoices<Value>(
-  choices: ReadonlyArray<string | Separator>,
+  choices: ReadonlyArray<string | Separator> | ReadonlyArray<Choice<Value> | Separator>,
 ): Array<NormalizedChoice<Value> | Separator> {
   return choices.map((choice) => {
     if (Separator.isSeparator(choice)) return choice;
@@ -171,7 +177,7 @@ export default createPrompt(
           let next = active;
           do {
             next = (next + offset + items.length) % items.length;
-          } while (!isSelectable(items[next]));
+          } while (!isSelectable(items[next]!));
           setActive(next);
         }
       } else if (isNumberKey(key) && !Number.isNaN(Number(rl.line))) {

--- a/packages/select/test/select.test.ts
+++ b/packages/select/test/select.test.ts
@@ -1100,4 +1100,46 @@ describe('select prompt', () => {
       await expect(answer).resolves.toEqual(3);
     });
   });
+
+  describe('vimEmacsBindings', () => {
+    it('supports vim and emac bindings when config option is passed in', async () => {
+      const { answer, events, getScreen } = await render(select, {
+        message: 'Select a number',
+        choices: [
+          new Separator(),
+          new Separator('---'),
+          { value: 1, name: 'One' },
+          { value: 2, name: 'Two' },
+          { value: 3, name: 'Three' },
+          { value: 4, name: 'Four' },
+        ],
+        theme: {
+          indexMode: 'number',
+        },
+        vimEmacsBindings: true,
+      });
+
+      expect(getScreen()).toMatchInlineSnapshot(`
+        "? Select a number (Use arrow keys)
+         ──────────────
+         ---
+        ❯ 1. One
+          2. Two
+          3. Three
+          4. Four"
+      `);
+
+      // Vim bindings
+      events.keypress('j');
+      expect(getScreen()).toContain('❯ 2. Two');
+      events.keypress('k');
+      expect(getScreen()).toContain('❯ 1. One');
+
+      // Emac bindings
+      events.keypress({ name: 'n', ctrl: true });
+      expect(getScreen()).toContain('❯ 2. Two');
+      events.keypress({ name: 'p', ctrl: true });
+      expect(getScreen()).toContain('❯ 1. One');
+    });
+  });
 });


### PR DESCRIPTION
https://github.com/SBoudrias/Inquirer.js/pull/1822 removed the vim and emacs keybindings - this adds an option to `@inquirer/select` to support them again.