### PR TITLE
fix(@inquirer/external-editor): harden editor temp files

### DIFF
--- a/packages/external-editor/src/index.test.ts
+++ b/packages/external-editor/src/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { readFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import iconv from 'iconv-lite';
 import path from 'node:path';
-import { edit, editAsync, ExternalEditor } from './index.ts';
+import { edit, editAsync, ExternalEditor, LaunchEditorError } from './index.ts';
 import { parseEditorCommand } from './parse-editor-command.ts';
 
 const testingInput = 'aAbBcCdDeEfFgG';
@@ -141,8 +141,7 @@ describe('custom options', () => {
     editor.run();
     const usedPath = readFileSync(captureFile, 'utf8');
     unlinkSync(captureFile);
-    const escapedSep = path.sep.replace(/\\/g, '\\\\');
-    expect(usedPath).toMatch(new RegExp(`.+${escapedSep}pre.+$`));
+    expect(path.basename(usedPath)).toMatch(/^pre.+$/);
   });
 
   it('postfix', () => {
@@ -155,7 +154,7 @@ describe('custom options', () => {
     editor.run();
     const usedPath = readFileSync(captureFile, 'utf8');
     unlinkSync(captureFile);
-    expect(usedPath).toMatch(/.+end\.post$/);
+    expect(path.basename(usedPath)).toMatch(/.+end\.post$/);
   });
 
   it('dir', () => {
@@ -168,7 +167,7 @@ describe('custom options', () => {
     editor.run();
     const usedPath = readFileSync(captureFile, 'utf8');
     unlinkSync(captureFile);
-    expect(path.dirname(usedPath)).toBe(import.meta.dirname);
+    expect(path.dirname(path.dirname(usedPath))).toBe(import.meta.dirname);
   });
 
   it('mode', () => {
@@ -189,6 +188,54 @@ describe('custom options', () => {
     } else {
       expect(int).toBe(100755);
     }
+  });
+
+  it('sanitizes prefix and postfix path separators', () => {
+    const captureFile = path.join(os.tmpdir(), randomUUID());
+    const editor = new ExternalEditor('testing', {
+      prefix: '../pre/',
+      postfix: '/../post',
+    });
+    editor.editor = {
+      bin: process.execPath,
+      args: ['-e', capturePathScript, captureFile],
+    };
+    editor.run();
+    const usedPath = readFileSync(captureFile, 'utf8');
+    unlinkSync(captureFile);
+    const filename = path.basename(usedPath);
+    expect(filename.startsWith('.._pre_')).toBe(true);
+    expect(filename.endsWith('_.._post')).toBe(true);
+  });
+
+  it('removes the temporary editor directory after reading', () => {
+    const captureFile = path.join(os.tmpdir(), randomUUID());
+    const editor = new ExternalEditor('testing');
+    editor.editor = {
+      bin: process.execPath,
+      args: ['-e', capturePathScript, captureFile],
+    };
+    editor.run();
+    const usedPath = readFileSync(captureFile, 'utf8');
+    unlinkSync(captureFile);
+    expect(existsSync(usedPath)).toBe(false);
+    expect(existsSync(path.dirname(usedPath))).toBe(false);
+  });
+});
+
+describe('launch errors', () => {
+  it('run() throws LaunchEditorError when the editor cannot start', () => {
+    const editor = new ExternalEditor('testing');
+    editor.editor.bin = `missing-editor-${randomUUID()}`;
+
+    expect(() => editor.run()).toThrow(LaunchEditorError);
+  });
+
+  it('runAsync() rejects with LaunchEditorError when the editor cannot start', async () => {
+    const editor = new ExternalEditor('testing');
+    editor.editor.bin = `missing-editor-${randomUUID()}`;
+
+    await expect(editor.runAsync()).rejects.toBeInstanceOf(LaunchEditorError);
   });
 });
 

--- a/packages/external-editor/src/index.ts
+++ b/packages/external-editor/src/index.ts
@@ -1,6 +1,12 @@
 import { detect } from 'chardet';
 import { spawn, spawnSync } from 'node:child_process';
-import { readFileSync, unlinkSync, type WriteFileOptions, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  type WriteFileOptions,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -62,6 +68,7 @@ export class ExternalEditor {
 
   private text: string = '';
   private tempFile: string = '';
+  private tempDir: string = '';
   private fileOptions: FileOptions = {};
 
   constructor(text: string = '', fileOptions: FileOptions = {}) {
@@ -79,11 +86,13 @@ export class ExternalEditor {
     this.createTempFile();
     try {
       try {
-        const editorProcess = spawnSync(
-          this.editor.bin,
-          this.editor.args.concat([this.tempFile]),
-          { stdio: 'inherit' },
-        );
+        const editorProcess = spawnSync(this.editor.bin, this.editorArgs(), {
+          shell: false,
+          stdio: 'inherit',
+        });
+        if (editorProcess.error) {
+          throw editorProcess.error;
+        }
         this.lastExitStatus = editorProcess.status ?? 0;
       } catch (launchError) {
         throw new LaunchEditorError(launchError);
@@ -99,13 +108,15 @@ export class ExternalEditor {
     this.createTempFile();
     const promise = new Promise<void>((resolve, reject) => {
       try {
-        const editorProcess = spawn(
-          this.editor.bin,
-          this.editor.args.concat([this.tempFile]),
-          { stdio: 'inherit' },
-        );
-        editorProcess.on('exit', (code: number) => {
-          this.lastExitStatus = code;
+        const editorProcess = spawn(this.editor.bin, this.editorArgs(), {
+          shell: false,
+          stdio: 'inherit',
+        });
+        editorProcess.once('error', (launchError) => {
+          reject(new LaunchEditorError(launchError));
+        });
+        editorProcess.once('exit', (code: number | null) => {
+          this.lastExitStatus = code ?? 0;
           resolve();
         });
       } catch (launchError) {
@@ -132,10 +143,11 @@ export class ExternalEditor {
   }
 
   private cleanup(): void {
-    if (!this.tempFile) return;
+    if (!this.tempDir) return;
     try {
-      unlinkSync(this.tempFile);
+      rmSync(this.tempDir, { force: true, recursive: true });
       this.tempFile = '';
+      this.tempDir = '';
     } catch (removeFileError) {
       throw new RemoveFileError(removeFileError);
     }
@@ -143,17 +155,13 @@ export class ExternalEditor {
 
   private createTempFile() {
     try {
-      const baseDir = this.fileOptions.dir ?? os.tmpdir();
+      const baseDir = path.resolve(this.fileOptions.dir ?? os.tmpdir());
+      this.tempDir = mkdtempSync(path.join(baseDir, 'inquirer-editor-'));
       const id = randomUUID();
       const prefix = sanitizeAffix(this.fileOptions.prefix);
       const postfix = sanitizeAffix(this.fileOptions.postfix);
       const filename = `${prefix}${id}${postfix}`;
-      const candidate = path.resolve(baseDir, filename);
-      const baseResolved = path.resolve(baseDir) + path.sep;
-      if (!candidate.startsWith(baseResolved)) {
-        throw new Error('Resolved temporary file escaped the base directory');
-      }
-      this.tempFile = candidate;
+      this.tempFile = path.join(this.tempDir, filename);
       const opt: WriteFileOptions = { encoding: 'utf8', flag: 'wx' };
       if (Object.prototype.hasOwnProperty.call(this.fileOptions, 'mode')) {
         opt.mode = this.fileOptions.mode;
@@ -162,6 +170,10 @@ export class ExternalEditor {
     } catch (createFileError) {
       throw new CreateFileError(createFileError);
     }
+  }
+
+  private editorArgs(): string[] {
+    return [...this.editor.args, this.tempFile];
   }
 
   private readTemporaryFile() {


### PR DESCRIPTION
## Summary
- Create editor files inside a dedicated temporary directory and remove that directory after the editor exits.
- Launch editors with explicit non-shell `spawn`/`spawnSync` arguments and surface launch failures as `LaunchEditorError`.
- Add focused tests for temp path options, cleanup, sanitized affixes, and editor launch failures.

## Why
CodeQL reports the temporary file path being passed into editor launch calls. Keeping generated files inside an isolated temp directory and making the non-shell launch path explicit reduces the command-construction surface while preserving the existing `VISUAL`/`EDITOR` behavior.

## Validation
- `yarn vitest --run packages/external-editor`
- `yarn tsc`
- `yarn oxlint packages/external-editor/src/index.ts packages/external-editor/src/index.test.ts`
- `yarn oxfmt --check packages/external-editor/src/index.ts packages/external-editor/src/index.test.ts`
- `yarn eslint packages/external-editor/src/index.ts packages/external-editor/src/index.test.ts`
- `git diff --check`
- pre-push hook: full repo typecheck, format check, ESLint, package Vitest run, integration tests

Note: the pre-push `yarn eslint .` step emitted an existing unrelated warning in `packages/input/src/index.ts` about an unused eslint-disable directive.