### PR TITLE
fix(@inquirer/input): handle numeric default values

### DIFF
--- a/packages/input/input.test.ts
+++ b/packages/input/input.test.ts
@@ -141,6 +141,20 @@ describe('input prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`"✔ What is your name Mike"`);
   });
 
+  it('handle numeric default option', async () => {
+    const { answer, events, getScreen } = await render(input, {
+      message: 'What port do you want to use?',
+      // @ts-expect-error - testing runtime behavior with numeric default
+      default: 3042,
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`"? What port do you want to use? (3042)"`);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('3042');
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ What port do you want to use? 3042"`);
+  });
+
   it('handle overwriting the default option', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'What is your name',

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -37,7 +37,9 @@ export default createPrompt<string, InputConfig>((config, done) => {
   const { prefill = 'tab' } = config;
   const theme = makeTheme<InputTheme>(inputTheme, config.theme);
   const [status, setStatus] = useState<Status>('idle');
-  const [defaultValue = '', setDefaultValue] = useState<string>(config.default);
+  // Coerce to string to handle runtime values that may be numbers despite TypeScript types
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion
+  const [defaultValue, setDefaultValue] = useState<string>(String(config.default ?? ''));
   const [errorMsg, setError] = useState<string>();
   const [value, setValue] = useState<string>('');
 
@@ -87,9 +89,9 @@ export default createPrompt<string, InputConfig>((config, done) => {
         setStatus('idle');
       }
     } else if (isBackspaceKey(key) && !value) {
-      setDefaultValue(undefined);
+      setDefaultValue('');
     } else if (isTabKey(key) && !value) {
-      setDefaultValue(undefined);
+      setDefaultValue('');
       rl.clearLine(0); // Remove the tab character.
       rl.write(defaultValue);
       setValue(defaultValue);


### PR DESCRIPTION
## Summary

- Coerce `default` values to strings to prevent `TypeError` when using Node.js `util.styleText()` which requires string arguments
- After the v13 migration from `yoctocolors` to `styleText`, numeric defaults caused `ERR_INVALID_ARG_TYPE`

While the type didn't allow `numbers` in, not everyone is using typescript.

Fixes #1975

## Test plan

- [x] Added test case for numeric default values
- [x] Verified existing tests still pass
- [x] Integration tests pass