### PR TITLE
fix(@inquirer/input): allow explicit undefined for default option

### DIFF
--- a/packages/input/input.test.ts
+++ b/packages/input/input.test.ts
@@ -138,6 +138,20 @@ describe('input prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`"✔ What is your name Mike"`);
   });
 
+  it('accepts explicit undefined as default', async () => {
+    const defaultValue: string | undefined = undefined;
+    const { answer, events, getScreen } = await render(input, {
+      message: 'What is your name',
+      default: defaultValue,
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`"? What is your name"`);
+
+    events.type('Mike');
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('Mike');
+  });
+
   it('handle numeric default option', async () => {
     const { answer, events, getScreen } = await render(input, {
       message: 'What port do you want to use?',

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -23,7 +23,7 @@ const inputTheme: InputTheme = {
 
 type InputConfig = {
   message: string;
-  default?: string;
+  default?: string | undefined;
   prefill?: 'tab' | 'editable';
   required?: boolean;
   transformer?: (value: string, { isFinal }: { isFinal: boolean }) => string;


### PR DESCRIPTION
## Summary
- Change `InputConfig['default']` from `string` to `string | undefined` so the property accepts explicitly-undefined values under `exactOptionalPropertyTypes: true`.

Closes #2110

## Test plan
- [x] `yarn tsc`
- [x] `yarn vitest --run packages/input`
- [x] CI green