### PR TITLE
Fix: Cursor Positioning After Line Wrap

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,8 +66,7 @@
     "@inquirer/type": "^4.0.2",
     "cli-width": "^4.1.0",
     "mute-stream": "^3.0.0",
-    "signal-exit": "^4.1.0",
-    "wrap-ansi": "^9.0.2"
+    "signal-exit": "^4.1.0"
   },
   "devDependencies": {
     "@inquirer/testing": "^3.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,8 @@
     "@inquirer/type": "^4.0.2",
     "cli-width": "^4.1.0",
     "mute-stream": "^3.0.0",
-    "signal-exit": "^4.1.0"
+    "signal-exit": "^4.1.0",
+    "wrap-ansi": "^9.0.2"
   },
   "devDependencies": {
     "@inquirer/testing": "^3.0.3",

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -1,7 +1,5 @@
 import cliWidth from 'cli-width';
-import wrapAnsi from 'wrap-ansi';
 import { readline } from './hook-engine.ts';
-
 /**
  * Force line returns at specific width. This function is ANSI code friendly and it'll
  * ignore invisible codes during width calculation.
@@ -10,14 +8,55 @@ import { readline } from './hook-engine.ts';
  * @return {string}
  */
 export function breakLines(content: string, width: number): string {
-  return content
-    .split('\n')
-    .flatMap((line) =>
-      wrapAnsi(line, width, { trim: false, hard: true })
-        .split('\n')
-        .map((str) => str.trimEnd()),
-    )
-    .join('\n');
+  const lines = content.split('\n');
+  const result: string[] = [];
+
+  for (const line of lines) {
+    let currentLine = '';
+    let visibleLength = 0;
+    let escapeSequence = '';
+    let inEscape = false;
+
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i]!;
+
+      // Detect start of ANSI escape code
+      if (char === '\x1b') {
+        inEscape = true;
+        escapeSequence += char;
+        continue;
+      }
+
+      // If inside an escape sequence, accumulate it but don't count width
+      if (inEscape) {
+        escapeSequence += char;
+
+        if (/[a-zA-Z]/.test(char)) {
+          inEscape = false;
+          currentLine += escapeSequence;
+          escapeSequence = '';
+        }
+        continue;
+      }
+
+      // Normal character: Add to line and increment visual width
+      currentLine += char;
+      visibleLength++;
+
+      // Hard Wrap: If we reached the width limit
+      if (visibleLength === width) {
+        result.push(currentLine);
+        currentLine = '';
+        visibleLength = 0;
+      }
+    }
+
+    if (currentLine.length > 0 || result.length === 0) {
+      result.push(currentLine.trimEnd());
+    }
+  }
+
+  return result.join('\n');
 }
 
 /**

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -17,9 +17,7 @@ export function breakLines(content: string, width: number): string {
     let escapeSequence = '';
     let inEscape = false;
 
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i]!;
-
+    for (const char of line) {
       // Detect start of ANSI escape code
       if (char === '\x1b') {
         inEscape = true;
@@ -31,6 +29,8 @@ export function breakLines(content: string, width: number): string {
       if (inEscape) {
         escapeSequence += char;
 
+        // ANSI escape sequences always end with a letter (eg., 'm' in '\x1b[31m')
+        // This marks the end of the sequence so we can append it without counting its width
         if (/[a-zA-Z]/.test(char)) {
           inEscape = false;
           currentLine += escapeSequence;


### PR DESCRIPTION
## Summary
Implemented a character-based ANSI-safe wrapper directly in the `breakLines` function to force deterministic wrapping across all terminals:

- **Implemented internal wrapper**: The `breakLines` function now uses character-based wrapping instead of word-based wrapping

Fixes: https://github.com/SBoudrias/Inquirer.js/issues/1818


## Testing
All existing tests pass. Run:
```sh
yarn pretest && yarn test
```
## demo
https://vimeo.com/1147364471?fl=pl&fe=sh