### PR TITLE
fix(external-editor): set `shell` to `true`

### DIFF
--- a/packages/external-editor/src/index.ts
+++ b/packages/external-editor/src/index.ts
@@ -109,7 +109,7 @@ export class ExternalEditor {
     const promise = new Promise<void>((resolve, reject) => {
       try {
         const editorProcess = spawn(this.editor.bin, this.editorArgs(), {
-          shell: false,
+          shell: true,
           stdio: 'inherit',
         });
         editorProcess.once('error', (launchError) => {


### PR DESCRIPTION
On Windows devices, `shell` must be `true` to execute certain commands via `node:child_process`. For instance, `child_process.spawnSync("code")` will fail and `child_process.spawnSync("code", { shell: true })` will not.

This updates the external editor package to set `shell: true` rather than `shell: false`.