### PR TITLE
fix(inquirer)!: throw on unknown prompt types

### DIFF
--- a/packages/inquirer/inquirer.test.ts
+++ b/packages/inquirer/inquirer.test.ts
@@ -24,6 +24,7 @@ declare module './src/index.js' {
     stub2: { answer?: string | boolean; message: string; default: string };
     stubSelect: { choices: string[] };
     failing: { message: string };
+    list: { message: string };
   }
 }
 
@@ -32,6 +33,7 @@ type TestQuestions = {
   stub2: { answer?: string | boolean; message: string; default: string };
   stubSelect: { choices: string[] };
   failing: { message: string };
+  list: { message: string };
 };
 
 function throwFunc(step: any): any {
@@ -89,7 +91,7 @@ describe('exported types', () => {
     expectTypeOf({}).not.toExtend<Question>();
   });
 
-  it('exported Question type requires type, name and message', () => {
+  it('exported Question type requires name and message', () => {
     const question = {
       type: 'input',
       name: 'q1',
@@ -97,7 +99,7 @@ describe('exported types', () => {
     } as const;
     expectTypeOf(question).toExtend<Question>();
     expectTypeOf(question).toExtend<DistinctQuestion>();
-    expectTypeOf({ name: 'q1', message: 'message' }).not.toExtend<Question>();
+    expectTypeOf({ name: 'q1', message: 'message' }).toExtend<Question>();
     expectTypeOf({ type: 'stub', message: 'message' }).not.toExtend<Question>();
     expectTypeOf({ type: 'stub', name: 'q1' }).not.toExtend<Question>();
   });
@@ -202,6 +204,33 @@ describe('inquirer.prompt(...)', () => {
       });
       expect(answers).toEqual({ q1: 'bar' });
       expectTypeOf(answers).toEqualTypeOf<{ q1: any }>();
+    });
+
+    it('defaults to input when prompt type is unset', async () => {
+      inquirer.registerPrompt('input', StubPrompt);
+
+      const answers = await inquirer.prompt({
+        name: 'q1',
+        message: 'message',
+      });
+
+      expect(answers).toEqual({ q1: 'bar' });
+    });
+
+    it('throws when prompt type is not registered', async () => {
+      inquirer.registerPrompt('input', StubPrompt);
+
+      await expect(
+        inquirer.prompt({
+          type: 'list',
+          name: 'q1',
+          message: 'message',
+        }),
+      ).rejects.toMatchObject({
+        name: 'UnknownPromptTypeError',
+        message:
+          'Prompt type "list" is not registered. Available prompt types: checkbox, confirm, editor, expand, failing, input, number, password, rawlist, search, select, stub',
+      });
     });
 
     it('takes an Observable', async () => {

--- a/packages/inquirer/src/types.ts
+++ b/packages/inquirer/src/types.ts
@@ -114,7 +114,7 @@ type KeyValueOrAsyncGetterFunction<T, k extends string, A extends Answers> =
   T extends Record<string, any> ? MaybeAsyncValue<T[k], A> : never;
 
 export type Question<A extends Answers = Answers, Type extends string = string> = {
-  type: Type;
+  type?: Type;
   name: string;
   message: MaybeAsyncValue<string, A>;
   default?: any;
@@ -212,7 +212,7 @@ export type DictionaryAnswers<
 >;
 
 export type PromptModulePublicQuestion<A extends Answers, Flat extends Answers = A> = {
-  type:
+  type?:
     | 'input'
     | 'confirm'
     | 'editor'

--- a/packages/inquirer/src/ui/prompt.ts
+++ b/packages/inquirer/src/ui/prompt.ts
@@ -128,6 +128,17 @@ export type PromptFn<Value = any, Config = any> = (
  */
 export type PromptCollection = Record<string, PromptFn | LegacyPromptConstructor>;
 
+class UnknownPromptTypeError extends Error {
+  override name = 'UnknownPromptTypeError';
+
+  constructor(type: string, prompts: PromptCollection) {
+    const availableTypes = Object.keys(prompts).toSorted().join(', ');
+    super(
+      `Prompt type "${type}" is not registered. Available prompt types: ${availableTypes}`,
+    );
+  }
+}
+
 class TTYError extends Error {
   override name = 'TTYError';
   isTtyError = true;
@@ -263,6 +274,11 @@ export default class PromptsRunner<A extends Answers> {
   }
 
   private prepareQuestion = async (question: Question<A>) => {
+    const type = question.type ?? 'input';
+    if (!Object.hasOwn(this.prompts, type)) {
+      throw new UnknownPromptTypeError(type, this.prompts);
+    }
+
     const [message, defaultValue, resolvedChoices] = await Promise.all([
       fetchAsyncQuestionProperty(question, 'message', this.answers),
       fetchAsyncQuestionProperty(question, 'default', this.answers),
@@ -302,7 +318,7 @@ export default class PromptsRunner<A extends Answers> {
       message,
       default: defaultValue,
       choices,
-      type: question.type in this.prompts ? question.type : 'input',
+      type,
     });
 
     if (question.validate) {


### PR DESCRIPTION
## Summary

- Throw when a question specifies a prompt type that is not registered.
- Keep the historical `input` default when `type` is omitted.
- Update the public `Question` typing and tests to cover the omitted-type default and the unregistered-type error.

## Breaking Change

Explicit unregistered prompt types now throw an `UnknownPromptTypeError` instead of silently falling back to `input`. Omitting `type` still defaults to `input`.

## Why

Silently falling back to `input` hides configuration mistakes and removed aliases like `list`. The new error names the unknown type and lists the currently registered prompt types, including custom prompts.

Related to #2095.

## Test plan

- [x] `yarn vitest --run packages/inquirer/inquirer.test.ts`
- [x] `yarn pretest`
- [x] `yarn test` - local macOS run fails outside this change: BSD `truncate` rejects GNU-style options, followed by prompt simulation snapshot/timeouts and external-editor fixture mismatches.
