### PR TITLE
fix: accept explicit undefined as default in number, confirm, editor

### DIFF
--- a/packages/confirm/confirm.test.ts
+++ b/packages/confirm/confirm.test.ts
@@ -95,6 +95,18 @@ describe('confirm prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`"✔ Do you want to proceed? No"`);
   });
 
+  it('accepts explicit undefined as default', async () => {
+    const defaultValue: boolean | undefined = undefined;
+    const { answer, events } = await render(confirm, {
+      message: 'Do you want to proceed?',
+      default: defaultValue,
+    });
+
+    events.type('y');
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(true);
+  });
+
   it('uses default on gibberish input', async () => {
     const { answer, events, getScreen } = await render(confirm, {
       message: 'Do you want to proceed?',

--- a/packages/confirm/src/index.ts
+++ b/packages/confirm/src/index.ts
@@ -13,7 +13,7 @@ import type { PartialDeep } from '@inquirer/type';
 
 type ConfirmConfig = {
   message: string;
-  default?: boolean;
+  default?: boolean | undefined;
   transformer?: (value: boolean) => string;
   theme?: PartialDeep<Theme>;
 };

--- a/packages/editor/editor.test.ts
+++ b/packages/editor/editor.test.ts
@@ -54,6 +54,21 @@ describe('editor prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`"✔ Add a description"`);
   });
 
+  it('accepts explicit undefined as default', async () => {
+    const defaultValue: string | undefined = undefined;
+    const { answer, events } = await render(editor, {
+      message: 'Add a description',
+      default: defaultValue,
+    });
+
+    events.keypress('enter');
+    expect(editAsync).toHaveBeenLastCalledWith('', { postfix: '.txt' });
+
+    await editorAction(undefined, 'value from editor');
+
+    await expect(answer).resolves.toEqual('value from editor');
+  });
+
   it('open editor immediately', async () => {
     const { answer, getScreen } = await render(editor, {
       message: 'Add a description',

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -30,7 +30,7 @@ const editorTheme: EditorTheme = {
 
 type EditorConfig = {
   message: string;
-  default?: string;
+  default?: string | undefined;
   postfix?: string;
   waitForUserInput?: boolean;
   validate?: (value: string) => boolean | string | Promise<string | boolean>;

--- a/packages/number/number.test.ts
+++ b/packages/number/number.test.ts
@@ -226,6 +226,20 @@ describe('number prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`"✔ What is your age 35"`);
   });
 
+  it('accepts explicit undefined as default', async () => {
+    const defaultValue: number | undefined = undefined;
+    const { answer, events, getScreen } = await render(number, {
+      message: 'What is your age',
+      default: defaultValue,
+    });
+
+    expect(getScreen()).toMatchInlineSnapshot(`"? What is your age"`);
+
+    events.type('20');
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual(20);
+  });
+
   it('handle overwriting the default option', async () => {
     const { answer, events, getScreen } = await render(number, {
       message: 'What is your age',

--- a/packages/number/src/index.ts
+++ b/packages/number/src/index.ts
@@ -15,7 +15,7 @@ import { isStepOf } from './is-step-of.ts';
 
 type NumberConfig<Required extends boolean = boolean> = {
   message: string;
-  default?: number;
+  default?: number | undefined;
   min?: number;
   max?: number;
   step?: number | 'any';


### PR DESCRIPTION
## Summary

#2111 widened `InputConfig['default']` to `string | undefined` so the option accepts an explicitly-undefined value under `exactOptionalPropertyTypes: true` (the inconsistency reported in #2110). The other prompts that expose a scalar `default` still declare it as a bare optional, so they reject an explicit `undefined` the way `@inquirer/input` did before #2111:

- `@inquirer/number`: `default?: number`
- `@inquirer/confirm`: `default?: boolean`
- `@inquirer/editor`: `default?: string`

This applies the same widening to those three, so `default: value` type-checks when `value` is `T | undefined`. Each gets a test mirroring the one added in #2111.

The choice-based prompts (`select`, `rawlist`, `search`, `expand`) have the same gap on their `default` option. I kept this PR to the scalar-default prompts that match `@inquirer/input`, and am happy to follow up on the rest.

## Test plan

- [x] `yarn tsc`
- [x] `yarn vitest --run packages/number packages/confirm packages/editor`
- [x] `yarn oxlint` / `yarn eslint`
