### PR TITLE
fix(inquirer): remove deprecated 'list' type from TypeScript types

### DIFF
--- a/packages/inquirer/examples/hierarchical.ts
+++ b/packages/inquirer/examples/hierarchical.ts
@@ -11,7 +11,7 @@ async function main() {
 
 async function exitHouse() {
   const answers = await inquirer.prompt<{ direction: string }>({
-    type: 'list',
+    type: 'select',
     name: 'direction',
     message: 'Which direction would you like to go?',
     choices: ['Forward', 'Right', 'Left', 'Back'],
@@ -30,7 +30,7 @@ async function exitHouse() {
 
 async function encounter1() {
   const answers = await inquirer.prompt<{ direction: string }>({
-    type: 'list',
+    type: 'select',
     name: 'direction',
     message: 'Which direction would you like to go?',
     choices: ['Forward', 'Right', 'Left', 'Back'],
@@ -51,7 +51,7 @@ async function encounter1() {
 
 async function encounter2a() {
   const answers = await inquirer.prompt<{ direction: string }>({
-    type: 'list',
+    type: 'select',
     name: 'direction',
     message: 'Which direction would you like to go?',
     choices: ['Forward', 'Right', 'Left', 'Back'],
@@ -72,7 +72,7 @@ async function encounter2a() {
 
 async function encounter2b() {
   await inquirer.prompt<{ weapon: string }>({
-    type: 'list',
+    type: 'select',
     name: 'weapon',
     message: 'Pick one',
     choices: [

--- a/packages/inquirer/examples/long-list.ts
+++ b/packages/inquirer/examples/long-list.ts
@@ -25,7 +25,7 @@ const multiLineChoices = [
 
 const answers = await inquirer.prompt<{ letter: string; name: string[] }>([
   {
-    type: 'list',
+    type: 'select',
     loop: false,
     name: 'letter',
     message: "What's your favorite letter?",

--- a/packages/inquirer/examples/pizza.ts
+++ b/packages/inquirer/examples/pizza.ts
@@ -40,7 +40,7 @@ const answers = await inquirer.prompt<{
     },
   },
   {
-    type: 'list',
+    type: 'select',
     name: 'size',
     message: 'What size do you need?',
     choices: ['Large', 'Medium', 'Small'],
@@ -93,7 +93,7 @@ const answers = await inquirer.prompt<{
     default: 'Nope, all good!',
   },
   {
-    type: 'list',
+    type: 'select',
     name: 'prize',
     message: 'For leaving a comment, you get a freebie',
     choices: ['cake', 'fries'],

--- a/packages/inquirer/examples/select.ts
+++ b/packages/inquirer/examples/select.ts
@@ -1,12 +1,12 @@
 /**
- * List prompt example
+ * Select prompt example
  */
 
 import inquirer from 'inquirer';
 
 const answers = await inquirer.prompt<{ theme: string; size: string }>([
   {
-    type: 'list',
+    type: 'select',
     name: 'theme',
     message: 'What do you want to do?',
     choices: [
@@ -19,7 +19,7 @@ const answers = await inquirer.prompt<{ theme: string; size: string }>([
     ],
   },
   {
-    type: 'list',
+    type: 'select',
     name: 'size',
     message: 'What size do you need?',
     choices: [

--- a/packages/inquirer/src/types.ts
+++ b/packages/inquirer/src/types.ts
@@ -222,8 +222,7 @@ export type PromptModulePublicQuestion<A extends Answers, Flat extends Answers =
     | 'expand'
     | 'checkbox'
     | 'search'
-    | 'select'
-    | 'list';
+    | 'select';
   name: Extract<keyof Flat, string>;
   message: MaybeAsyncValue<string, A>;
   default?: unknown;


### PR DESCRIPTION
## Summary

- Removes `'list'` from the `PromptModulePublicQuestion` type union
- Updates all examples to use `type: 'select'` instead of `type: 'list'`
- Renames `list.ts` example to `select.ts`

The `list` prompt type was removed from v13 but is still accepted by TypeScript. This causes runtime issues where it silently fell back to the input behavior. Now users will get a compile-time error guiding them to use `select` instead.

Ref #1976 #1916

## Test plan

- [x] `yarn tsc` passes
- [x] `yarn test` passes
- [x] Integration tests pass