### PR TITLE
feat(@inquirer/prompts): customizable loading state message in prompts/editor

### DIFF
--- a/packages/demo/demo.test.ts
+++ b/packages/demo/demo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@inquirer/testing/vitest';
 
 // Import demos AFTER @inquirer/testing/vitest to ensure mocks are applied
@@ -71,7 +71,7 @@ describe('@inquirer/demo E2E tests', () => {
         ✔ Confirm with default to no? No
         ✔ Confirm with your custom transformer function? 👍"
       `);
-    });
+    }, 10000);
   });
 
   describe('screen.type()', () => {
@@ -265,6 +265,16 @@ describe('@inquirer/demo E2E tests', () => {
       await screen.next();
       screen.type('Auto editor content');
       screen.keypress('enter');
+
+      // Third prompt opens editor with custom messages; use fake timers
+      // to skip the 3s validation delay in the demo
+      await screen.next();
+      vi.useFakeTimers({ toFake: ['setTimeout'] });
+      screen.keypress('enter');
+      screen.type('Custom messages content');
+      screen.keypress('enter');
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
 
       await demo;
     });

--- a/packages/demo/src/demos/editor.ts
+++ b/packages/demo/src/demos/editor.ts
@@ -24,6 +24,23 @@ const demo = async () => {
       waitForUserInput: false,
     }),
   );
+
+  console.log(
+    'Answer:',
+    await editor({
+      message: 'Custom messages',
+      validate: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return true;
+      },
+      theme: {
+        style: {
+          loadingMessage: () => 'Loading...',
+          waitingMessage: (enterKey: string) => `Press ${enterKey} to write stuff`,
+        },
+      },
+    }),
+  );
 };
 
 if (import.meta.url.startsWith('file:')) {

--- a/packages/editor/editor.test.ts
+++ b/packages/editor/editor.test.ts
@@ -274,4 +274,61 @@ describe('editor prompt', () => {
     await expect(answer).resolves.toEqual('new value');
     expect(getScreen()).toMatchInlineSnapshot(`"✔ Add a description"`);
   });
+
+  it('displays custom waitingMessage', async () => {
+    const { answer, events, getScreen } = await render(editor, {
+      message: 'Add a description',
+      theme: {
+        style: {
+          waitingMessage: (enterKey: string) => `Hit ${enterKey} to continue`,
+        },
+      },
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Add a description Hit <enter> to continue"
+    `);
+
+    expect(editAsync).not.toHaveBeenCalled();
+
+    events.keypress('enter');
+    expect(editAsync).toHaveBeenCalledOnce();
+
+    await editorAction(undefined, 'test value with waiting message');
+
+    await expect(answer).resolves.toEqual('test value with waiting message');
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Add a description"`);
+  });
+
+  it('displays custom loadingMessage', async () => {
+    let resolveValidation: () => void;
+    const { answer, events, getScreen } = await render(editor, {
+      message: 'Add a description',
+      theme: {
+        style: {
+          loadingMessage: () => 'Loading...',
+        },
+      },
+      validate: () =>
+        new Promise<boolean>((resolve) => {
+          resolveValidation = () => resolve(true);
+        }),
+    });
+
+    expect(editAsync).not.toHaveBeenCalled();
+    events.keypress('enter');
+
+    // Trigger the editor callback; validation starts and loadingMessage should appear
+    const editPromise = editorAction(undefined, 'test value with loading message');
+    events.type('foo'); // Ignored events while validation runs
+    await editPromise;
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Add a description Loading..."
+    `);
+
+    resolveValidation!();
+
+    await expect(answer).resolves.toEqual('test value with loading message');
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Add a description"`);
+  });
 });

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -15,6 +15,7 @@ import type { PartialDeep, InquirerReadline } from '@inquirer/type';
 type EditorTheme = {
   validationFailureMode: 'keep' | 'clear';
   style: {
+    loadingMessage: () => string;
     waitingMessage: (enterKey: string) => string;
   };
 };
@@ -22,6 +23,7 @@ type EditorTheme = {
 const editorTheme: EditorTheme = {
   validationFailureMode: 'keep',
   style: {
+    loadingMessage: () => 'Validating...',
     waitingMessage: (enterKey) => `Press ${enterKey} to launch your preferred editor.`,
   },
 };
@@ -103,7 +105,9 @@ export default createPrompt<string, EditorConfig>((config, done) => {
 
   const message = theme.style.message(config.message, status);
   let helpTip = '';
-  if (status === 'idle') {
+  if (status === 'loading') {
+    helpTip = theme.style.help(theme.style.loadingMessage());
+  } else if (status === 'idle') {
     const enterKey = theme.style.key('enter');
     helpTip = theme.style.help(theme.style.waitingMessage(enterKey));
   }

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -100,6 +100,7 @@ const deLocale: Locale = {
   },
   search: { helpNavigate: 'Navigieren', helpSelect: 'Auswählen' },
   editor: {
+    loadingMessage: () => 'Überprüfung...',
     waitingMessage: (enterKey) => `Drücken Sie ${enterKey}, um Ihren Editor zu öffnen.`,
   },
   password: { maskedText: '[Eingabe verborgen]' },

--- a/packages/i18n/src/create.ts
+++ b/packages/i18n/src/create.ts
@@ -134,6 +134,7 @@ export function createLocalizedPrompts(locale: Locale) {
     editor(this: void, config: EditorConfig, context?: Context) {
       const theme = makeTheme(config.theme, {
         style: {
+          loadingMessage: locale.editor.loadingMessage,
           waitingMessage: locale.editor.waitingMessage,
         },
       });

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -24,6 +24,7 @@ const esLocale: Locale = {
     helpSelect: 'seleccionar',
   },
   editor: {
+    loadingMessage: () => 'Validando...',
     waitingMessage: (enterKey) => `Presione ${enterKey} para lanzar su editor preferido.`,
   },
   password: {

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -24,6 +24,7 @@ const frLocale: Locale = {
     helpSelect: 'sélectionner',
   },
   editor: {
+    loadingMessage: () => 'Validation en cours...',
     waitingMessage: (enterKey) =>
       `Appuyez sur ${enterKey} pour lancer votre éditeur préféré.`,
   },

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -24,6 +24,7 @@ const ptLocale: Locale = {
     helpSelect: 'selecionar',
   },
   editor: {
+    loadingMessage: () => 'Validando...',
     waitingMessage: (enterKey) =>
       `Pressione ${enterKey} para abrir seu editor preferido.`,
   },

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -24,6 +24,7 @@ const zhLocale: Locale = {
     helpSelect: '选择',
   },
   editor: {
+    loadingMessage: () => '验证中...',
     waitingMessage: (enterKey) => `按 ${enterKey} 键启动您的首选编辑器。`,
   },
   password: {

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -52,6 +52,8 @@ export interface SearchStrings {
  * Localized strings for the editor prompt
  */
 export interface EditorStrings {
+  /** Message shown while prompt is validating file contents */
+  loadingMessage: () => string;
   /** Message shown while waiting for user to open editor (receives formatted enter key) */
   waitingMessage: (enterKey: string) => string;
 }

--- a/packages/i18n/test/auto-detect.test.ts
+++ b/packages/i18n/test/auto-detect.test.ts
@@ -143,6 +143,7 @@ describe('auto locale detection', () => {
         },
         search: { helpNavigate: 'navigieren', helpSelect: 'wählen' },
         editor: {
+          loadingMessage: () => 'Überprüfung...',
           waitingMessage: (key) => `Drücken Sie ${key} um Ihren Editor zu öffnen.`,
         },
         password: { maskedText: '[Eingabe verborgen]' },


### PR DESCRIPTION
Add `loadingMessage` property in editor prompt theme which is used to display a message while the prompt is in the `loading` state

**loadingMessage**
- Default message is an empty string
- Add new prompt in editor demo to show usage of `loadingMessage` and `waitingMessage`
- Add two new unit tests for `loadingMessage` and `waitingMessage`
- Add `loadingMessage` property to locale objects

**Also in this change**
- Fix various tests that did not work properly on windows
  - Improper use of `> /dev/null` (should be `> NUL` on windows)
  - Bad `file://` url since windows uses `\\` as a path separator rather than `/`
  - `import.meta.filename` string is already resolved with `\\` separator but `callSites.getFileName()` was not
  - File modes on windows have a max of 666 since windows does not set permissions for executable bits, so a test setting the mode to 755 was not taking this into account
  - Fix regex for path always using `/` rather than `path.sep`
  - Fix test for figures for fallback to ascii figures not working correctly on windows
- Changed deprecated `rejects.toThrowError` to `rejects.toThrow`

Closes #2038