### PR TITLE
chore: Update yarn setup to cover all packages in the repository

### DIFF
--- a/integration/cjs/package.json
+++ b/integration/cjs/package.json
@@ -13,5 +13,6 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "sideEffects": false
 }

--- a/integration/esm/package.json
+++ b/integration/esm/package.json
@@ -14,5 +14,6 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "sideEffects": false
 }

--- a/internals/hoist-peer-dependencies/package.json
+++ b/internals/hoist-peer-dependencies/package.json
@@ -9,5 +9,6 @@
   },
   "dependencies": {
     "type-fest": "^5.1.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/internals/isolate-monorepo-package/package.json
+++ b/internals/isolate-monorepo-package/package.json
@@ -2,16 +2,7 @@
   "name": "isolate-monorepo-package",
   "version": "1.0.0",
   "private": true,
-  "author": "Simon Boudrias <admin@simonboudrias.com>",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SBoudrias/Inquirer.js.git"
-  },
   "sideEffects": false,
-  "files": [
-    "dist"
-  ],
   "description": "Tool for testing package isolation in Yarn workspace monorepo",
   "type": "module",
   "bin": "./src/bin.ts",
@@ -31,9 +22,5 @@
   },
   "engines": {
     "node": ">=22.3.0"
-  },
-  "publishConfig": {
-    "access": "public",
-    "bin": "./dist/bin.js"
   }
 }

--- a/internals/tsconfig/package.json
+++ b/internals/tsconfig/package.json
@@ -8,5 +8,6 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "sideEffects": false
 }

--- a/internals/tsconfig/tsconfig.json
+++ b/internals/tsconfig/tsconfig.json
@@ -4,10 +4,7 @@
     "lib": ["es2023"],
     "skipLibCheck": false,
     "esModuleInterop": true,
-
-    //========== Use filename extension .ts in imports ==========
     "allowImportingTsExtensions": true,
-    // Only needed if compiling to JavaScript
-    "rewriteRelativeImportExtensions": true // from .ts to .js
+    "rewriteRelativeImportExtensions": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prepare": "husky && turbo tsc attw",
     "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i '' -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
     "postpack": "git restore packages/*/package.json packages/*/README.md",
-    "setup": "node ./tools/setup-packages.ts && prettier --write .",
+    "setup": "node ./tools/setup-packages.ts && prettier --write . --log-level=silent",
     "pretest": "yarn tsc && oxlint && prettier --check . && eslint .",
     "test": "vitest --run packages && turbo test",
     "tsc": "turbo tsc && tsc -p tsconfig.json"


### PR DESCRIPTION
To properly support #1856 - we should ensure the setup script covers all packages within the repository.