### PR TITLE
docs: fix typos in examples, README, and test description

### DIFF
--- a/packages/core/core.test.ts
+++ b/packages/core/core.test.ts
@@ -797,7 +797,7 @@ describe('keybindings', () => {
     ).toBeTruthy();
   });
 
-  it('does not support vim and emac bindings by default', () => {
+  it('does not support vim and emacs bindings by default', () => {
     expect(isUpKey({ name: 'up', ctrl: false, shift: false })).toBeTruthy();
     expect(isUpKey({ name: 'k', ctrl: false, shift: false })).toBeFalsy();
     expect(isUpKey({ name: 'p', ctrl: true, shift: false })).toBeFalsy();

--- a/packages/expand/README.md
+++ b/packages/expand/README.md
@@ -112,7 +112,7 @@ Here's each property:
 
 - `value`: The value is what will be returned by `await expand()`.
 - `name`: The string displayed in the choice list. It'll default to the stringify `value`.
-- `key`: The input the use must provide to select the choice. Must be a lowercase single alpha-numeric character string.
+- `key`: The input the use must provide to select the choice. Must be a lowercase single alphanumeric character string.
 
 ## Theming
 

--- a/packages/inquirer/examples/hierarchical.ts
+++ b/packages/inquirer/examples/hierarchical.ts
@@ -1,11 +1,11 @@
 /**
- * Heirarchical conversation example
+ * Hierarchical conversation example
  */
 
 import inquirer from 'inquirer';
 
 async function main() {
-  console.log('You find youself in a small room, there is a door in front of you.');
+  console.log('You find yourself in a small room, there is a door in front of you.');
   await exitHouse();
 }
 


### PR DESCRIPTION
Fixed four typos found by codespell:

- `packages/inquirer/examples/hierarchical.ts`: `Heirarchical` -> `Hierarchical`, `youself` -> `yourself`
- `packages/expand/README.md`: `alpha-numeric` -> `alphanumeric`
- `packages/core/core.test.ts`: `emac` -> `emacs` in test description