### PR TITLE
Add inquirer-tree-prompt community prompt to README

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -566,6 +566,21 @@ A modern multiselect checkbox prompt with search and filter capabilities, highli
 ↑↓ navigate • space de/select • type search • 2 selected  • ⏎ submit
 ```
 
+[**Tree Prompt**](https://github.com/3z3qu13l/inquirer-tree-prompt)<br/>
+Navigate a tree of choices, expanding and collapsing branches with the arrow keys. Children can be loaded lazily, and single or multiple items can be selected.
+
+```
+? Where is my phone?
+  ▼ in the house
+    ▼ in the living room
+      ❯ on the sofa
+        on the TV cabinet
+    ▶ in the bedroom
+      in the bathroom
+  ▶ in the car
+----------------
+```
+
 # License
 
 Copyright (c) 2023 Simon Boudrias (twitter: [@vaxilart](https://twitter.com/Vaxilart))<br/>


### PR DESCRIPTION
Adds inquirer-tree-prompt to the community prompts list.

It's a maintained fork of the original [inquirer-tree-prompt](https://github.com/insightfuls/inquirer-tree-prompt). Unfortunately not maintained anymore it was not compatible with the latest versions of inquirer.

This fork is working with @inquirer/core v10+.

https://www.npmjs.com/package/@3z3qu13l/inquirer-tree-prompt

Related to https://github.com/SBoudrias/Inquirer.js/issues/1674