### PR TITLE
fix: handle skipped questions in when with display option

### DIFF
--- a/packages/inquirer/inquirer.test.ts
+++ b/packages/inquirer/inquirer.test.ts
@@ -739,6 +739,62 @@ describe('inquirer.prompt(...)', () => {
       ]);
       expect(answers).toEqual({ q: 'foo' });
     });
+
+    it('should display skipped question when `when` returns { ask: false, display: true }', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        {
+          type: 'stub',
+          name: 'q1',
+          message: 'Question 1',
+        },
+        {
+          type: 'stub',
+          name: 'q2',
+          message: 'Question 2',
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Question 2/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should skip question entirely when `when` returns { ask: false, display: false }', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        {
+          type: 'stub',
+          name: 'q1',
+          message: 'Question 1',
+        },
+        {
+          type: 'stub',
+          name: 'q2',
+          message: 'Question 2',
+          when() {
+            return { ask: false, display: false };
+          },
+        },
+        {
+          type: 'stub',
+          name: 'q3',
+          message: 'Question 3',
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).not.toMatch(/Question 2/);
+      expect(answers).toEqual({ q1: 'bar', q3: 'bar' });
+      writeSpy.mockRestore();
+    });
   });
 
   describe('Prefilling answers', () => {

--- a/packages/inquirer/inquirer.test.ts
+++ b/packages/inquirer/inquirer.test.ts
@@ -760,8 +760,7 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Question 2/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Question 2');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -791,7 +790,7 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).not.toMatch(/Question 2/);
+      expect(output).not.toContain('Question 2');
       expect(answers).toEqual({ q1: 'bar', q3: 'bar' });
       writeSpy.mockRestore();
     });
@@ -812,8 +811,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Are you sure\?.*Yes/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Are you sure?');
+      expect(output).toContain('Yes');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -838,8 +837,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Select fruit.*Banana/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Select fruit');
+      expect(output).toContain('Banana');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -865,8 +864,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Pick foods.*Pizza, Burger/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Pick foods');
+      expect(output).toContain('Pizza, Burger');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -888,8 +887,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Enter password.*\[PASSWORD SET\]/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Enter password');
+      expect(output).toContain('[PASSWORD SET]');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -911,8 +910,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Write content.*\[Default Content\]/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Write content');
+      expect(output).toContain('[Default Content]');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -934,8 +933,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Enter name.*John/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Enter name');
+      expect(output).toContain('John');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });
@@ -957,8 +956,8 @@ describe('inquirer.prompt(...)', () => {
       ]);
 
       const output = writeSpy.mock.calls.map(([text]) => text).join('');
-      expect(output).toMatch(/Enter age.*25/);
-      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(output).toContain('Enter age');
+      expect(output).toContain('25');
       expect(answers).toEqual({ q1: 'bar' });
       writeSpy.mockRestore();
     });

--- a/packages/inquirer/inquirer.test.ts
+++ b/packages/inquirer/inquirer.test.ts
@@ -795,6 +795,173 @@ describe('inquirer.prompt(...)', () => {
       expect(answers).toEqual({ q1: 'bar', q3: 'bar' });
       writeSpy.mockRestore();
     });
+
+    it('should display skipped confirm question with default true', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'confirm',
+          name: 'confirmQ',
+          message: 'Are you sure?',
+          default: true,
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Are you sure\?.*Yes/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should display skipped select question', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'select',
+          name: 'fruit',
+          message: 'Select fruit',
+          choices: [
+            { name: 'Apple', value: 'a' },
+            { name: 'Banana', value: 'b' },
+          ],
+          default: 'b',
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Select fruit.*Banana/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should display skipped checkbox question', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'checkbox',
+          name: 'foods',
+          message: 'Pick foods',
+          choices: [
+            { name: 'Pizza', value: 'p' },
+            { name: 'Burger', value: 'b' },
+          ],
+          default: ['p', 'b'],
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Pick foods.*Pizza, Burger/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should display skipped password question', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'password',
+          name: 'pwd',
+          message: 'Enter password',
+          default: 'secret',
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Enter password.*\[PASSWORD SET\]/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should display skipped editor question', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'editor',
+          name: 'ed',
+          message: 'Write content',
+          default: 'notes...',
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Write content.*\[Default Content\]/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should display skipped input question', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'input',
+          name: 'name',
+          message: 'Enter name',
+          default: 'John',
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Enter name.*John/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
+
+    it('should display skipped number question', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      const answers = await inquirer.prompt([
+        { type: 'stub', name: 'q1', message: 'Question 1' },
+        {
+          type: 'number',
+          name: 'age',
+          message: 'Enter age',
+          default: 25,
+          when() {
+            return { ask: false, display: true };
+          },
+        },
+      ]);
+
+      const output = writeSpy.mock.calls.map(([text]) => text).join('');
+      expect(output).toMatch(/Enter age.*25/);
+      expect(output.includes('\x1b[2m')).toBe(true);
+      expect(answers).toEqual({ q1: 'bar' });
+      writeSpy.mockRestore();
+    });
   });
 
   describe('Prefilling answers', () => {

--- a/packages/inquirer/src/types.ts
+++ b/packages/inquirer/src/types.ts
@@ -111,6 +111,11 @@ export interface QuestionMap {
 type KeyValueOrAsyncGetterFunction<T, k extends string, A extends Answers> =
   T extends Record<string, any> ? T[k] | AsyncGetterFunction<T[k], A> : never;
 
+export type CustomWhenResult = {
+  display: boolean;
+  ask: boolean;
+};
+
 export type Question<A extends Answers = Answers, Type extends string = string> = {
   type: Type;
   name: string;
@@ -119,7 +124,7 @@ export type Question<A extends Answers = Answers, Type extends string = string> 
   choices?: any;
   filter?: (answer: any, answers: NoInfer<Partial<A>>) => any;
   askAnswered?: boolean;
-  when?: boolean | AsyncGetterFunction<boolean, A>;
+  when?: boolean | CustomWhenResult | AsyncGetterFunction<boolean | CustomWhenResult, A>;
 };
 
 type QuestionWithGetters<
@@ -131,7 +136,7 @@ type QuestionWithGetters<
   {
     type: Type;
     askAnswered?: boolean;
-    when?: boolean | AsyncGetterFunction<boolean, A>;
+    when?: boolean | AsyncGetterFunction<boolean | CustomWhenResult, A>;
     filter?(input: any, answers: NoInfer<A>): any;
     message: KeyValueOrAsyncGetterFunction<Q, 'message', A>;
     default?: KeyValueOrAsyncGetterFunction<Q, 'default', A>;

--- a/packages/inquirer/src/ui/prompt.ts
+++ b/packages/inquirer/src/ui/prompt.ts
@@ -6,7 +6,6 @@ import {
   from,
   of,
   concatMap,
-  filter,
   reduce,
   isObservable,
   Observable,
@@ -23,7 +22,9 @@ import type {
   AsyncGetterFunction,
   PromptSession,
   StreamOptions,
+  CustomWhenResult,
 } from '../types.ts';
+import SkippedRenderer from './skipped-renderer.ts';
 
 export const _ = {
   set: (obj: Record<string, unknown>, path: string = '', value: unknown): void => {
@@ -230,16 +231,18 @@ export default class PromptsRunner<A extends Answers> {
       concatMap((question) =>
         of(question).pipe(
           concatMap((question) =>
-            from(
-              this.shouldRun(question).then((shouldRun: boolean | void) => {
-                if (shouldRun) {
-                  return question;
+            from(this.shouldRun(question)).pipe(
+              concatMap(({ display, ask }) => {
+                if (ask) {
+                  return defer(() => from(this.fetchAnswer(question)));
                 }
-                return;
+                if (display) {
+                  this.displaySkippedQuestion(question);
+                }
+                return EMPTY;
               }),
-            ).pipe(filter((val) => val != null)),
+            ),
           ),
-          concatMap((question) => defer(() => from(this.fetchAnswer(question)))),
         ),
       ),
     );
@@ -391,6 +394,13 @@ export default class PromptsRunner<A extends Answers> {
       });
   };
 
+  private displaySkippedQuestion(question: Question<A>) {
+    const renderer = SkippedRenderer[question.type] || SkippedRenderer.default;
+    type RendererFunc<A extends Answers> = (question: Question<A>) => string;
+    const outputText = (renderer as RendererFunc<A>)(question);
+    (this.opt.output || process.stdout).write(`${outputText}\n`);
+  }
+
   /**
    * Close the interface and cleanup listeners
    */
@@ -398,20 +408,27 @@ export default class PromptsRunner<A extends Answers> {
     this.abortController.abort();
   };
 
-  private shouldRun = async (question: Question<A>): Promise<boolean> => {
+  private shouldRun = async (question: Question<A>): Promise<CustomWhenResult> => {
     if (
       question.askAnswered !== true &&
       _.get(this.answers, question.name) !== undefined
     ) {
-      return false;
+      return { display: false, ask: false };
     }
 
     const { when } = question;
     if (typeof when === 'function') {
       const shouldRun = await runAsync(when)(this.answers);
-      return Boolean(shouldRun);
+      if (typeof shouldRun === 'object') {
+        const display = shouldRun.display;
+        const ask = shouldRun.ask;
+        return { display, ask };
+      }
+      const ask = Boolean(shouldRun);
+      return { display: ask, ask };
     }
 
-    return when !== false;
+    const ask = when !== false;
+    return { display: ask, ask };
   };
 }

--- a/packages/inquirer/src/ui/prompt.ts
+++ b/packages/inquirer/src/ui/prompt.ts
@@ -394,11 +394,10 @@ export default class PromptsRunner<A extends Answers> {
       });
   };
 
-  private displaySkippedQuestion(question: Question<A>) {
+  private displaySkippedQuestion(question: Question<any>) {
+    const output = this.opt.output || process.stdout;
     const renderer = SkippedRenderer[question.type] || SkippedRenderer.default;
-    type RendererFunc<A extends Answers> = (question: Question<A>) => string;
-    const outputText = (renderer as RendererFunc<A>)(question);
-    (this.opt.output || process.stdout).write(`${outputText}\n`);
+    output.write(`${renderer(question)}\n`);
   }
 
   /**
@@ -419,13 +418,9 @@ export default class PromptsRunner<A extends Answers> {
     const { when } = question;
     if (typeof when === 'function') {
       const shouldRun = await runAsync(when)(this.answers);
-      if (typeof shouldRun === 'object') {
-        const display = shouldRun.display;
-        const ask = shouldRun.ask;
-        return { display, ask };
-      }
-      const ask = Boolean(shouldRun);
-      return { display: ask, ask };
+      return typeof shouldRun === 'object'
+        ? shouldRun
+        : { display: Boolean(shouldRun), ask: Boolean(shouldRun) };
     }
 
     const ask = when !== false;

--- a/packages/inquirer/src/ui/skipped-renderer.ts
+++ b/packages/inquirer/src/ui/skipped-renderer.ts
@@ -1,4 +1,4 @@
-import { Answers, Question } from '../types.ts';
+import type { Answers, Question } from '../types.ts';
 import { makeTheme } from '@inquirer/core';
 
 type RendererFunction<A extends Answers = Answers> = (question: Question<A>) => string;

--- a/packages/inquirer/src/ui/skipped-renderer.ts
+++ b/packages/inquirer/src/ui/skipped-renderer.ts
@@ -1,0 +1,91 @@
+import { Answers, Question } from '../types.ts';
+import { makeTheme } from '@inquirer/core';
+
+type RendererFunction<A extends Answers = Answers> = (question: Question<A>) => string;
+
+type Choice = { name: string; value: string | number };
+
+type TypedQuestion<A extends Answers = Answers, T = string | boolean | number> = Omit<
+  Question<A>,
+  'choices' | 'default'
+> & {
+  choices?: Choice[];
+  default?: T; // now default is typed
+};
+
+type SkippedRendererType<A extends Answers = Answers> = {
+  [key: string]: RendererFunction<A>;
+  confirm: RendererFunction<A>;
+  select: RendererFunction<A>;
+  checkbox: RendererFunction<A>;
+  editor: RendererFunction<A>;
+  password: RendererFunction<A>;
+  default: RendererFunction<A>;
+};
+const theme = makeTheme();
+const prefix = typeof theme.prefix === 'string' ? theme.prefix : theme.prefix.idle;
+
+const SkippedRenderer: SkippedRendererType = {
+  confirm: (question: TypedQuestion) => {
+    const defaultVal = question.default;
+    const answerText = defaultVal === true ? 'Yes' : defaultVal === false ? 'No' : '';
+    return renderLine(question.message.toString(), answerText);
+  },
+
+  select: (question: TypedQuestion) => {
+    const defaultVal = question.default;
+    let answerText = String(defaultVal);
+
+    if (question.choices && defaultVal !== undefined) {
+      const selectedChoice = question.choices.find((c) => c.value === defaultVal);
+      answerText = selectedChoice ? selectedChoice.name : String(defaultVal);
+    }
+    return renderLine(question.message.toString(), answerText);
+  },
+
+  checkbox: (question: TypedQuestion) => {
+    const defaultVal = question.default;
+    let answerText = '';
+
+    if (Array.isArray(defaultVal) && question.choices) {
+      const selectedNames = question.choices
+        .filter((c) => defaultVal.includes(c.value))
+        .map((c) => c.name);
+      answerText = selectedNames.join(', ');
+    } else if (defaultVal !== undefined) {
+      answerText = String(defaultVal);
+    }
+
+    return renderLine(question.message.toString(), answerText);
+  },
+
+  editor: (question: TypedQuestion) => {
+    const answerText = question.default !== undefined ? '[Default Content]' : '';
+    return renderLine(question.message.toString(), answerText);
+  },
+
+  password: (question: TypedQuestion) => {
+    const defaultVal = question.default;
+    let answerText = '';
+
+    if (defaultVal !== undefined) {
+      answerText = '[PASSWORD SET]';
+    }
+    return renderLine(question.message.toString(), answerText);
+  },
+
+  default: (question: TypedQuestion) => {
+    const answerText = question.default !== undefined ? String(question.default) : '';
+    return renderLine(question.message.toString(), answerText);
+  },
+  list: (question: TypedQuestion) => SkippedRenderer.select(question),
+  rawlist: (question: TypedQuestion) => SkippedRenderer.select(question),
+  input: (question: TypedQuestion) => SkippedRenderer.default(question),
+  number: (question: TypedQuestion) => SkippedRenderer.default(question),
+};
+
+function renderLine(message: string, answerText: string) {
+  return theme.style.help(`${prefix} ${message} ${answerText}`);
+}
+
+export default SkippedRenderer;


### PR DESCRIPTION
1. Display questions when when returns { ask: false, display: true } without adding to answers.
2. Fully skip questions when when returns { ask: false, display: false } or false.
3. Added tests to cover these cases.