### PR TITLE
feat: show checkedName for selected checkbox options

### DIFF
--- a/packages/checkbox/checkbox.test.ts
+++ b/packages/checkbox/checkbox.test.ts
@@ -1279,5 +1279,53 @@ describe('checkbox prompt', () => {
       events.keypress('enter');
       await expect(answer).resolves.toEqual(['three']);
     });
+
+   it('displays checkedName when option is selected', async () => {
+    const choices = [
+      { name: 'npm', value: 'npm', checkedName: 'Node Package Manager' },
+      { name: 'yarn', value: 'yarn', checkedName: 'Yet Another Resource Negotiator' },
+      new Separator(),
+      { name: 'jspm', value: 'jspm' },
+      { name: 'pnpm', value: 'pnpm', disabled: '(pnpm is not available)' },
+    ];
+
+    const { answer, events, getScreen } = await render(checkbox, {
+      message: 'Select package managers',
+      choices,
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select package managers (Press <space> to select, <a> to toggle all, <i> to
+      invert selection, and <enter> to proceed)
+      ❯◯ npm
+      ◯ yarn
+      ──────────────
+      ◯ jspm
+      - pnpm (pnpm is not available)"
+    `);
+
+    events.keypress('space');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select package managers
+      ❯◉ Node Package Manager
+       ◯ yarn
+       ──────────────
+       ◯ jspm
+      - pnpm (pnpm is not available)"
+    `);
+    events.keypress('down');
+    events.keypress('space');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select package managers
+       ◉ Node Package Manager
+      ❯◉ Yet Another Resource Negotiator
+       ──────────────
+       ◯ jspm
+      - pnpm (pnpm is not available)"
+    `);
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(['npm', 'yarn']);
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Select package managers npm, yarn"`);
+  });
   });
 });

--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -63,6 +63,7 @@ type Choice<Value> = {
   value: Value;
   name?: string;
   description?: string;
+  checkedName?: string;
   short?: string;
   disabled?: boolean | string;
   checked?: boolean;
@@ -73,6 +74,7 @@ type NormalizedChoice<Value> = {
   value: Value;
   name: string;
   description?: string;
+  checkedName?: string;
   short: string;
   disabled: boolean | string;
   checked: boolean;
@@ -131,6 +133,7 @@ function normalizeChoices<Value>(
         value: choice as Value,
         name: choice,
         short: choice,
+        checkedName: choice,
         disabled: false,
         checked: false,
       };
@@ -141,6 +144,7 @@ function normalizeChoices<Value>(
       value: choice.value,
       name,
       short: choice.short ?? name,
+      checkedName: choice.checkedName ?? undefined,
       disabled: choice.disabled ?? false,
       checked: choice.checked ?? false,
     };
@@ -264,9 +268,10 @@ export default createPrompt(
         }
 
         const checkbox = item.checked ? theme.icon.checked : theme.icon.unchecked;
+        const displayVal = item.checked ? item.checkedName || item.name : item.name;
         const color = isActive ? theme.style.highlight : (x: string) => x;
         const cursor = isActive ? theme.icon.cursor : ' ';
-        return color(`${cursor}${checkbox} ${item.name}`);
+        return color(`${cursor}${checkbox} ${displayVal}`);
       },
       pageSize,
       loop,

--- a/packages/demo/src/demos/checkbox.ts
+++ b/packages/demo/src/demos/checkbox.ts
@@ -53,6 +53,22 @@ const demo = async () => {
     ],
   });
   console.log('Answer:', answer);
+
+  answer = await checkbox({
+    message: 'Select a package manager (custom checked name)',
+    choices: [
+      { name: 'npm', value: 'npm', checkedName: 'Node Package Manager' },
+      { name: 'yarn', value: 'yarn', checkedName: 'Yet Another Resource Negotiator' },
+      new Separator(),
+      { name: 'jspm', value: 'jspm' },
+      {
+        name: 'pnpm',
+        value: 'pnpm',
+        disabled: '(pnpm is not available)',
+      },
+    ],
+  });
+  console.log('Answer:', answer);
 };
 
 if (import.meta.url.startsWith('file:')) {


### PR DESCRIPTION
This PR updates the checkbox prompt to display the `checkedName` property for selected options, 
falling back to `name` if `checkedName` is not provided. It includes:

- Updated `normalizeChoices` to handle `checkedName`.
- Updated `renderItem` logic to display `checkedName` when an item is checked.
- Test case added to verify the behavior.

This improves the clarity of selected options in prompts without breaking existing functionality.
