### PR TITLE
chore: replace husky with Git 2.54 config-based hooks

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,11 @@
+[hook "pre-commit"]
+	event = pre-commit
+	command = sh -c 'yarn nano-staged'
+
+[hook "post-checkout"]
+	event = post-checkout
+	command = sh -c 'yarn install'
+
+[hook "pre-push"]
+	event = pre-push
+	command = sh -c 'CI=true yarn pretest && yarn test'

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,1 +1,0 @@
-yarn install

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-yarn nano-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-CI=true yarn pretest && yarn test

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "demo": "node --watch-path=packages/ packages/demo/src/index.ts",
     "dev": "turbo watch tsc",
-    "prepare": "husky",
+    "prepare": "git config --local include.path ../.gitconfig || true",
     "prepublishOnly": "yarn tsc",
     "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i '' -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
     "postpack": "git restore packages/*/package.json packages/*/README.md",
@@ -76,7 +76,6 @@
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-oxlint": "^1.58.0",
     "globals": "^17.4.0",
-    "husky": "^9.1.7",
     "isolate-monorepo-package": "workspace:*",
     "nano-staged": "^1.0.2",
     "oxfmt": "^0.47.0",

--- a/packages/checkbox/checkbox.test.ts
+++ b/packages/checkbox/checkbox.test.ts
@@ -931,7 +931,7 @@ describe('checkbox prompt', () => {
           style: {
             renderSelectedChoices: (selected: { value: number }[]) => {
               if (selected.length > 1) {
-                return `You have selected ${(selected[0] as { value: number }).value} and ${selected.length - 1} more.`;
+                return `You have selected ${selected[0]!.value} and ${selected.length - 1} more.`;
               }
               return `You have selected ${selected
                 .slice(0, 1)

--- a/packages/core/src/lib/create-prompt.ts
+++ b/packages/core/src/lib/create-prompt.ts
@@ -21,7 +21,7 @@ type ViewFunction<Value, Config> = (
 
 function getCallSites() {
   // oxlint-disable-next-line typescript/unbound-method
-  const _prepareStackTrace = Error.prepareStackTrace;
+  const savedPrepareStackTrace = Error.prepareStackTrace;
   let result: NodeJS.CallSite[] = [];
   try {
     Error.prepareStackTrace = (_, callSites) => {
@@ -36,7 +36,7 @@ function getCallSites() {
     // https://nodejs.org/api/cli.html#--frozen-intrinsics
     return result;
   }
-  Error.prepareStackTrace = _prepareStackTrace;
+  Error.prepareStackTrace = savedPrepareStackTrace;
   return result;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,7 +583,6 @@ __metadata:
     eslint-plugin-n: "npm:^17.24.0"
     eslint-plugin-oxlint: "npm:^1.58.0"
     globals: "npm:^17.4.0"
-    husky: "npm:^9.1.7"
     isolate-monorepo-package: "workspace:*"
     nano-staged: "npm:^1.0.2"
     oxfmt: "npm:^0.47.0"
@@ -3900,15 +3899,6 @@ __metadata:
   dependencies:
     ms: "npm:^2.0.0"
   checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
-  languageName: node
-  linkType: hard
-
-"husky@npm:^9.1.7":
-  version: 9.1.7
-  resolution: "husky@npm:9.1.7"
-  bin:
-    husky: bin.js
-  checksum: 10/c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Replaces Husky with Git 2.54's native config-based hooks, removing a dev dependency entirely
- Commits a `.gitconfig` file with declarative hook definitions for `pre-commit`, `post-checkout`, and `pre-push`
- The `prepare` script wires it in via `git config --local include.path ../.gitconfig`
- Commands are wrapped in `sh -c '...'` to prevent remote name/URL arguments that git passes to pre-push hooks from leaking into the commands
- Also fixes two pre-existing lint errors caught by the new pre-push hook (`no-underscore-dangle` in `create-prompt.ts`, redundant type assertion in `checkbox.test.ts`)

## Test plan

- [ ] `yarn install` on a fresh clone sets `include.path` in `.git/config`
- [ ] `git commit` triggers nano-staged (oxfmt + eslint)
- [ ] `git push` runs lint + full test suite and blocks on failure
- [ ] `git hook list pre-commit`, `git hook list pre-push`, and `git hook list post-checkout` show the hooks