### PR TITLE
docs: document readline handoff

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -207,6 +207,22 @@ The context options are:
 > before calling inquirer functions. Node.js usually does it automatically, but when we shadow the stdin, Node can loss track
 > and not know it has to. If the prompt isn't interactive (arrows don't work, etc), it's likely due to this.
 
+When running Inquirer from an existing `node:readline` interface, pause the readline instance before starting the prompt, then resume it after the prompt settles. This makes the handoff of `process.stdin` ownership explicit and prevents the parent readline loop from losing control of the input stream.
+
+```js
+const answer = await rl.question('Command: ');
+
+if (answer === 'configure') {
+  rl.pause();
+
+  try {
+    const value = await input({ message: 'Configuration value' });
+  } finally {
+    rl.resume();
+  }
+}
+```
+
 Example:
 
 ```js


### PR DESCRIPTION
## Summary

- Document that callers with an existing `node:readline` interface should pause it before running an Inquirer prompt and resume it afterward.
- Clarify that this explicitly hands off `process.stdin` ownership while the prompt is active.

## Validation

- `yarn oxfmt --check packages/prompts/README.md`
- `git diff --check`