### PR TITLE
refactor(@inquirer/select,@inquirer/checkbox): clean up disabled choice rendering

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -27,10 +27,11 @@ type CheckboxTheme = {
     checked: string;
     unchecked: string;
     cursor: string;
+    disabledChecked: string;
+    disabledUnchecked: string;
   };
   style: {
-    disabledChoice: (text: string) => string;
-    disabledCheckedChoice: (text: string) => string;
+    disabled: (text: string) => string;
     renderSelectedChoices: <T>(
       selectedChoices: ReadonlyArray<NormalizedChoice<T>>,
       allChoices: ReadonlyArray<NormalizedChoice<T> | Separator>,
@@ -51,11 +52,11 @@ const checkboxTheme: CheckboxTheme = {
     checked: styleText('green', figures.circleFilled),
     unchecked: figures.circle,
     cursor: figures.pointer,
+    disabledChecked: styleText('green', figures.circleDouble),
+    disabledUnchecked: '-',
   },
   style: {
-    disabledChoice: (text: string) => styleText('dim', ` - ${text}`),
-    disabledCheckedChoice: (text: string) =>
-      styleText('dim', ` ${styleText('green', figures.circleDouble)} ${text}`),
+    disabled: (text: string) => styleText('dim', text),
     renderSelectedChoices: (selectedChoices) =>
       selectedChoices.map((choice) => choice.short).join(', '),
     description: (text: string) => styleText('cyan', text),
@@ -256,13 +257,17 @@ export default createPrompt(
           return ` ${item.separator}`;
         }
 
+        const cursor = isActive ? theme.icon.cursor : ' ';
+
         if (item.disabled) {
           const disabledLabel =
             typeof item.disabled === 'string' ? item.disabled : '(disabled)';
-          if (item.checked) {
-            return theme.style.disabledCheckedChoice(`${item.name} ${disabledLabel}`);
-          }
-          return theme.style.disabledChoice(`${item.name} ${disabledLabel}`);
+          const checkbox = item.checked
+            ? theme.icon.disabledChecked
+            : theme.icon.disabledUnchecked;
+          return theme.style.disabled(
+            `${cursor}${checkbox} ${item.name} ${disabledLabel}`,
+          );
         }
 
         if (isActive) {
@@ -272,7 +277,6 @@ export default createPrompt(
         const checkbox = item.checked ? theme.icon.checked : theme.icon.unchecked;
         const name = item.checked ? item.checkedName : item.name;
         const color = isActive ? theme.style.highlight : (x: string) => x;
-        const cursor = isActive ? theme.icon.cursor : ' ';
         return color(`${cursor}${checkbox} ${name}`);
       },
       pageSize,

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -242,6 +242,8 @@ export default createPrompt(
 
         const indexLabel =
           theme.indexMode === 'number' ? `${index + 1 - separatorCount}. ` : '';
+        const cursor = isActive ? theme.icon.cursor : ' ';
+
         if (item.disabled) {
           const disabledLabel =
             typeof item.disabled === 'string' ? item.disabled : '(disabled)';
@@ -249,7 +251,6 @@ export default createPrompt(
         }
 
         const color = isActive ? theme.style.highlight : (x: string) => x;
-        const cursor = isActive ? theme.icon.cursor : ` `;
         return color(`${cursor} ${indexLabel}${item.name}`);
       },
       pageSize,


### PR DESCRIPTION
## Summary

- Hoist the `cursor` variable before the disabled check in `renderItem` for both prompts, fixing alignment and reducing duplication
- **Checkbox**: merge `style.disabledChoice`/`style.disabledCheckedChoice` into a single `style.disabled` that receives the full pre-composed line (cursor + icon + text). Move the checked/unchecked disabled icons into `icon.disabledChecked` and `icon.disabledUnchecked`
- Aligns the `style.disabled` API across both prompts — both now receive the full line content

## Test plan

- [x] `yarn vitest --run packages/checkbox packages/demo` — all 53 tests pass, no snapshot changes