### PR TITLE
feat(@inquirer/core): allow useState setter to accept a reducer function

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,6 +62,14 @@ State lets a component “remember” information like user input. For example, 
 
 `useState` declares a state variable that you can update directly.
 
+The setter also accepts an updater function to compute the next state from the current one (mirroring React):
+
+```ts
+const [index, setIndex] = useState(0);
+
+setIndex((current) => current + 1);
+```
+
 ```ts
 import { createPrompt, useState } from '@inquirer/core';
 

--- a/packages/core/core.test.ts
+++ b/packages/core/core.test.ts
@@ -240,6 +240,93 @@ describe('createPrompt()', () => {
     await expect(answer).resolves.toEqual('up');
   });
 
+  it('useState: setter accepts a reducer/action function', async () => {
+    const Prompt = (config: { message: string }, done: (value: string) => void) => {
+      const [value, setValue] = useState('');
+
+      useKeypress((key: KeypressEvent) => {
+        if (isEnterKey(key)) {
+          done(value);
+        } else if (isDownKey(key)) {
+          setValue((current) => `${current}down`);
+        } else if (isUpKey(key)) {
+          setValue((current) => `${current}up`);
+        }
+      });
+
+      return `${config.message} ${value}`;
+    };
+
+    const prompt = createPrompt(Prompt);
+    const { answer, events } = await render(prompt, { message: 'Question' });
+
+    events.keypress('down');
+    events.keypress('down');
+    events.keypress('up');
+    events.keypress('enter');
+
+    // Each reducer reads the latest value: 'down' -> 'downdown' -> 'downdownup'
+    await expect(answer).resolves.toEqual('downdownup');
+  });
+
+  it('useState: reducer that returns the same value does not re-render', async () => {
+    const renderSpy = vi.fn();
+    const Prompt = (config: { message: string }, done: (value: string) => void) => {
+      renderSpy();
+
+      const [value, setValue] = useState('same');
+
+      useKeypress((key: KeypressEvent) => {
+        if (isEnterKey(key)) {
+          done(value);
+        } else if (isDownKey(key)) {
+          setValue((current) => current);
+        }
+      });
+
+      return `${config.message} ${value}`;
+    };
+
+    const prompt = createPrompt(Prompt);
+    const { answer, events } = await render(prompt, { message: 'Question' });
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    events.keypress('down');
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('same');
+  });
+
+  it('useState: NaN is treated as unchanged (Object.is semantics)', async () => {
+    const renderSpy = vi.fn();
+    const Prompt = (config: { message: string }, done: (value: string) => void) => {
+      renderSpy();
+
+      const [value, setValue] = useState<number>(Number.NaN);
+
+      useKeypress((key: KeypressEvent) => {
+        if (isEnterKey(key)) {
+          done(`${value}`);
+        } else if (isDownKey(key)) {
+          setValue(Number.NaN);
+        }
+      });
+
+      return `${config.message} ${value}`;
+    };
+
+    const prompt = createPrompt(Prompt);
+    const { answer, events } = await render(prompt, { message: 'Question' });
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    events.keypress('down');
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('NaN');
+  });
+
   it('useState: set state is always bound to the async context', async () => {
     const eventEmitter = new EventEmitter();
     const Prompt = (config: { message: string }, done: (value: string) => void) => {

--- a/packages/core/src/lib/hook-engine.ts
+++ b/packages/core/src/lib/hook-engine.ts
@@ -87,17 +87,11 @@ export function withUpdates<Args extends unknown[], R>(
   return AsyncResource.bind(wrapped);
 }
 
-type SetPointer<Value> = {
+type Pointer<Value> = {
   get(): Value;
   set(value: Value): void;
-  initialized: true;
+  initialized: boolean;
 };
-type UnsetPointer<Value> = {
-  get(): void;
-  set(value: Value): void;
-  initialized: false;
-};
-type Pointer<Value> = SetPointer<Value> | UnsetPointer<Value>;
 export function withPointer<Value, ReturnValue>(
   cb: (pointer: Pointer<Value>) => ReturnValue,
 ): ReturnValue {

--- a/packages/core/src/lib/use-memo.ts
+++ b/packages/core/src/lib/use-memo.ts
@@ -12,7 +12,7 @@ export function useMemo<Value>(
   return withPointer<PointerValue<Value>, Value>((pointer) => {
     const prev = pointer.get();
     if (
-      !prev ||
+      !pointer.initialized ||
       prev.dependencies.length !== dependencies.length ||
       prev.dependencies.some((dep, i) => dep !== dependencies[i])
     ) {

--- a/packages/core/src/lib/use-state.ts
+++ b/packages/core/src/lib/use-state.ts
@@ -3,22 +3,39 @@ import { withPointer, handleChange } from './hook-engine.ts';
 
 type NotFunction<T> = T extends (...args: never) => unknown ? never : T;
 
+type Reducer<Value> = (currentValue: Value) => Value;
+
+type SetState<Value> = (newValue: NotFunction<Value> | Reducer<Value>) => void;
+
+type OptionalSetState<Value> = (newValue?: NotFunction<Value> | Reducer<Value>) => void;
+
 function isFactory<V>(value: NotFunction<V> | (() => V)): value is () => V {
+  return typeof value === 'function';
+}
+
+function isReducer<Value>(
+  value: NotFunction<Value> | Reducer<Value>,
+): value is Reducer<Value> {
   return typeof value === 'function';
 }
 
 export function useState<Value>(
   defaultValue: NotFunction<Value> | (() => Value),
-): [Value, (newValue: Value) => void];
+): [Value, SetState<Value>];
 export function useState<Value>(
   defaultValue?: NotFunction<Value> | (() => Value),
-): [Value | undefined, (newValue?: Value) => void];
+): [Value | undefined, OptionalSetState<Value | undefined>];
 export function useState<Value>(defaultValue: NotFunction<Value> | (() => Value)) {
-  return withPointer<Value, [Value, (newValue: Value) => void]>((pointer) => {
-    const setState = AsyncResource.bind(function setState(newValue: Value) {
+  return withPointer<Value, [Value, SetState<Value>]>((pointer) => {
+    const setState = AsyncResource.bind(function setState(
+      newValue: NotFunction<Value> | Reducer<Value>,
+    ) {
+      const currentValue = pointer.get();
+      const nextValue = isReducer(newValue) ? newValue(currentValue) : newValue;
+
       // Noop if the value is still the same.
-      if (pointer.get() !== newValue) {
-        pointer.set(newValue);
+      if (!Object.is(currentValue, nextValue)) {
+        pointer.set(nextValue);
 
         // Trigger re-render
         handleChange();


### PR DESCRIPTION
## What

Allow the setter returned by `useState` to accept an updater/reducer function `(currentValue: T) => T`, mirroring React:

```ts
const [index, setIndex] = useState(0);
setIndex((current) => current + 1);
```

The updater always receives the **latest** state (read from the hook store at call time, not a stale closure), which makes async and reducer-style state updates less boilerplate-y.

## Why

Feature request from [discussion #2224](https://github.com/SBoudrias/Inquirer.js/discussions/2224). The hooks API aims to align with React behavior "as much as possible" ([#1282](https://github.com/SBoudrias/Inquirer.js/issues/1282)), and functional updates are core React `useState` behavior. The machinery already exists (`NotFunction` + `isFactory` are used for the default-value factory); this just exposes the same pattern on the setter.

## How

- `packages/core/src/lib/use-state.ts`: added a `Reducer<Value>` type + `isReducer` guard. The setter reads the current value once, derives `nextValue` from it when passed a function, then keeps the existing noop/re-render logic.
- The noop check now uses `Object.is` instead of `!==`, matching React's bailout semantics. This only changes behavior for `NaN` (now correctly treated as unchanged) and `-0`/`+0` (now treated as different).
- `packages/core/core.test.ts`: three new tests — updater reads latest state across chained updates, an updater returning the same value does not re-render, and `NaN` is treated as unchanged.
- `packages/core/README.md`: documented the new behavior.

### Typing cleanup

Implementing the reducer exposed a typing wart in the hook engine: `Pointer<Value>` was a union of `SetPointer`/`UnsetPointer`, where the unset variant declared `get(): void`. That `void` is a fiction (at runtime `get()` returns `undefined` before init), and it forced `pointer.get()` to be `Value | void` — which can't be narrowed inside closures, so `useState`'s setter needed an `as Value` cast.

`get()` now returns `Value` unconditionally and `initialized` carries the "is there a value yet" question. This removes the cast, and `useMemo` switches from a `!prev` falsiness check to an explicit `pointer.initialized` check (cleaner, and no longer relies on the state value being truthy).

## Notes / trade-offs

- A reducer returning the same reference is a noop (`Object.is` bailout, same as React).
- Edge case: function-valued state (only reachable via the factory default, e.g. `useState(() => () => 1)`) — a function passed to the setter is now treated as an updater rather than stored. This is already outside the intended design (`NotFunction` reserves functions for factories).

## Commands run

- `vitest --run packages` — 388 passed, 1 skipped
- `tsc -p tsconfig.json --noEmit` — clean
- `oxfmt --check` + `oxlint` on changed files — clean
