### PR TITLE
fix: don't restore package.json in postpack before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prepare": "git config --local include.path ../.gitconfig || true",
     "prepublishOnly": "yarn tsc",
     "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i '' -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
-    "postpack": "git restore packages/*/package.json packages/*/README.md",
+    "postpack": "git restore packages/*/README.md",
     "setup": "setup-packages && package lint && oxfmt . --no-error-on-unmatched-pattern",
     "pretest": "yarn tsc && oxlint . && oxfmt --check . && eslint .",
     "test": "vitest --run packages && turbo test",


### PR DESCRIPTION
## Problem

`npx @inquirer/demo` fails with:

```
'inquirer-demo' is not recognized as an internal or external command,
operable program or batch file.
```

Reproduced on macOS too: `sh: inquirer-demo: command not found`.

## Root cause

The npm **registry packument** advertises `bin: src/index.ts`, a path that is not shipped in the tarball (only `dist/` is). Because npm resolves the `bin` shim from the packument, no `inquirer-demo` shim is created.

The **tarball** itself is correct (`bin: ./dist/index.js`), which is why `npm install` + `node node_modules/@inquirer/demo/dist/index.js` works fine — only `npx`/`npm exec` break.

### Why the tarball is right but the registry is wrong

lerna-lite's publish flow (`@lerna-lite/publish` `publish-command.js`):

1. `applyPublishConfigOverrides()` — moves `publishConfig.bin/main/exports` to top-level fields in the in-memory manifest
2. `serializeChanges()` — writes the overridden `package.json` to disk (`bin: ./dist/index.js`)
3. `packUpdated()` — packs the tarball ✅ (correct)
   - …inside here, the root **`postpack`** lifecycle runs `git restore packages/*/package.json packages/*/README.md` → **restores the source `package.json` (`bin: src/index.ts`) on disk**
4. `publishPacked()` → `npmPublish()` → **re-reads the on-disk `package.json`** and sends it as registry metadata → registry receives `bin: src/index.ts` ❌
5. `resetChanges()` — lerna-lite's *own* post-publish git checkout that restores `package.json`

So the manual `postpack: git restore packages/*/package.json` runs **between packing and publishing**, undoing the overrides before lerna-lite re-reads the manifest to publish. lerna-lite already restores `package.json` itself after publish via `resetChanges()`, so the manual restore is redundant **and** harmful.

This affects **every** `@inquirer/*` package (all packuments show `exports: ./src/...`, `main: null`), but only the `demo` package breaks visibly because it's the only one with a `bin`.

The `postpack` restore was added in #1742 (May 2025), before the `publishConfig` override pattern (introduced with `setup-packages` in May 2026) existed.

## Fix

Remove `packages/*/package.json` from the `postpack` git restore (keep the README restore, since lerna-lite only resets `package.json`, not READMEs):

```diff
- "postpack": "git restore packages/*/package.json packages/*/README.md",
+ "postpack": "git restore packages/*/README.md",
```

`package.json` is still restored after publish by lerna-lite's `resetChanges()`.

## Follow-up needed

Already-published versions on npm can't be repaired in place — a new release is needed so the packument gets the correct `bin`.

Fixes #2230