### PR TITLE
docs(external-editor): document Windows editor executables

### DIFF
--- a/packages/external-editor/README.md
+++ b/packages/external-editor/README.md
@@ -77,6 +77,19 @@ try {
 }
 ```
 
+### Windows editor commands
+
+On Windows, prefer setting `$VISUAL` or `$EDITOR` to the editor executable
+rather than a `.cmd` or `.bat` shim. This package launches the editor directly
+instead of through a shell so editor arguments and temporary file paths are not
+interpreted as shell commands.
+
+For example, use `Code.exe` with `--wait` instead of `code.cmd`:
+
+```powershell
+setx VISUAL '"C:\Program Files\Microsoft VS Code\Code.exe" --wait'
+```
+
 #### API
 
 **Convenience Functions**


### PR DESCRIPTION
## Summary

- document that Windows users should point `VISUAL`/`EDITOR` at an editor executable instead of a `.cmd` or `.bat` shim
- explain that `@inquirer/external-editor` launches editors directly to avoid shell interpretation of arguments and temp paths

## Testing

- `git diff --check`