### PR TITLE
fix(@inquirer/testing): auto-mock @inquirer/prompts barrel re-exports

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -152,13 +152,29 @@ The `screen` object provides:
 
 ### Mocking Third-Party Prompts
 
-All `@inquirer/*` prompts are mocked automatically. To mock a third-party or custom prompt package, use `wrapPrompt` in your own `vi.mock()` call:
+All `@inquirer/*` prompts are mocked automatically. To mock a third-party or custom prompt package, use `wrapPrompt` in your own mock call:
+
+#### Vitest
 
 ```ts
 import { screen, wrapPrompt } from '@inquirer/testing/vitest';
 
 vi.mock('@my-company/custom-prompt', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@my-company/custom-prompt')>();
+  return { ...actual, default: wrapPrompt(actual.default) };
+});
+```
+
+#### Jest
+
+In Jest, `jest.mock()` factories are hoisted before imports, so `wrapPrompt` must be accessed via `jest.requireActual()` inside the factory:
+
+```ts
+import { screen } from '@inquirer/testing/jest';
+
+jest.mock('@my-company/custom-prompt', () => {
+  const { wrapPrompt } = jest.requireActual('@inquirer/testing/jest');
+  const actual = jest.requireActual('@my-company/custom-prompt');
   return { ...actual, default: wrapPrompt(actual.default) };
 });
 ```

--- a/packages/testing/src/jest.ts
+++ b/packages/testing/src/jest.ts
@@ -16,6 +16,15 @@ beforeEach(() => {
 /**
  * Wrap a prompt function to use the shared screen I/O.
  * Use this in your own `jest.mock()` calls to mock third-party prompts.
+ *
+ * @example
+ * ```ts
+ * jest.mock('@my-company/custom-prompt', () => {
+ *   const { wrapPrompt } = jest.requireActual('@inquirer/testing/jest');
+ *   const actual = jest.requireActual('@my-company/custom-prompt');
+ *   return { ...actual, default: wrapPrompt(actual.default) };
+ * });
+ * ```
  */
 export function wrapPrompt<Value, Config>(
   prompt: Prompt<Value, Config>,
@@ -37,8 +46,7 @@ export function wrapPrompt<Value, Config>(
   };
 }
 
-// Mock individual prompt packages
-// Note: @inquirer/prompts just re-exports these, so mocking individual packages covers both import styles
+// Mock individual prompt packages (covers `import input from '@inquirer/input'` style)
 jest.mock('@inquirer/input', () => {
   const actual = jest.requireActual('@inquirer/input');
   return { ...actual, default: wrapPrompt(actual.default) };
@@ -87,6 +95,25 @@ jest.mock('@inquirer/search', () => {
 jest.mock('@inquirer/editor', () => {
   const actual = jest.requireActual('@inquirer/editor');
   return { ...actual, default: wrapPrompt(actual.default) };
+});
+
+// Mock @inquirer/prompts barrel re-exports (covers `import { input } from '@inquirer/prompts'` style).
+// Jest's module mock for individual packages doesn't propagate through barrel re-exports.
+jest.mock('@inquirer/prompts', () => {
+  const actual = jest.requireActual('@inquirer/prompts');
+  return {
+    ...actual,
+    input: wrapPrompt(actual.input),
+    select: wrapPrompt(actual.select),
+    confirm: wrapPrompt(actual.confirm),
+    checkbox: wrapPrompt(actual.checkbox),
+    password: wrapPrompt(actual.password),
+    expand: wrapPrompt(actual.expand),
+    rawlist: wrapPrompt(actual.rawlist),
+    number: wrapPrompt(actual.number),
+    search: wrapPrompt(actual.search),
+    editor: wrapPrompt(actual.editor),
+  };
 });
 
 // Mock the external editor to capture typed input instead of spawning a real editor.

--- a/packages/testing/src/vitest.ts
+++ b/packages/testing/src/vitest.ts
@@ -45,8 +45,7 @@ export function wrapPrompt<Value, Config>(
   };
 }
 
-// Mock individual prompt packages
-// Note: @inquirer/prompts just re-exports these, so mocking individual packages covers both import styles
+// Mock individual prompt packages (covers `import input from '@inquirer/input'` style)
 vi.mock('@inquirer/input', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@inquirer/input')>();
   return { ...actual, default: wrapPrompt(actual.default) };
@@ -95,6 +94,26 @@ vi.mock('@inquirer/search', async (importOriginal) => {
 vi.mock('@inquirer/editor', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@inquirer/editor')>();
   return { ...actual, default: wrapPrompt(actual.default) };
+});
+
+// Mock @inquirer/prompts barrel re-exports (covers `import { input } from '@inquirer/prompts'` style).
+// While Vitest's module interception often propagates through ESM re-exports, an explicit mock
+// ensures consistent behavior across all environments and bundler configurations.
+vi.mock('@inquirer/prompts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@inquirer/prompts')>();
+  return {
+    ...actual,
+    input: wrapPrompt(actual.input),
+    select: wrapPrompt(actual.select),
+    confirm: wrapPrompt(actual.confirm),
+    checkbox: wrapPrompt(actual.checkbox),
+    password: wrapPrompt(actual.password),
+    expand: wrapPrompt(actual.expand),
+    rawlist: wrapPrompt(actual.rawlist),
+    number: wrapPrompt(actual.number),
+    search: wrapPrompt(actual.search),
+    editor: wrapPrompt(actual.editor),
+  };
 });
 
 // Mock the external editor to capture typed input instead of spawning a real editor.


### PR DESCRIPTION
## Summary

Jest's module mocking for individual packages doesn't propagate through barrel re-exports. Users importing from `@inquirer/prompts` (e.g., `import { input } from '@inquirer/prompts'`) would get unmocked versions. Add explicit mocks for `@inquirer/prompts` in both `jest.ts` and `vitest.ts`, and document the `jest.requireActual()` pattern for third-party prompt mocking.

## Changes

- **jest.ts**: Add `jest.mock('@inquirer/prompts', ...)` wrapping all 10 prompt functions
- **vitest.ts**: Mirror the same with `vi.mock('@inquirer/prompts', ...)`
- **jest.ts JSDoc**: Add `@example` showing the `jest.requireActual()` pattern for third-party prompts
- **README.md**: Expand "Mocking Third-Party Prompts" with both Vitest and Jest examples

## Test plan

- `yarn vitest --run packages/demo` — existing E2E tests verify barrel imports still work ✓
- `yarn tsc` — no type errors ✓