### PR TITLE
feat(@inquirer/search): add escape key handling

### DIFF
--- a/packages/i18n/src/create.ts
+++ b/packages/i18n/src/create.ts
@@ -20,7 +20,11 @@ export type { Locale } from './types.ts';
 type ConfirmConfig = Parameters<typeof confirmPrompt>[0];
 type SelectConfig<Value> = Parameters<typeof selectPrompt<Value>>[0];
 type CheckboxConfig<Value> = Parameters<typeof checkboxPrompt<Value>>[0];
-type SearchConfig<Value> = Parameters<typeof searchPrompt<Value>>[0];
+type SearchEscapeKeyAction = 'none' | 'clear' | 'cancel' | 'clear-then-cancel';
+type SearchConfig<
+  Value,
+  EscapeKey extends SearchEscapeKeyAction = 'clear-then-cancel',
+> = Parameters<typeof searchPrompt<Value, EscapeKey>>[0];
 type ExpandConfig<Value> = Parameters<typeof expandPrompt<Value>>[0];
 type RawlistConfig<Value> = Parameters<typeof rawlistPrompt<Value>>[0];
 type EditorConfig = Parameters<typeof editorPrompt>[0];
@@ -104,7 +108,11 @@ export function createLocalizedPrompts(locale: Locale) {
       return checkboxPrompt({ ...config, theme }, context);
     },
 
-    search<Value>(this: void, config: SearchConfig<Value>, context?: Context) {
+    search<Value, EscapeKey extends SearchEscapeKeyAction = 'clear-then-cancel'>(
+      this: void,
+      config: SearchConfig<Value, EscapeKey>,
+      context?: Context,
+    ) {
       const theme = makeTheme(config.theme, {
         style: {
           keysHelpTip: (keys: Array<[string, string]>) => {
@@ -120,7 +128,7 @@ export function createLocalizedPrompts(locale: Locale) {
         },
       });
 
-      return searchPrompt({ ...config, theme }, context);
+      return searchPrompt<Value, EscapeKey>({ ...config, theme }, context);
     },
 
     expand<Value>(this: void, config: ExpandConfig<Value>, context?: Context) {

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -76,14 +76,15 @@ const answer = await search({
 
 ## Options
 
-| Property | Type                                                       | Required | Description                                                                                                                                                                                          |
-| -------- | ---------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| message  | `string`                                                   | yes      | The question to ask                                                                                                                                                                                  |
-| source   | `(term: string \| void) => Promise<Choice[]>`              | yes      | This function returns the choices relevant to the search term.                                                                                                                                       |
-| pageSize | `number`                                                   | no       | By default, lists of choice longer than 7 will be paginated. Use this option to control how many choices will appear on the screen at once.                                                          |
-| default  | `Value`                                                    | no       | Defines in front of which item the cursor will initially appear. When omitted, the cursor will appear on the first selectable item.                                                                  |
-| validate | `Value => boolean \| string \| Promise<boolean \| string>` | no       | On submit, validate the answer. When returning a string, it'll be used as the error message displayed to the user. Note: returning a rejected promise, we'll assume a code error happened and crash. |
-| theme    | [See Theming](#Theming)                                    | no       | Customize look of the prompt.                                                                                                                                                                        |
+| Property  | Type                                                       | Required | Description                                                                                                                                                                                          |
+| --------- | ---------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| message   | `string`                                                   | yes      | The question to ask                                                                                                                                                                                  |
+| source    | `(term: string \| void) => Promise<Choice[]>`              | yes      | This function returns the choices relevant to the search term.                                                                                                                                       |
+| pageSize  | `number`                                                   | no       | By default, lists of choice longer than 7 will be paginated. Use this option to control how many choices will appear on the screen at once.                                                          |
+| default   | `Value`                                                    | no       | Defines in front of which item the cursor will initially appear. When omitted, the cursor will appear on the first selectable item.                                                                  |
+| validate  | `Value => boolean \| string \| Promise<boolean \| string>` | no       | On submit, validate the answer. When returning a string, it'll be used as the error message displayed to the user. Note: returning a rejected promise, we'll assume a code error happened and crash. |
+| escapeKey | `'none' \| 'clear' \| 'cancel' \| 'clear-then-cancel'`     | no       | Controls Escape key behavior. Defaults to `'clear-then-cancel'`.                                                                                                                                     |
+| theme     | [See Theming](#Theming)                                    | no       | Customize look of the prompt.                                                                                                                                                                        |
 
 ### `source` function
 
@@ -138,6 +139,19 @@ You can rely on this behavior to implement progressive autocomplete searches. Wh
 Pressing `tab` also triggers the term autocomplete.
 
 You can see this behavior in action in [our search demo](https://github.com/SBoudrias/Inquirer.js/blob/main/packages/demo/src/demos/search.ts).
+
+### Escape key behavior
+
+By default, pressing <kbd>Escape</kbd> clears the current search term. Pressing <kbd>Escape</kbd> again while the search term is empty resolves the prompt with `undefined`.
+
+You can customize this behavior with the `escapeKey` option:
+
+- `'clear-then-cancel'`: clear the search term first, then resolve with `undefined` if it is already empty.
+- `'clear'`: clear the search term and keep the prompt open.
+- `'cancel'`: resolve with `undefined`.
+- `'none'`: ignore Escape.
+
+When `escapeKey` can cancel the prompt, the returned promise type includes `undefined`.
 
 ## Theming
 

--- a/packages/search/search.test.ts
+++ b/packages/search/search.test.ts
@@ -314,6 +314,110 @@ describe('search prompt', () => {
     await expect(answer).rejects.toThrow();
   });
 
+  it('clears the search term before cancelling with escape by default', async () => {
+    const { answer, events, getScreen, nextRender } = await render(search, {
+      message: 'Select a Canadian province',
+      source: getListSearch(PROVINCES),
+    });
+
+    events.type('New');
+    await nextRender();
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a Canadian province New
+      ❯ New Brunswick
+        Newfoundland and Labrador
+
+      ↑↓ navigate • ⏎ select"
+    `);
+
+    events.keypress('escape');
+    await nextRender();
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a Canadian province
+      ❯ Alberta
+        British Columbia
+        Manitoba
+        New Brunswick
+        Newfoundland and Labrador
+        Nova Scotia
+        Ontario
+
+      ↑↓ navigate • ⏎ select"
+    `);
+
+    events.keypress('escape');
+    await expect(answer).resolves.toBeUndefined();
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Select a Canadian province"`);
+  });
+
+  it('cancels with escape without clearing first when configured', async () => {
+    const { answer, events, getScreen, nextRender } = await render(search, {
+      message: 'Select a Canadian province',
+      source: getListSearch(PROVINCES),
+      escapeKey: 'cancel',
+    });
+
+    events.type('New');
+    await nextRender();
+    events.keypress('escape');
+
+    await expect(answer).resolves.toBeUndefined();
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Select a Canadian province"`);
+  });
+
+  it('clears with escape without cancelling when configured', async () => {
+    const { answer, events, getScreen, nextRender } = await render(search, {
+      message: 'Select a Canadian province',
+      source: getListSearch(PROVINCES),
+      escapeKey: 'clear',
+    });
+
+    events.type('New');
+    await nextRender();
+    events.keypress('escape');
+    await nextRender();
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a Canadian province
+      ❯ Alberta
+        British Columbia
+        Manitoba
+        New Brunswick
+        Newfoundland and Labrador
+        Nova Scotia
+        Ontario
+
+      ↑↓ navigate • ⏎ select"
+    `);
+
+    events.keypress('escape');
+    events.keypress('enter');
+
+    await expect(answer).resolves.toEqual('AB');
+  });
+
+  it('ignores escape when configured', async () => {
+    const { answer, events, getScreen, nextRender } = await render(search, {
+      message: 'Select a Canadian province',
+      source: getListSearch(PROVINCES),
+      escapeKey: 'none',
+    });
+
+    events.type('New');
+    await nextRender();
+    events.keypress('escape');
+
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Select a Canadian province New
+      ❯ New Brunswick
+        Newfoundland and Labrador
+
+      ↑↓ navigate • ⏎ select"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('NB');
+  });
+
   it('handles separators & disabled choices', async () => {
     const choices = [
       new Separator('~ Americas ~'),
@@ -719,7 +823,7 @@ describe('search prompt', () => {
 });
 
 describe('search types', () => {
-  it('infers exact string union from hardcoded string choices', async () => {
+  it('infers undefined from default escape cancellation', async () => {
     const abortController = new AbortController();
     const { answer } = await render(
       search,
@@ -729,9 +833,38 @@ describe('search types', () => {
       },
       { signal: abortController.signal },
     );
-    expectTypeOf(answer).resolves.toExtend<'foo' | 'bar'>();
+    expectTypeOf(answer).resolves.toExtend<'foo' | 'bar' | undefined>();
     abortController.abort();
     await expect(answer).rejects.toThrow();
+  });
+
+  it('excludes undefined when escape only clears or is ignored', async () => {
+    const abortController = new AbortController();
+    const { answer: clearAnswer } = await render(
+      search,
+      {
+        message: 'test',
+        source: () => ['foo', 'bar'] as const,
+        escapeKey: 'clear',
+      },
+      { signal: abortController.signal },
+    );
+    expectTypeOf(clearAnswer).resolves.toExtend<'foo' | 'bar'>();
+
+    const { answer: noneAnswer } = await render(
+      search,
+      {
+        message: 'test',
+        source: () => ['foo', 'bar'] as const,
+        escapeKey: 'none',
+      },
+      { signal: abortController.signal },
+    );
+    expectTypeOf(noneAnswer).resolves.toExtend<'foo' | 'bar'>();
+
+    abortController.abort();
+    await expect(clearAnswer).rejects.toThrow();
+    await expect(noneAnswer).rejects.toThrow();
   });
 
   it('infers number from Choice<number> choices', async () => {
@@ -744,7 +877,7 @@ describe('search types', () => {
       },
       { signal: abortController.signal },
     );
-    expectTypeOf(answer).resolves.toExtend<number>();
+    expectTypeOf(answer).resolves.toExtend<number | undefined>();
     abortController.abort();
     await expect(answer).rejects.toThrow();
   });

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from '@inquirer/core';
 import { styleText } from 'node:util';
 import figures from '@inquirer/figures';
-import type { PartialDeep } from '@inquirer/type';
+import type { InquirerReadline, PartialDeep } from '@inquirer/type';
 
 type SearchTheme = {
   icon: { cursor: string };
@@ -60,7 +60,18 @@ type NormalizedChoice<Value> = {
   disabled: boolean | string;
 };
 
-type SearchConfig<Value = string> = {
+type SearchEscapeKeyAction = 'none' | 'clear' | 'cancel' | 'clear-then-cancel';
+
+type SearchAnswer<Value, EscapeKey extends SearchEscapeKeyAction> = EscapeKey extends
+  | 'none'
+  | 'clear'
+  ? Value
+  : Value | undefined;
+
+type SearchConfig<
+  Value = string,
+  EscapeKey extends SearchEscapeKeyAction = 'clear-then-cancel',
+> = {
   message: string;
   source: (
     term: string | undefined,
@@ -71,6 +82,7 @@ type SearchConfig<Value = string> = {
   validate?: (value: Value) => boolean | string | Promise<string | boolean>;
   pageSize?: number;
   default?: NoInfer<Value>;
+  escapeKey?: EscapeKey;
   theme?: PartialDeep<Theme<SearchTheme>>;
 };
 
@@ -113,7 +125,10 @@ function normalizeChoices<Value>(
 }
 
 export default createPrompt(
-  <const Value>(config: SearchConfig<Value>, done: (value: Value) => void) => {
+  <const Value, EscapeKey extends SearchEscapeKeyAction = 'clear-then-cancel'>(
+    config: SearchConfig<Value, EscapeKey>,
+    done: (value: SearchAnswer<Value, EscapeKey>) => void,
+  ) => {
     const { pageSize = 7, validate = () => true } = config;
     const theme = makeTheme<SearchTheme>(searchTheme, config.theme);
     const [status, setStatus] = useState<Status>('loading');
@@ -121,6 +136,7 @@ export default createPrompt(
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [searchResults, setSearchResults] = useState<ReadonlyArray<Item<Value>>>([]);
     const [searchError, setSearchError] = useState<string>();
+    const [isCanceled, setIsCanceled] = useState(false);
     const defaultApplied = useRef(false);
 
     const prefix = usePrefix({ status, theme });
@@ -181,8 +197,29 @@ export default createPrompt(
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     const selectedChoice = searchResults[active] as NormalizedChoice<Value> | void;
 
+    const cancel = () => {
+      setIsCanceled(true);
+      setStatus('done');
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      done(undefined as SearchAnswer<Value, EscapeKey>);
+    };
+
+    const clearSearchTerm = (rl: InquirerReadline) => {
+      rl.clearLine(0);
+      setSearchTerm('');
+      setSearchError(undefined);
+    };
+
     useKeypress(async (key, rl) => {
-      if (isEnterKey(key)) {
+      const escapeKey = config.escapeKey ?? 'clear-then-cancel';
+
+      if (key.name === 'escape' && escapeKey !== 'none') {
+        if (escapeKey === 'clear' || (escapeKey === 'clear-then-cancel' && rl.line)) {
+          clearSearchTerm(rl);
+        } else {
+          cancel();
+        }
+      } else if (isEnterKey(key)) {
         if (selectedChoice) {
           setStatus('loading');
           const isValid = await validate(selectedChoice.value);
@@ -262,7 +299,9 @@ export default createPrompt(
     }
 
     let searchStr;
-    if (status === 'done' && selectedChoice) {
+    if (status === 'done' && isCanceled) {
+      return [prefix, message].filter(Boolean).join(' ').trimEnd();
+    } else if (status === 'done' && selectedChoice) {
       return [prefix, message, theme.style.answer(selectedChoice.short)]
         .filter(Boolean)
         .join(' ')
@@ -288,3 +327,4 @@ export default createPrompt(
 );
 
 export { Separator } from '@inquirer/core';
+export type { SearchEscapeKeyAction };


### PR DESCRIPTION
## Summary
- Add an `escapeKey` option to `@inquirer/search` with `none`, `clear`, `cancel`, and `clear-then-cancel` modes.
- Default Escape behavior now clears a non-empty search term, then resolves with `undefined` when pressed again on an empty term.
- Preserve the cancellation-aware return type through the i18n search wrapper and document the behavior.

## Why
Search prompts need a graceful keyboard path for clearing or cancelling without relying on abort errors. The default mirrors the requested clear-first interaction while making `undefined` part of the type when cancellation is possible.

Closes #2179

## Validation
- `yarn vitest --run packages/search`
- `yarn pretest`
- `yarn test`