### PR TITLE
ci: add Node.js 26 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 26]
     steps:
       - uses: actions/checkout@v6
       - run: npm install -g corepack --force


### PR DESCRIPTION
## Summary
- Add Node.js 26 to the unit test matrix in `.github/workflows/main.yml` alongside 20, 22, and 24.

## Test plan
- [ ] CI runs the unit test job on Node 26 across ubuntu-latest and windows-latest.