### PR TITLE
chore: limit CI token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
+permissions:
+  contents: read
+
 jobs:
   Compile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add a workflow-level `contents: read` permission block to CI.
- Keep the CI token scoped to the minimum permissions needed for checkout and read-only jobs.

## Why
CodeQL reports missing explicit `GITHUB_TOKEN` permissions for the CI workflow jobs. A top-level read-only permission closes those alerts without granting per-job write access.

## Validation
- `yarn oxfmt --check .github/workflows/main.yml`
- pre-push hook: `yarn tsc`, format check, `yarn eslint .`, package Vitest run, integration tests

Note: `yarn eslint .` emitted an existing warning in `packages/input/src/index.ts` about an unused eslint-disable directive.