### PR TITLE
fix(lint): run type-aware oxlint in pretest

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i '' -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
     "postpack": "git restore packages/*/package.json packages/*/README.md",
     "setup": "setup-packages && package lint && oxfmt . --no-error-on-unmatched-pattern",
-    "pretest": "yarn tsc && oxlint && oxfmt --check . && eslint .",
+    "pretest": "yarn tsc && oxlint . && oxfmt --check . && eslint .",
     "test": "vitest --run packages && turbo test",
     "tsc": "turbo tsc && tsc -p tsconfig.json"
   },


### PR DESCRIPTION
## Summary

Run Oxlint against the repository root in `pretest`, so the existing root type-aware configuration is actually executed locally.

## Validation

- `yarn pretest`
- `yarn test`
- `yarn package lint --check`