### PR TITLE
fix: reset cursor to column 0 after prompt completes (Windows)

### DIFF
--- a/packages/core/core.test.ts
+++ b/packages/core/core.test.ts
@@ -23,7 +23,7 @@ import {
   makeTheme,
   type Status,
 } from './src/index.ts';
-import { cursorShow, eraseLines } from '@inquirer/ansi';
+import { cursorLeft, cursorShow, eraseLines } from '@inquirer/ansi';
 
 describe('createPrompt()', () => {
   it('onKeypress: allow to implement custom behavior on keypress', async () => {
@@ -489,7 +489,7 @@ describe('createPrompt()', () => {
     events.keypress('enter');
 
     await expect(answer).resolves.toEqual('done');
-    expect(getScreen({ raw: true })).toEqual(eraseLines(1) + cursorShow);
+    expect(getScreen({ raw: true })).toEqual(eraseLines(1) + cursorLeft + cursorShow);
   });
 
   it('clear timeout when force closing', { timeout: 1000 }, async () => {

--- a/packages/core/src/lib/screen-manager.ts
+++ b/packages/core/src/lib/screen-manager.ts
@@ -1,6 +1,13 @@
 import { stripVTControlCharacters } from 'node:util';
 import { breakLines, readlineWidth } from './utils.ts';
-import { cursorDown, cursorUp, cursorTo, cursorShow, eraseLines } from '@inquirer/ansi';
+import {
+  cursorDown,
+  cursorLeft,
+  cursorUp,
+  cursorTo,
+  cursorShow,
+  eraseLines,
+} from '@inquirer/ansi';
 import type { InquirerReadline } from '@inquirer/type';
 
 const height = (content: string): number => content.split('\n').length;
@@ -97,6 +104,11 @@ export default class ScreenManager {
 
     let output = cursorDown(this.extraLinesUnderPrompt);
     output += clearContent ? eraseLines(this.height) : '\n';
+    // Reset cursor to column 0. On Windows terminals, \n moves the cursor
+    // down without resetting the column when the rendered prompt+answer
+    // wraps past the terminal width. Without this, all subsequent output
+    // starts at the wrong horizontal offset.
+    output += cursorLeft;
     output += cursorShow;
     this.write(output);
 

--- a/packages/inquirer/src/ui/prompt.ts
+++ b/packages/inquirer/src/ui/prompt.ts
@@ -354,6 +354,11 @@ export default class PromptsRunner<A extends Answers> {
               rl.setPrompt('');
               rl.output.unmute();
               rl.output.write(cursorShow);
+              // Reset cursor to column 0. On Windows terminals, \n moves the
+              // cursor down without resetting the column when the rendered
+              // prompt+answer wraps past the terminal width. Without this,
+              // all subsequent output starts at the wrong horizontal offset.
+              readline.cursorTo(rl.output, 0);
               rl.output.end();
               rl.close();
             };


### PR DESCRIPTION
## Summary

On Windows terminals, after a prompt completes, all subsequent console output starts at the wrong horizontal offset — producing garbled output. This happens because `\n` on Windows moves the cursor down **without** resetting to column 0 when the rendered prompt+answer text wraps past the terminal width.

Fixes #2108

## Changes

### `packages/inquirer/src/ui/prompt.ts` (legacy API)

Added `readline.cursorTo(rl.output, 0)` in the `onClose` handler before `rl.output.end()`:

```diff
 const onClose = () => {
   ...
   rl.output.write(cursorShow);
+  // Reset cursor to column 0 — on Windows, \n does not reset column after line wrap
+  readline.cursorTo(rl.output, 0);
   rl.output.end();
   rl.close();
 };
```

### `packages/core/src/lib/screen-manager.ts` (modern `@inquirer/*` API)

Appended `cursorLeft` (already exported from `@inquirer/ansi` as `\x1b[G`) to the `done()` output before `cursorShow`:

```diff
 let output = cursorDown(this.extraLinesUnderPrompt);
 output += clearContent ? eraseLines(this.height) : '\n';
+output += cursorLeft;
 output += cursorShow;
```

### `packages/core/core.test.ts`

Updated the `'allow cleaning the prompt after completion'` assertion to include the new `cursorLeft` in the expected raw output.

## Why this is safe

- `cursorLeft` (`\x1b[G`) is a no-op when the cursor is already at column 0, which is the case on Linux/macOS where `\n` resets the column automatically
- The escape sequence is standard ANSI CSI and supported by all modern terminals
- Affects all prompt types (checkbox, list, input, confirm, etc.) since they all share the same close/done path

## Reproduction

See #2108 for the full reproduction case and screenshots. In short: any prompt whose rendered answer wraps past the terminal width on Windows produces garbled output for all subsequent `console.log` calls.