### PR TITLE
fix(@inquirer/number): avoid floating-point step errors

### DIFF
--- a/packages/number/number.test.ts
+++ b/packages/number/number.test.ts
@@ -366,4 +366,18 @@ describe('number prompt', () => {
     await expect(answer).resolves.toEqual(10.01);
     expect(getScreen()).toMatchInlineSnapshot(`"✔ Enter a decimal number 10.01"`);
   });
+
+  it('accepts decimal steps without floating-point precision errors', async () => {
+    const { answer, events, getScreen } = await render(number, {
+      message: 'Enter a value',
+      step: 0.001,
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`"? Enter a value"`);
+
+    events.type('1.001');
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(1.001);
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Enter a value 1.001"`);
+  });
 });

--- a/packages/number/src/index.ts
+++ b/packages/number/src/index.ts
@@ -11,6 +11,7 @@ import {
   type Status,
 } from '@inquirer/core';
 import type { PartialDeep } from '@inquirer/type';
+import { isStepOf } from './is-step-of.ts';
 
 type NumberConfig<Required extends boolean = boolean> = {
   message: string;
@@ -24,14 +25,6 @@ type NumberConfig<Required extends boolean = boolean> = {
   ) => boolean | string | Promise<string | boolean>;
   theme?: PartialDeep<Theme>;
 };
-
-function isStepOf(value: number, step: number, min: number): boolean {
-  const valuePow = value * Math.pow(10, 6);
-  const stepPow = step * Math.pow(10, 6);
-  const minPow = min * Math.pow(10, 6);
-
-  return (valuePow - (Number.isFinite(min) ? minPow : 0)) % stepPow === 0;
-}
 
 function validateNumber(
   value: number | undefined,

--- a/packages/number/src/is-step-of.test.ts
+++ b/packages/number/src/is-step-of.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isStepOf } from './is-step-of.ts';
+
+describe('isStepOf', () => {
+  it.each([
+    { value: 1.001, step: 0.001, min: -Infinity },
+    { value: 0.0000008, step: 0.0000004, min: -Infinity },
+    { value: 0.0000009, step: 0.0000004, min: 0.0000001 },
+  ])('accepts $value with step $step and min $min', ({ value, step, min }) => {
+    expect(isStepOf(value, step, min)).toBe(true);
+  });
+
+  it.each([
+    { value: 0.0000006, step: 0.000001 },
+    { value: 1.0010004, step: 0.001 },
+  ])('rejects $value with step $step', ({ value, step }) => {
+    expect(isStepOf(value, step, -Infinity)).toBe(false);
+  });
+});

--- a/packages/number/src/is-step-of.ts
+++ b/packages/number/src/is-step-of.ts
@@ -1,0 +1,37 @@
+type Decimal = {
+  significand: bigint;
+  exponent: number;
+};
+
+function toDecimal(value: number): Decimal {
+  const [coefficient = '', exponent = '0'] = value.toString().toLowerCase().split('e');
+  const [integer = '', fraction = ''] = coefficient.split('.');
+
+  return {
+    significand: BigInt(`${integer}${fraction}`),
+    exponent: Number(exponent) - fraction.length,
+  };
+}
+
+export function isStepOf(value: number, step: number, min: number): boolean {
+  if (!Number.isFinite(value) || !Number.isFinite(step) || step === 0) {
+    return false;
+  }
+
+  const valueDecimal = toDecimal(value);
+  const stepDecimal = toDecimal(step);
+  const minDecimal = Number.isFinite(min) ? toDecimal(min) : undefined;
+  const exponent = Math.min(
+    valueDecimal.exponent,
+    stepDecimal.exponent,
+    minDecimal?.exponent ?? Infinity,
+  );
+  const toInteger = (decimal: Decimal): bigint =>
+    decimal.significand * 10n ** BigInt(decimal.exponent - exponent);
+
+  const valueInteger = toInteger(valueDecimal);
+  const stepInteger = toInteger(stepDecimal);
+  const minInteger = minDecimal ? toInteger(minDecimal) : 0n;
+
+  return (valueInteger - minInteger) % stepInteger === 0n;
+}


### PR DESCRIPTION
## Bug

`isStepOf` scaled values by a fixed `1e6` before checking the remainder. IEEE-754 multiplication can still produce a fractional result:

```js
1.001 * 1e6; // 1000999.9999999999
```

As a result, the number prompt rejected valid decimal steps such as `1.001` with `step: 0.001`.

## Fix

Convert the supplied value, step, and finite minimum from their canonical decimal representations into integer significands. Scale them to their shared decimal exponent and perform the remainder check with `bigint` arithmetic.

This avoids floating-point remainder errors without imposing a fixed six-decimal precision limit. It also preserves correct behavior for:

- steps smaller than `1e-6`
- decimal `min` offsets
- near-multiples that must remain invalid
- values represented with scientific notation

## Verification

```sh
yarn pretest
yarn workspace @inquirer/number tsc
yarn vitest --run packages/number/src/is-step-of.test.ts
yarn vitest --run packages/number/number.test.ts -t 'decimal steps'
```

The full local suite also ran during the push hook: 360 tests passed and 21 unrelated synthetic-backspace tests failed across existing prompt suites in this terminal environment. GitHub CI will rerun the complete supported matrix.

> This fix was developed with AI assistance.
