### PR TITLE
fix(@inquirer/core): hard wrap rendered lines

### DIFF
--- a/packages/core/src/lib/utils.test.ts
+++ b/packages/core/src/lib/utils.test.ts
@@ -1,0 +1,30 @@
+import { stripVTControlCharacters } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { breakLines } from './utils.ts';
+
+const visibleLines = (content: string): string[] =>
+  stripVTControlCharacters(content).split('\n');
+
+describe('breakLines', () => {
+  it('wraps prompt text at terminal columns when spaces could word-wrap earlier', () => {
+    const content =
+      '\x1B[34m?\x1B[39m \x1B[1mType a long line that wraps to see cursor bug:\x1B[22m hello world';
+
+    expect(visibleLines(breakLines(content, 20))).toEqual([
+      '? Type a long line t',
+      'hat wraps to see cur',
+      'sor bug: hello world',
+    ]);
+  });
+
+  it('hard wraps continuous strings that exceed the terminal width', () => {
+    const content = 'Go to https://example.com/some/really-long-url';
+
+    expect(visibleLines(breakLines(content, 15))).toEqual([
+      'Go to https://e',
+      'xample.com/some',
+      '/really-long-ur',
+      'l',
+    ]);
+  });
+});

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -13,7 +13,7 @@ export function breakLines(content: string, width: number): string {
   return content
     .split('\n')
     .flatMap((line) =>
-      wrapAnsi(line, width, { trim: false, hard: true })
+      wrapAnsi(line, width, { trim: false, wordWrap: false })
         .split('\n')
         .map((str) => str.trimEnd()),
     )


### PR DESCRIPTION
## Summary

Change `breakLines()` to ask `fast-wrap-ansi` for deterministic terminal-column wrapping with `wordWrap: false`.

This keeps ANSI-aware wrapping in the dependency while avoiding word-boundary line breaks that can disagree with readline cursor positioning on wrapped prompt input.

Fixes #1818.

## Root Cause

`hard: true` still allows word wrapping for normal words and can move over-width words to the next line before splitting them. That makes rendered rows differ from the terminal/readline column model, which can leave the cursor in the wrong place after editing wrapped input.

## Testing

- `yarn vitest --run packages/core`
- `yarn pretest`
- `yarn test` currently fails in existing prompt interaction tests around backspace/input retention; the same `packages/input/input.test.ts` failures reproduce on a clean `origin/main` worktree.
