### PR TITLE
bug(external-editor): External editor incorrectly parses editor to open when a full path is used and contains spaces

### DIFF
--- a/packages/external-editor/src/index.ts
+++ b/packages/external-editor/src/index.ts
@@ -9,6 +9,7 @@ import { CreateFileError } from './errors/CreateFileError.ts';
 import { LaunchEditorError } from './errors/LaunchEditorError.ts';
 import { ReadFileError } from './errors/ReadFileError.ts';
 import { RemoveFileError } from './errors/RemoveFileError.ts';
+import { parseEditorCommand } from './parse-editor-command.ts';
 
 export interface IEditorParams {
   args: string[];
@@ -57,29 +58,6 @@ export function editAsync(
 function sanitizeAffix(affix?: string): string {
   if (!affix) return '';
   return affix.replace(/[^a-zA-Z0-9_.-]/g, '_');
-}
-
-function splitStringBySpace(str: string): string[] {
-  const pieces: string[] = [];
-  let currentString = '';
-  for (let strIndex = 0; strIndex < str.length; strIndex++) {
-    const currentLetter = str.charAt(strIndex);
-    if (
-      strIndex > 0 &&
-      currentLetter === ' ' &&
-      str[strIndex - 1] !== '\\' &&
-      currentString.length > 0
-    ) {
-      pieces.push(currentString);
-      currentString = '';
-    } else {
-      currentString = `${currentString}${currentLetter}`;
-    }
-  }
-  if (currentString.length > 0) {
-    pieces.push(currentString);
-  }
-  return pieces;
 }
 
 export class ExternalEditor {
@@ -136,20 +114,12 @@ export class ExternalEditor {
   }
 
   private determineEditor() {
-    const editor = process.env['VISUAL']
-      ? process.env['VISUAL']
-      : process.env['EDITOR']
-        ? process.env['EDITOR']
-        : process.platform.startsWith('win')
-          ? 'notepad'
-          : 'vim';
+    const editor =
+      process.env['VISUAL'] ??
+      process.env['EDITOR'] ??
+      (process.platform.startsWith('win') ? 'notepad' : 'vim');
 
-    const editorOpts = splitStringBySpace(editor).map((piece: string) =>
-      piece.replace('\\ ', ' '),
-    );
-    const bin = editorOpts.shift()!;
-
-    this.editor = { args: editorOpts, bin };
+    this.editor = parseEditorCommand(editor);
   }
 
   private createTemporaryFile() {

--- a/packages/external-editor/src/parse-editor-command.ts
+++ b/packages/external-editor/src/parse-editor-command.ts
@@ -1,0 +1,29 @@
+import type { IEditorParams } from './index.ts';
+
+export function parseEditorCommand(editor: string): IEditorParams {
+  let bin: string;
+  let rest: string;
+
+  if (editor.startsWith('"')) {
+    const closeQuote = editor.indexOf('"', 1);
+    if (closeQuote === -1) {
+      // Unmatched quote — treat the whole string as the binary
+      bin = editor.slice(1);
+      rest = '';
+    } else {
+      bin = editor.substring(1, closeQuote);
+      rest = editor.substring(closeQuote + 1).trim();
+    }
+  } else {
+    const firstSpace = editor.indexOf(' ');
+    if (firstSpace === -1) {
+      bin = editor;
+      rest = '';
+    } else {
+      bin = editor.substring(0, firstSpace);
+      rest = editor.substring(firstSpace + 1).trim();
+    }
+  }
+
+  return { bin, args: rest ? rest.split(/\s+/) : [] };
+}

--- a/packages/external-editor/test/main.test.ts
+++ b/packages/external-editor/test/main.test.ts
@@ -3,6 +3,7 @@ import { readFileSync, statSync, writeFileSync } from 'node:fs';
 import iconv from 'iconv-lite';
 import path from 'node:path';
 import { edit, editAsync, ExternalEditor } from '../src/index.ts';
+import { parseEditorCommand } from '../src/parse-editor-command.ts';
 
 const testingInput = 'aAbBcCdDeEfFgG';
 const expectedResult = 'aAbBcCdDeE';
@@ -81,6 +82,56 @@ describe('main', () => {
     });
 
     expect(text).toBe(editor.text);
+  });
+});
+
+describe('parseEditorCommand', () => {
+  it('simple binary name', () => {
+    expect(parseEditorCommand('vim')).toEqual({ bin: 'vim', args: [] });
+  });
+
+  it('binary with arguments', () => {
+    expect(parseEditorCommand('notepad --test')).toEqual({
+      bin: 'notepad',
+      args: ['--test'],
+    });
+  });
+
+  it('path containing spaces and no quotes', () => {
+    // Without quotes, splits on the first space
+    expect(
+      parseEditorCommand('C:\\Program Files (x86)\\Notepad++\\notepad++.exe'),
+    ).toEqual({
+      bin: 'C:\\Program',
+      args: ['Files', '(x86)\\Notepad++\\notepad++.exe'],
+    });
+  });
+
+  it('quoted path without arguments', () => {
+    expect(
+      parseEditorCommand('"C:\\Program Files (x86)\\Notepad++\\notepad++.exe"'),
+    ).toEqual({
+      bin: 'C:\\Program Files (x86)\\Notepad++\\notepad++.exe',
+      args: [],
+    });
+  });
+
+  it('quoted path with arguments', () => {
+    expect(
+      parseEditorCommand(
+        '"C:\\Program Files (x86)\\Notepad++\\notepad++.exe" --wait --line 10',
+      ),
+    ).toEqual({
+      bin: 'C:\\Program Files (x86)\\Notepad++\\notepad++.exe',
+      args: ['--wait', '--line', '10'],
+    });
+  });
+
+  it('unmatched quote treats rest as binary', () => {
+    expect(parseEditorCommand('"unclosed path')).toEqual({
+      bin: 'unclosed path',
+      args: [],
+    });
   });
 });
 


### PR DESCRIPTION
Tweak logic for splitting spaces when determining editor to open so that it will not split a space if it's inside quotes
Add unit tests for `determineEditor`

Closes #2040 