### PR TITLE
Add checkedName support for checkboxes

### DIFF
--- a/packages/checkbox/src/index.mts
+++ b/packages/checkbox/src/index.mts
@@ -53,6 +53,7 @@ type Choice<Value> = {
   value: Value;
   disabled?: boolean | string;
   checked?: boolean;
+  checkedName?: string;
   type?: never;
 };
 
@@ -182,7 +183,7 @@ export default createPrompt(
           return ` ${item.separator}`;
         }
 
-        const line = item.name || item.value;
+        const line = item.checked ? item.checkedName || item.name || item.value : item.name || item.value;
         if (item.disabled) {
           const disabledLabel =
             typeof item.disabled === 'string' ? item.disabled : '(disabled)';

--- a/packages/demo/demos/checkbox.mjs
+++ b/packages/demo/demos/checkbox.mjs
@@ -53,6 +53,17 @@ const demo = async () => {
     ],
   });
   console.log('Answer:', answer);
+
+  answer = await checkbox({
+    message: 'Select fruits',
+    choices: [
+      new Separator('== Fruits with checkedName (changes when selected) =='),
+      { name: 'Apple', value: 'apple', checkedName: 'Apple selected' },
+      { name: 'Banana', value: 'banana', checkedName: 'Banana selected' },
+      { name: 'Cherry', value: 'cherry' },
+    ],
+  });
+  console.log('Answer:', answer);
 };
 
 if (import.meta.url.startsWith('file:')) {


### PR DESCRIPTION
Adds an optional checkedName property to Choice. When a choice is selected, checkedName is displayed instead of name.

Example:
{ name: 'Apple', value: 'apple', checkedName: 'Apple selected' }

Fully backward-compatible. Demo added in the demo folder.