### PR TITLE
chore: remove unencessary oxlint ignore patterns

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,13 +4,7 @@
     "node": true
   },
   "ignorePatterns": [
-    ".git",
-    "node_modules",
-    "coverage",
-    ".yarn",
-    "packages/*/dist/**",
-    "packages/*/node_modules/**",
-    "packages/*/__snapshots__/**"
+    ".yarn"
   ],
   "categories": {
     "correctness": "error",


### PR DESCRIPTION
Oxlint does respect `.gitignore` when in a Git repository. I've removed all pattern except the `".yarn"` one, otherwise the Yarn CJS will be linted.