### PR TITLE
Add checkbox-plus-plus community prompt to README

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -519,6 +519,19 @@ A sortable checkbox prompt that maintains the order of selection. Perfect for pr
 (Linting, formatting, and analysis)
 ```
 
+[**Checkbox Plus Plus Prompt**](https://github.com/behnamazimi/inquirer-checkbox-plus-plus)<br/>
+A modern multiselect checkbox prompt with search and filter capabilities, highlighting, autocomplete, and improved UX. Supports both ESM and CommonJS and is compatible with @inquirer/core v10+.
+
+```
+? Select colors [searching: "re"]
+❯ ◉ The red color
+  ◯ The green color
+  ◉ The purple color
+  ◯ The orange color
+
+↑↓ navigate • space de/select • type search • 2 selected  • ⏎ submit
+```
+
 # License
 
 Copyright (c) 2023 Simon Boudrias (twitter: [@vaxilart](https://twitter.com/Vaxilart))<br/>


### PR DESCRIPTION
Adds `inquirer-checkbox-plus-plus` to the community prompts list. This is a modern checkbox prompt with search/filter capabilities, highlighting, and improved UX. Features autocomplete, and dual package support (ESM + CommonJS). It's a maintained fork of the original inquirer-checkbox-plus-prompt that works with @inquirer/core v10+.

https://www.npmjs.com/package/inquirer-checkbox-plus-plus
