### PR TITLE
fix(@inquirer/core): mute output after readline initialization

### DIFF
--- a/packages/core/src/lib/create-prompt.ts
+++ b/packages/core/src/lib/create-prompt.ts
@@ -54,17 +54,18 @@ export function createPrompt<Value, Config>(
     const output = new MuteStream();
     output.pipe(context.output ?? process.stdout);
 
-    // Pre-mute the output so that readline doesn't echo stale keystrokes
-    // to the terminal before the first render. ScreenManager will unmute/mute
-    // the output around each render call as needed.
-    output.mute();
-
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     const rl = readline.createInterface({
       terminal: true,
       input,
       output,
     }) as unknown as InquirerReadline;
+
+    // Mute the output after readline has initialized so readline can perform
+    // any terminal setup writes (e.g. Windows Console API initialization)
+    // before suppressing output. ScreenManager will unmute/mute around each
+    // render call as needed.
+    output.mute();
     const screen = new ScreenManager(rl);
 
     const { promise, resolve, reject } = PromisePolyfill.withResolver<Value>();


### PR DESCRIPTION
## Summary

- Moves `output.mute()` to **after** `readline.createInterface()` instead of before it
- On Windows, readline may write to the output stream during initialization (via Console APIs) to configure terminal state; muting beforehand silently drops those writes and can leave readline unable to receive keyboard input

## Root cause

PR #2064 / commit `fd40b437` introduced `output.mute()` before `readline.createInterface()` as part of fixing #1303 (stale keystrokes draining into fresh prompts). The intent was to suppress readline echoing stale input before the first render.

However, on Windows 11 / PowerShell, readline performs terminal initialization writes during `createInterface()`. On Unix, raw mode is configured via an `ioctl()` syscall that doesn't depend on the output stream, but on Windows the Console APIs may route through the output handle. Muting the stream before readline runs means those initialization writes are silently dropped, leaving readline unable to receive keyboard input — the prompt renders correctly but all keystrokes are ignored.

The fix is minimal: simply move `output.mute()` to the line after `readline.createInterface()` completes. Readline still can't echo stale keystrokes (the drain tick via `setImmediate` drains before `startCycle` registers any keypress handlers), and the output is muted before any user-visible rendering begins.

## Test plan

- [x] `yarn vitest --run packages/core` — all 31 tests pass (including the buffered-keystroke test added in `fd40b437`)
- [ ] Validated on Windows 11 / PowerShell by issue reporter (see #2076)

Closes #2076