### PR TITLE
fix(@inquirer/testing): break Turbo cyclic dependency via package-level task override

### DIFF
--- a/packages/testing/turbo.json
+++ b/packages/testing/turbo.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "tsc": {
+      "dependsOn": [],
+      "outputs": ["dist/**"],
+      "inputs": ["../../package.json", "package.json", "src/*", "!**/*.test.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `packages/testing/turbo.json` to override the `tsc` task's `dependsOn` for `@inquirer/testing`
- Fixes CI breakage introduced when Turbo 2.8.x started detecting cycles through `peerDependencies` in the workspace package graph

## Root cause

`@inquirer/testing` declares all prompt packages as optional `peerDependencies` (needed so Yarn PnP strict-mode consumers can access them at runtime). Those same packages list `@inquirer/testing` as a `devDependency`. Turbo 2.8.x started including `peerDependencies` when building the workspace dependency graph, making this a detected cycle that blocks `yarn tsc`.

This broke **all** Dependabot PRs simultaneously — not just this one.

## Why the override is safe

All workspace packages export from `./src/index.ts` (not `dist/`), so TypeScript resolves types from source. `@inquirer/testing` has no actual build-time dependency on the prompt packages' compiled output — overriding `dependsOn: []` for its `tsc` task is both correct and sufficient to break the task-graph cycle.

## Test plan

- `yarn turbo tsc --dry` no longer exits immediately with "Invalid package dependency graph: Cyclic dependency detected"
- CI should pass on this PR and unblock the queue of failing Dependabot PRs