### PR TITLE
fix(@inquirer/checkbox): include disabled+checked items in the answer

### DIFF
--- a/packages/checkbox/checkbox.test.ts
+++ b/packages/checkbox/checkbox.test.ts
@@ -418,7 +418,7 @@ describe('checkbox prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`
       "? Select a topping
       ❯◯ Ham
-      - Pineapple (disabled)
+       - Pineapple (disabled)
        ◯ Pepperoni
 
       ↑↓ navigate • space select • a all • i invert • ⏎ submit"
@@ -429,7 +429,7 @@ describe('checkbox prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`
       "? Select a topping
        ◯ Ham
-      - Pineapple (disabled)
+       - Pineapple (disabled)
       ❯◉ Pepperoni
 
       ↑↓ navigate • space select • a all • i invert • ⏎ submit"
@@ -438,6 +438,85 @@ describe('checkbox prompt', () => {
     events.keypress('enter');
     await expect(answer).resolves.toEqual(['pepperoni']);
     expect(getScreen()).toMatchInlineSnapshot('"✔ Select a topping Pepperoni"');
+  });
+
+  it('includes disabled+checked choice in the answer', async () => {
+    const { answer, events, getScreen } = await render(checkbox, {
+      message: 'Select a topping',
+      choices: [
+        { name: 'Ham', value: 'ham' },
+        { name: 'Pineapple', value: 'pineapple', disabled: true, checked: true },
+        { name: 'Pepperoni', value: 'pepperoni' },
+      ],
+    });
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(['pineapple']);
+    expect(getScreen()).toMatchInlineSnapshot('"✔ Select a topping Pineapple"');
+  });
+
+  it('renders disabled+checked choice with checked icon', async () => {
+    const { answer, events, getScreen } = await render(checkbox, {
+      message: 'Select a topping',
+      choices: [
+        { name: 'Ham', value: 'ham' },
+        { name: 'Pineapple', value: 'pineapple', disabled: true, checked: true },
+        { name: 'Pepperoni', value: 'pepperoni' },
+      ],
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a topping
+      ❯◯ Ham
+       ◎ Pineapple (disabled)
+       ◯ Pepperoni
+
+      ↑↓ navigate • space select • a all • i invert • ⏎ submit"
+    `);
+
+    events.keypress('enter');
+    await answer;
+  });
+
+  it('excludes disabled+unchecked choice from the answer', async () => {
+    const { answer, events } = await render(checkbox, {
+      message: 'Select a topping',
+      choices: [
+        { name: 'Ham', value: 'ham' },
+        { name: 'Pineapple', value: 'pineapple', disabled: true },
+        { name: 'Pepperoni', value: 'pepperoni' },
+      ],
+    });
+
+    events.keypress('space');
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(['ham']);
+  });
+
+  it('cannot toggle a disabled+checked choice', async () => {
+    const { answer, events, getScreen } = await render(checkbox, {
+      message: 'Select a topping',
+      choices: [
+        { name: 'Ham', value: 'ham' },
+        { name: 'Pineapple', value: 'pineapple', disabled: true, checked: true },
+        { name: 'Pepperoni', value: 'pepperoni' },
+      ],
+    });
+
+    // Arrow keys skip disabled items, so pressing down goes to Pepperoni
+    events.keypress('down');
+    events.keypress('space');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a topping
+       ◯ Ham
+       ◎ Pineapple (disabled)
+      ❯◉ Pepperoni
+
+      ↑↓ navigate • space select • a all • i invert • ⏎ submit"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(['pineapple', 'pepperoni']);
   });
 
   it('skip disabled options by number key', async () => {
@@ -453,7 +532,7 @@ describe('checkbox prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`
       "? Select a topping
       ❯◯ Ham
-      - Pineapple (disabled)
+       - Pineapple (disabled)
        ◯ Pepperoni
 
       ↑↓ navigate • space select • a all • i invert • ⏎ submit"
@@ -463,7 +542,7 @@ describe('checkbox prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`
       "? Select a topping
       ❯◯ Ham
-      - Pineapple (disabled)
+       - Pineapple (disabled)
        ◯ Pepperoni
 
       ↑↓ navigate • space select • a all • i invert • ⏎ submit"
@@ -1250,7 +1329,7 @@ describe('checkbox prompt', () => {
          ◯ yarn
          ──────────────
          ◯ jspm
-        - pnpm (pnpm is not available)
+         - pnpm (pnpm is not available)
 
         ↑↓ navigate • space select • a all • i invert • ⏎ submit"
       `);
@@ -1262,7 +1341,7 @@ describe('checkbox prompt', () => {
          ◯ yarn
          ──────────────
          ◯ jspm
-        - pnpm (pnpm is not available)
+         - pnpm (pnpm is not available)
 
         ↑↓ navigate • space select • a all • i invert • ⏎ submit"
       `);
@@ -1274,7 +1353,7 @@ describe('checkbox prompt', () => {
         ❯◉ Yet Another Resource Negotiator
          ──────────────
          ◯ jspm
-        - pnpm (pnpm is not available)
+         - pnpm (pnpm is not available)
 
         ↑↓ navigate • space select • a all • i invert • ⏎ submit"
       `);

--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -30,6 +30,7 @@ type CheckboxTheme = {
   };
   style: {
     disabledChoice: (text: string) => string;
+    disabledCheckedChoice: (text: string) => string;
     renderSelectedChoices: <T>(
       selectedChoices: ReadonlyArray<NormalizedChoice<T>>,
       allChoices: ReadonlyArray<NormalizedChoice<T> | Separator>,
@@ -52,7 +53,9 @@ const checkboxTheme: CheckboxTheme = {
     cursor: figures.pointer,
   },
   style: {
-    disabledChoice: (text: string) => styleText('dim', `- ${text}`),
+    disabledChoice: (text: string) => styleText('dim', ` - ${text}`),
+    disabledCheckedChoice: (text: string) =>
+      styleText('dim', ` ${styleText('green', figures.circleDouble)} ${text}`),
     renderSelectedChoices: (selectedChoices) =>
       selectedChoices.map((choice) => choice.short).join(', '),
     description: (text: string) => styleText('cyan', text),
@@ -113,7 +116,7 @@ function isSelectable<Value>(item: Item<Value>): item is NormalizedChoice<Value>
 }
 
 function isChecked<Value>(item: Item<Value>): item is NormalizedChoice<Value> {
-  return isSelectable(item) && item.checked;
+  return !Separator.isSeparator(item) && item.checked;
 }
 
 function toggle<Value>(item: Item<Value>): Item<Value> {
@@ -193,7 +196,7 @@ export default createPrompt(
       if (isEnterKey(key)) {
         const selection = items.filter(isChecked);
         const isValid = await validate([...selection]);
-        if (required && !items.some(isChecked)) {
+        if (required && !selection.length) {
           setError('At least one choice must be selected');
         } else if (isValid === true) {
           setStatus('done');
@@ -256,6 +259,9 @@ export default createPrompt(
         if (item.disabled) {
           const disabledLabel =
             typeof item.disabled === 'string' ? item.disabled : '(disabled)';
+          if (item.checked) {
+            return theme.style.disabledCheckedChoice(`${item.name} ${disabledLabel}`);
+          }
           return theme.style.disabledChoice(`${item.name} ${disabledLabel}`);
         }
 

--- a/packages/demo/demo.test.ts
+++ b/packages/demo/demo.test.ts
@@ -206,8 +206,9 @@ describe('@inquirer/demo E2E tests', () => {
         ❯◯ npm
          ◯ yarn
          ──────────────
-        - jspm (disabled)
-        - pnpm (pnpm is not available)
+         - jspm (disabled)
+         - pnpm (pnpm is not available)
+         ◎ Node.js (required dependency)
 
         ↑↓ navigate • space select • a all • i invert • ⏎ submit"
       `);
@@ -218,8 +219,9 @@ describe('@inquirer/demo E2E tests', () => {
         ❯◉ npm
          ◯ yarn
          ──────────────
-        - jspm (disabled)
-        - pnpm (pnpm is not available)
+         - jspm (disabled)
+         - pnpm (pnpm is not available)
+         ◎ Node.js (required dependency)
 
         ↑↓ navigate • space select • a all • i invert • ⏎ submit"
       `);
@@ -243,7 +245,7 @@ describe('@inquirer/demo E2E tests', () => {
       await demo;
 
       expect(await screen.getFullOutput()).toMatchInlineSnapshot(`
-        "✔ Select a package manager npm
+        "✔ Select a package manager npm, Node.js
         ✔ Select your favorite letters A, C"
       `);
     });

--- a/packages/demo/src/demos/checkbox.ts
+++ b/packages/demo/src/demos/checkbox.ts
@@ -16,6 +16,12 @@ const demo = async () => {
         value: 'pnpm',
         disabled: '(pnpm is not available)',
       },
+      {
+        name: 'Node.js',
+        value: 'node',
+        checked: true,
+        disabled: '(required dependency)',
+      },
     ],
   });
   console.log('Answer:', answer);


### PR DESCRIPTION
## Summary
- Checkbox choices with both `checked: true` and `disabled: true` are now included in the final answer value
- Disabled+checked items render with a checked icon (◉) instead of showing the same style as disabled+unchecked items
- Users still cannot toggle disabled+checked items interactively (arrow keys skip them, space/number keys don't affect them)

Closes #575

## Test plan
- [x] `yarn vitest --run packages/checkbox` — all 44 tests pass
- New tests cover:
  - Disabled+checked choice is included in the final answer
  - Disabled+checked choice renders with a checked icon
  - Disabled+unchecked choice is still excluded from the answer  
  - User cannot toggle a disabled+checked choice