### PR TITLE
feat(prompts): preserve literal types in choices via const generics

### DIFF
--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -166,7 +166,7 @@ function normalizeChoices<Value>(
 }
 
 export default createPrompt(
-  <Value>(config: CheckboxConfig<Value>, done: (value: Array<Value>) => void) => {
+  <const Value>(config: CheckboxConfig<Value>, done: (value: Array<Value>) => void) => {
     const { pageSize = 7, loop = true, required, validate = () => true } = config;
     const shortcuts = { all: 'a', invert: 'i', ...config.shortcuts };
     const theme = makeTheme<CheckboxTheme>(checkboxTheme, config.theme);

--- a/packages/expand/src/index.ts
+++ b/packages/expand/src/index.ts
@@ -103,7 +103,7 @@ const helpChoice = {
 };
 
 const expand = createPrompt(
-  <Value>(config: ExpandConfig<Value>, done: (value: Value) => void) => {
+  <const Value>(config: ExpandConfig<Value>, done: (value: Value) => void) => {
     const { default: defaultKey = 'h' } = config;
     const choices = useMemo(() => normalizeChoices(config.choices), [config.choices]);
     const [status, setStatus] = useState<Status>('idle');

--- a/packages/rawlist/rawlist.test.ts
+++ b/packages/rawlist/rawlist.test.ts
@@ -489,3 +489,17 @@ describe('rawlist prompt', () => {
     });
   });
 });
+
+describe('rawlist types', () => {
+  it('preserves string literal union when called directly with inline choices', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const answer = rawlist(
+      { message: 'Select one', choices: ['1', '2'] },
+      { signal: abortController.signal },
+    );
+
+    expectTypeOf(answer).resolves.toEqualTypeOf<'1' | '2'>();
+    await expect(answer).rejects.toThrow();
+  });
+});

--- a/packages/rawlist/src/index.ts
+++ b/packages/rawlist/src/index.ts
@@ -111,7 +111,7 @@ function getSelectedChoice<Value>(
 }
 
 export default createPrompt(
-  <Value>(config: RawlistConfig<Value>, done: (value: Value) => void) => {
+  <const Value>(config: RawlistConfig<Value>, done: (value: Value) => void) => {
     const { loop = true } = config;
     const choices = useMemo(() => normalizeChoices(config.choices), [config.choices]);
     const [status, setStatus] = useState<Status>('idle');

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -113,7 +113,7 @@ function normalizeChoices<Value>(
 }
 
 export default createPrompt(
-  <Value>(config: SearchConfig<Value>, done: (value: Value) => void) => {
+  <const Value>(config: SearchConfig<Value>, done: (value: Value) => void) => {
     const { pageSize = 7, validate = () => true } = config;
     const theme = makeTheme<SearchTheme>(searchTheme, config.theme);
     const [status, setStatus] = useState<Status>('loading');

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -123,7 +123,7 @@ function normalizeChoices<Value>(
 }
 
 export default createPrompt(
-  <Value>(config: SelectConfig<Value>, done: (value: Value) => void) => {
+  <const Value>(config: SelectConfig<Value>, done: (value: Value) => void) => {
     const { loop = true, pageSize = 7 } = config;
     const theme = makeTheme<SelectTheme>(selectTheme, config.theme);
     const { keybindings } = theme;

--- a/packages/select/test/select.test.ts
+++ b/packages/select/test/select.test.ts
@@ -1397,5 +1397,17 @@ describe('select prompt', () => {
       events.keypress('enter');
       await expect(answer).resolves.toEqual(1);
     });
+
+    it('preserves string literal union when called directly with inline choices', async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      const answer = select(
+        { message: 'Select one', choices: ['1', '2'] },
+        { signal: abortController.signal },
+      );
+
+      expectTypeOf(answer).resolves.toEqualTypeOf<'1' | '2'>();
+      await expect(answer).rejects.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds the TypeScript `const` modifier to the `<Value>` generic on `select`, `checkbox`, `rawlist`, `expand`, and `search`, so calls like `select({ choices: ['1', '2'] })` infer `'1' | '2'` instead of widening to `string`. No more `as const` ceremony at the call site.
- The change is a single token per prompt (`<Value>` → `<const Value>`) on the `createPrompt` callback. The outer `createPrompt<Value, Config>` signature is unchanged.

## Why this is needed
Reported in #2101: TS can't retain literal information about choices passed inline. The repo already runs TypeScript 6.0.2, so `const` modifiers (TS 5.0+) are supported. The five prompts touched here are exactly the ones whose return type is derived from `Value`.

## Test coverage
- New direct-call type-inference tests in `packages/select/test/select.test.ts` and `packages/rawlist/rawlist.test.ts`. These call the prompt directly (with an aborted `AbortSignal`) rather than through `@inquirer/testing`'s `render`, because `render` already declares `<Value, const Config>` and would mask whether the prompt itself preserves literals.
- I confirmed the new tests genuinely lock in the modifier: removing `const` from the prompt's `<Value>` produces a clear `TS2344` error on the `expectTypeOf().toEqualTypeOf<'1' | '2'>()` assertion.
- Existing literal-preservation tests in checkbox/expand/search continue to pass.

## Test plan
- [x] `yarn vitest --run packages/select packages/checkbox packages/rawlist packages/expand packages/search` (138 tests)
- [x] `yarn pretest` (lint + format + tsc)
- [x] `yarn test` (vitest + ESM/CJS integration suites)

Closes #2101