### PR TITLE
fix(isolate-monorepo-package): Include direct dependencies in resolutions/overrides

### DIFF
--- a/internals/isolate-monorepo-package/src/index.ts
+++ b/internals/isolate-monorepo-package/src/index.ts
@@ -418,25 +418,19 @@ export async function setupIsolatedEnvironment(
     }
   }
 
-  // Add resolutions/overrides for transitive workspace dependencies
+  // Add resolutions/overrides for all workspace dependencies
   // Yarn uses 'resolutions', npm uses 'overrides'
+  // Include direct dependencies to ensure consistent versions across the entire dependency tree
   pkg.resolutions ??= {};
   pkg.overrides ??= {};
   for (const [depName, tarballPath] of packMap) {
-    // Don't add resolution if it's already a direct dependency
-    const isDirectDep =
-      (pkg.dependencies && pkg.dependencies[depName]) ||
-      (pkg.devDependencies && pkg.devDependencies[depName]);
-
-    if (!isDirectDep) {
-      const fileUrl = `file:${tarballPath}`;
-      pkg.resolutions[depName] = fileUrl;
-      pkg.overrides[depName] = fileUrl;
-      if (verbose) {
-        console.error(
-          `[isolate-monorepo-package]   Added resolution/override for ${depName}`,
-        );
-      }
+    const fileUrl = `file:${tarballPath}`;
+    pkg.resolutions[depName] = fileUrl;
+    pkg.overrides[depName] = fileUrl;
+    if (verbose) {
+      console.error(
+        `[isolate-monorepo-package]   Added resolution/override for ${depName}`,
+      );
     }
   }
 

--- a/internals/isolate-monorepo-package/tsconfig.json
+++ b/internals/isolate-monorepo-package/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@repo/tsconfig",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Resolutions and overrides need to include all workspace dependencies, including direct ones, to ensure consistent versions across the entire dependency tree when transitive dependencies reference them.