### PR TITLE
fix: run package bin unconditionally

### DIFF
--- a/tools/package/src/bin.test.ts
+++ b/tools/package/src/bin.test.ts
@@ -1,15 +1,18 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { Writable } from 'node:stream';
-import { afterEach, describe, expect, it } from 'vitest';
-import { main } from './bin.ts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const tempDirs: string[] = [];
 const originalCwd = process.cwd();
+const originalArgv = process.argv;
+const originalExitCode = process.exitCode;
 
 afterEach(async () => {
   process.chdir(originalCwd);
+  process.argv = originalArgv;
+  process.exitCode = originalExitCode;
+  vi.restoreAllMocks();
   await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
   tempDirs.length = 0;
 });
@@ -29,19 +32,18 @@ async function readJson(filepath: string) {
   return JSON.parse(await fs.readFile(filepath, 'utf8')) as unknown;
 }
 
-function createWritableCapture() {
+function captureStderr() {
   let output = '';
-  const stream = new Writable({
-    write(chunk, _encoding, callback) {
-      output += String(chunk);
-      callback();
-    },
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk, ...args) => {
+    output += String(chunk);
+
+    const callback = args.find((arg) => typeof arg === 'function');
+    callback?.();
+
+    return true;
   });
 
-  return {
-    stream,
-    output: () => output,
-  };
+  return () => output;
 }
 
 describe('package CLI', () => {
@@ -62,18 +64,22 @@ describe('package CLI', () => {
       },
     });
     await writeJson(packagePath, originalPackageJson);
-    const stderr = createWritableCapture();
+    const stderr = captureStderr();
     process.chdir(cwd);
+    process.argv = [
+      process.execPath,
+      path.join(originalCwd, 'tools/package/src/bin.ts'),
+      'lint',
+      '--check',
+    ];
 
-    const exitCode = await main(['lint', '--check'], {
-      stderr: stderr.stream,
-    });
+    await import('./bin.ts');
 
-    expect(exitCode).toBe(1);
-    expect(stderr.output()).toContain(
+    expect(process.exitCode).toBe(1);
+    expect(stderr()).toContain(
       '[would fix] app must define an engines.node range within the root range ">=20.17.0".',
     );
-    expect(stderr.output()).toContain('[would fix] app must export ./package.json.');
+    expect(stderr()).toContain('[would fix] app must export ./package.json.');
     expect(await readJson(packagePath)).toEqual(originalPackageJson);
   });
 });

--- a/tools/package/src/bin.ts
+++ b/tools/package/src/bin.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { Builtins, Cli, Command, Option, type BaseContext } from 'clipanion';
+import { Builtins, Cli, Command, Option } from 'clipanion';
 import { lintPackages } from './lint.ts';
 
 class LintCommand extends Command {
@@ -44,19 +42,4 @@ const cli = Cli.from([LintCommand, Builtins.HelpCommand], {
   enableCapture: false,
 });
 
-export async function main(
-  argv = process.argv.slice(2),
-  context: Partial<BaseContext> = {},
-) {
-  return cli.run(argv, {
-    ...Cli.defaultContext,
-    ...context,
-  });
-}
-
-if (
-  process.argv[1] != null &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
-) {
-  process.exitCode = await main();
-}
+process.exitCode = await cli.run(process.argv.slice(2), Cli.defaultContext);


### PR DESCRIPTION
## Summary

- Run the package bin entrypoint unconditionally instead of checking process.argv[1].
- Remove the importable main helper from the bin file.
- Update the CLI test to execute the bin entrypoint through process.argv and module import.

## Why

Package manager bin links can invoke the script through a symlink path, so comparing process.argv[1] to import.meta.url can skip execution outside the direct source path. Since this file is the bin entrypoint, it should execute directly.

## Validation

- yarn vitest --run tools/package/src/bin.test.ts
- yarn tsc
- ./node_modules/.bin/package --help
- yarn package --help
- pre-push hook: format, tsc, unit tests, integration tests