### PR TITLE
feat(@inquirer/checkbox): add exclusive choice option

### DIFF
--- a/packages/checkbox/checkbox.test.ts
+++ b/packages/checkbox/checkbox.test.ts
@@ -1480,6 +1480,120 @@ describe('checkbox prompt', () => {
       await expect(answer).resolves.toEqual([]);
     });
   });
+
+  describe('exclusive choices', () => {
+    const exclusiveChoices = [
+      { value: 'none', name: 'None', exclusive: true },
+      { value: 'apple', name: 'Apple' },
+      { value: 'orange', name: 'Orange' },
+    ];
+
+    it('selecting an exclusive choice deselects all other choices', async () => {
+      const { answer, events } = await render(checkbox, {
+        message: 'Select fruits',
+        choices: exclusiveChoices,
+      });
+
+      // Select apple and orange first
+      events.keypress('down');
+      events.keypress('space');
+      events.keypress('down');
+      events.keypress('space');
+
+      // Navigate to None (exclusive) and select it
+      events.keypress('up');
+      events.keypress('up');
+      events.keypress('space');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(['none']);
+    });
+
+    it('selecting a non-exclusive choice deselects all exclusive choices', async () => {
+      const { answer, events } = await render(checkbox, {
+        message: 'Select fruits',
+        choices: exclusiveChoices,
+      });
+
+      // Select None (exclusive) first
+      events.keypress('space');
+
+      // Navigate to Apple and select it
+      events.keypress('down');
+      events.keypress('space');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(['apple']);
+    });
+
+    it('unchecking an exclusive choice just unchecks it without side effects', async () => {
+      const { answer, events } = await render(checkbox, {
+        message: 'Select fruits',
+        choices: exclusiveChoices,
+      });
+
+      // Select None (exclusive), then deselect it
+      events.keypress('space');
+      events.keypress('space');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual([]);
+    });
+
+    it('multiple exclusive choices mutually exclude each other', async () => {
+      const { answer, events } = await render(checkbox, {
+        message: 'Select fruits',
+        choices: [
+          { value: 'none', name: 'None', exclusive: true },
+          { value: 'na', name: 'N/A', exclusive: true },
+          { value: 'apple', name: 'Apple' },
+        ],
+      });
+
+      // Select None (exclusive)
+      events.keypress('space');
+
+      // Navigate to N/A (also exclusive) and select it
+      events.keypress('down');
+      events.keypress('space');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(['na']);
+    });
+
+    it('number key selection respects exclusivity', async () => {
+      const { answer, events } = await render(checkbox, {
+        message: 'Select fruits',
+        choices: exclusiveChoices,
+      });
+
+      // Select apple (item 2) via number key
+      events.keypress('2');
+
+      // Select none (item 1, exclusive) via number key
+      events.keypress('1');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(['none']);
+    });
+
+    it('does not deselect disabled checked items when an exclusive choice is selected', async () => {
+      const { answer, events } = await render(checkbox, {
+        message: 'Select fruits',
+        choices: [
+          { value: 'fruit', name: 'Fruit', exclusive: true },
+          { value: 'apple', name: 'Apple', checked: true, disabled: true },
+          { value: 'orange', name: 'Orange' },
+        ],
+      });
+
+      // Select Fruit (exclusive)
+      events.keypress('space');
+
+      events.keypress('enter');
+      await expect(answer).resolves.toEqual(['fruit', 'apple']);
+    });
+  });
 });
 
 describe('checkbox types', () => {

--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -79,6 +79,7 @@ type Choice<Value> = {
   disabled?: boolean | string;
   checked?: boolean;
   type?: never;
+  exclusive?: boolean;
 };
 
 type NormalizedChoice<Value> = {
@@ -89,6 +90,7 @@ type NormalizedChoice<Value> = {
   short: string;
   disabled: boolean | string;
   checked: boolean;
+  exclusive: boolean;
 };
 
 type CheckboxConfig<Value = string> = {
@@ -123,10 +125,26 @@ function toggle<Value>(item: Item<Value>): Item<Value> {
   return isSelectable(item) ? { ...item, checked: !item.checked } : item;
 }
 
+function deselect<Value>(item: Item<Value>): Item<Value> {
+  return isSelectable(item) && item.checked ? { ...item, checked: false } : item;
+}
+
 function check(checked: boolean) {
   return function <Value>(item: Item<Value>): Item<Value> {
     return isSelectable(item) ? { ...item, checked } : item;
   };
+}
+
+function processSelection<Value>(
+  items: readonly Item<Value>[],
+  selectedItem: NormalizedChoice<Value>,
+) {
+  return items.map((choice) => {
+    if (Separator.isSeparator(choice)) return choice;
+    else if (choice === selectedItem) return toggle(choice);
+    else if (selectedItem.exclusive) return deselect(choice);
+    else return choice.exclusive ? deselect(choice) : choice;
+  });
 }
 
 function normalizeChoices<Value>(
@@ -144,6 +162,7 @@ function normalizeChoices<Value>(
         checkedName: name,
         disabled: false,
         checked: false,
+        exclusive: false,
       };
     }
 
@@ -155,6 +174,7 @@ function normalizeChoices<Value>(
       checkedName: choice.checkedName ?? name,
       disabled: choice.disabled ?? false,
       checked: choice.checked ?? false,
+      exclusive: choice.exclusive ?? false,
     };
 
     if (choice.description) {
@@ -228,7 +248,7 @@ export default createPrompt(
             setError(theme.i18n.disabledError);
           } else {
             setError(undefined);
-            setItems(items.map((choice, i) => (i === active ? toggle(choice) : choice)));
+            setItems(processSelection(items, activeItem));
           }
         }
       } else if (key.name === shortcuts.all) {
@@ -251,7 +271,7 @@ export default createPrompt(
         const selectedItem = items[position];
         if (selectedItem && isSelectable(selectedItem)) {
           setActive(position);
-          setItems(items.map((choice, i) => (i === position ? toggle(choice) : choice)));
+          setItems(processSelection(items, selectedItem));
         }
       }
     });


### PR DESCRIPTION
I'd like to introduce this feature PR by illustrating how the checkbox module is currently
being used in a very popular library, @angular/cli. When creating a new angular workspace
the user is prompted to select AI tools to add to the workspace. However, it currently allows
for illogical selections such as having None, Claude, and Cursor selected at the same time.

<img width="502" height="251" alt="Screenshot 2026-05-14 at 7 11 05 PM" src="https://github.com/user-attachments/assets/af46039d-9168-4c09-b8d7-a00eaecf9caf" />

This PR introduces a new `exclusive: boolean` property on checkbox `Choice` objects. What this
would allow a library like @angular/cli to do is setup their options as:
```typescript
[
  { name: 'None', value: 'none', exclusive: true },
  { name: 'Claude', value: 'claude' },
  { name: 'Cursor', value: 'cursor' },
]
```

Selecting "Claude" would automatically deselect "None". Selecting "None" would automatically
deselect "Claude" and "Cursor" if they were selected.

**Edge cases**

If you're open to the functionality added in this PR one thing we'll need to address is how to handle exclusive options in relation to the "select all" and "invert selection" features that inquirer already provides. I would think that users would not typically want the "select all" and "invert selection" features alongside usage of exclusive options but it's probably something we'd need to address at some point.