### PR TITLE
chore: secure release pipeline with npm Trusted Publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
     groups:
       # Group all testing related packages
       testing:
@@ -46,3 +48,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -1,0 +1,23 @@
+name: Lint CI workflows
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,10 +31,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,4 +47,4 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           skip-commit-verification: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,15 +17,17 @@ jobs:
   Compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Cache turbo build setup
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: ${{ runner.os }}-turbo-
       - run: corepack enable
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: latest
           cache: 'yarn'
@@ -37,15 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: Compile
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Cache turbo build setup
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: ${{ runner.os }}-turbo-
       - run: corepack enable
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: latest
           cache: 'yarn'
@@ -69,16 +73,19 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         node-version: [20, 22, 24, 26]
     steps:
-      - uses: actions/checkout@v7
-      - run: npm install -g corepack --force
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Windows runners ship a corepack too old for current package manager signatures (#2062).
+      - run: npm install -g corepack --force # zizmor: ignore[adhoc-packages] required to fix broken corepack on windows runners
       - run: corepack enable
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn vitest --run --coverage
-      - uses: codecov/codecov-action@v7
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
 
   e2e:
     name: End to End build tests
@@ -87,15 +94,17 @@ jobs:
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Cache turbo build setup
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: ${{ runner.os }}-turbo-
       - run: corepack enable
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: latest
           cache: 'yarn'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,124 @@
+name: Release
+
+# Secure release pipeline (npm Trusted Publishing + Staged Publishing).
+# See CONTRIBUTING.md "Publishing new versions" for the maintainer flow.
+#
+# Triggered by pushes to `main`. `yarn lerna version` bumps versions, commits,
+# and creates tags (inquirer@<version>, @inquirer/<name>@<version>, ...) all
+# pointing at the same commit; `lerna publish from-git --stage` then stages
+# every package tagged at HEAD in a single run. A `guard` job skips the rest
+# of the workflow when no release tag points at the pushed commit.
+#
+# Security model:
+#   - No npm token exists to steal; auth is GitHub OIDC → npm Trusted Publishing.
+#   - The publish job only *stages* the release. A maintainer must approve it
+#     with 2FA (`npm stage approve`) before it goes live.
+#   - Only the publish job has `id-token: write`; every job uses
+#     `persist-credentials: false` on checkout. Installs are `--immutable`
+#     with dependency scripts disabled (`enableScripts: false`) and a 3-day
+#     minimum age gate on new package versions.
+#   - lerna-lite applies `publishConfig` manifest overrides (main/types/exports)
+#     natively during publish, and runs the root `prepublishOnly` build and
+#     `prepack` lifecycle (workspace devDependency strip, README utm rewrite),
+#     so the staged tarball matches what a local `lerna publish` would produce.
+#   - The workflow filename must stay `publish.yml`: it is part of the Trusted
+#     Publisher configuration on npmjs.com.
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      has-release: ${{ steps.check.outputs.has-release }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # need tags to detect release commits
+      - name: Check for release tags at HEAD
+        id: check
+        run: |
+          if git tag --list 'inquirer@*' '@inquirer/*@*' '@sboudrias/*@*' --points-at HEAD | grep -q .; then
+            echo "has-release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [guard]
+    if: needs.guard.outputs.has-release == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false # no cache poisoning risk in a release workflow
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Run tests
+        run: yarn vitest --run packages
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [guard]
+    if: needs.guard.outputs.has-release == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false # no cache poisoning risk
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build packages
+        run: yarn tsc
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [guard, test, build]
+    if: needs.guard.outputs.has-release == 'true'
+    permissions:
+      contents: read
+      id-token: write # required for npm Trusted Publishing (OIDC)
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # `lerna publish from-git` needs the tags pointing at HEAD
+          fetch-tags: true
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Stage npm release
+        run: yarn lerna publish from-git --stage --yes --no-git-reset

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,8 +5,15 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
-enableScripts: true
+enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 1440
+npmMinimalAgeGate: 4320
+
+# Explicitly requested fresh releases are exempt from the age gate; it only
+# guards against auto-bumps (dependabot / `yarn upgrade`) picking up a
+# maliciously-published version. verkit ships in lockstep with lerna-lite.
+npmPreapprovedPackages:
+  - '@lerna-lite/*'
+  - 'verkit'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,46 @@ yarn demo
 
 ## Publishing new versions
 
-Note: This can only be done by someone with permission to the org on `npm` and requires 2FA setup.
+Releases are staged. CI builds and stages the packages when a release commit lands on `main`; a maintainer approves the staged versions with 2FA before they go live. Publishing authenticates via GitHub OIDC → npm Trusted Publishing — there is no npm token to steal.
+
+### Cut a release
 
 ```sh
-yarn lerna publish
+git checkout main
+git pull
+
+yarn lerna version           # interactive: pick the bump per package
+# → updates each package.json + CHANGELOG
+# → commits and creates tags like @inquirer/core@1.2.3
+
+git push origin main --follow-tags   # required: the tags must ride along with the push
 ```
+
+The push to `main` triggers `.github/workflows/publish.yml`. A `guard` job checks whether any release tags point at the pushed commit and skips the rest of the workflow when there are none (so regular commits don't re-run the release pipeline):
+
+1. **test** — `yarn install --immutable` + `yarn vitest --run packages`
+2. **build** — `yarn tsc`
+3. **publish** — `yarn lerna publish from-git --stage --yes --no-git-reset`
+
+`lerna publish from-git` stages every package tagged at HEAD (all tags created by `lerna version` point at the same commit). lerna-lite applies the `publishConfig` manifest overrides (main/types/exports) natively, runs the `prepublishOnly` build and the root `prepack` (workspace devDependency strip, README utm rewrite), and stages each package via OIDC Trusted Publishing. The packages are now **staged**, not live.
+
+Forgot `--follow-tags`? Push the tags afterwards (`git push origin <tag>...`), then re-run the publish workflow on the release commit from the Actions tab — `from-git` reads the tags at that commit, so it will pick them up on the re-run.
+
+### Approve the release
+
+```sh
+npm stage list
+npm stage view <stage-id>
+npm stage approve <stage-id>   # 2FA → package goes live with provenance
+```
+
+### First publish of a new package
+
+Trusted Publishing can't be configured until the package exists on npm. Publish once manually:
+
+```sh
+cd packages/<name>
+npm publish --ignore-scripts --access public   # interactive 2FA
+```
+
+Then configure the Trusted Publisher on npmjs.com (GitHub Actions, workflow `publish.yml`, stage-only). Later releases use the tag → stage → approve flow.

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "scripts": {
     "demo": "node --watch-path=packages/ packages/demo/src/index.ts",
     "dev": "turbo watch tsc",
-    "prepare": "git config --local include.path ../.gitconfig || true",
+    "postinstall": "git config --local include.path ../.gitconfig || true",
     "prepublishOnly": "yarn tsc",
-    "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i '' -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
+    "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i.bak -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1 -type f -name 'README*.bak' -delete && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
     "postpack": "git restore packages/*/README.md",
     "setup": "setup-packages && package lint && oxfmt . --no-error-on-unmatched-pattern",
     "pretest": "yarn tsc && oxlint . && oxfmt --check . && eslint .",
@@ -66,8 +66,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@lerna-lite/cli": "^5.0.0",
-    "@lerna-lite/publish": "^5.0.0",
+    "@lerna-lite/cli": "^5.6.0",
+    "@lerna-lite/publish": "^5.6.0",
     "@repo/tsconfig": "workspace:*",
     "@sboudrias/package": "workspace:*",
     "@types/node": "^26.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@conventional-changelog/template@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@conventional-changelog/template@npm:1.2.1"
-  checksum: 10/be65738f81cb232a794fc0ab2bbe9af2e32896e0c731fe8bdf8a2ab8dabdcc2645937d1025d6f7ad8878c6a51be1da9cab71e287ac476b8e07fb0b8cb7811425
+"@conventional-changelog/git-client@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@conventional-changelog/git-client@npm:3.1.2"
+  dependencies:
+    "@simple-libs/child-process-utils": "npm:^2.0.0"
+    "@simple-libs/stream-utils": "npm:^2.0.0"
+    semver: "npm:^7.5.2"
+  peerDependencies:
+    conventional-commits-filter: ^6.0.1
+    conventional-commits-parser: ^7.1.2
+  peerDependenciesMeta:
+    conventional-commits-filter:
+      optional: true
+    conventional-commits-parser:
+      optional: true
+  checksum: 10/fa5c21b0d2d15584fd843868ec0c2433b625779a2c036bf13a23a4f1e172557890243c1d2409cf39ef02c9cdbf2f96bdfd0ec112d42b8b4f0114ac8fa31958e5
+  languageName: node
+  linkType: hard
+
+"@conventional-changelog/template@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@conventional-changelog/template@npm:1.3.0"
+  checksum: 10/9b5b98fcd53de971bcdb882c67c44ce785843e49ef22ada8ac078e5e82eca273e013cdf27be5763d274c0fd3e45e63c6f2fb2b18155a0f0939eded4af759ea10
   languageName: node
   linkType: hard
 
@@ -213,16 +232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gar/promise-retry@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "@gar/promise-retry@npm:1.0.2"
-  dependencies:
-    retry: "npm:^0.13.1"
-  checksum: 10/b91326999ce94677cbe91973079eabc689761a93a045f6a2d34d4070e9305b27f6c54e4021688c7080cb14caf89eafa0c0f300af741b94c20d18608bdb66ca46
-  languageName: node
-  linkType: hard
-
-"@gar/promise-retry@npm:^1.0.2":
+"@gar/promise-retry@npm:^1.0.0, @gar/promise-retry@npm:^1.0.2":
   version: 1.0.3
   resolution: "@gar/promise-retry@npm:1.0.3"
   checksum: 10/0d13ea3bb1025755e055648f6e290d2a7e0c87affaf552218f09f66b3fcd9ea9d5c9cc5fe2aa6e285e1530437768e40f9448fe9a86f4f3417b216dcf488d3d1a
@@ -549,8 +559,8 @@ __metadata:
   resolution: "@inquirer/root@workspace:."
   dependencies:
     "@eslint/js": "npm:^10.0.1"
-    "@lerna-lite/cli": "npm:^5.0.0"
-    "@lerna-lite/publish": "npm:^5.0.0"
+    "@lerna-lite/cli": "npm:^5.6.0"
+    "@lerna-lite/publish": "npm:^5.6.0"
     "@repo/tsconfig": "workspace:*"
     "@sboudrias/package": "workspace:*"
     "@types/node": "npm:^26.1.1"
@@ -800,16 +810,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna-lite/cli@npm:5.4.2, @lerna-lite/cli@npm:^5.0.0":
-  version: 5.4.2
-  resolution: "@lerna-lite/cli@npm:5.4.2"
+"@lerna-lite/cli@npm:5.6.0, @lerna-lite/cli@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "@lerna-lite/cli@npm:5.6.0"
   dependencies:
-    "@lerna-lite/core": "npm:5.4.2"
-    "@lerna-lite/init": "npm:5.4.2"
+    "@lerna-lite/core": "npm:5.6.0"
+    "@lerna-lite/init": "npm:5.6.0"
     "@lerna-lite/npmlog": "npm:5.4.1"
     dotenv: "npm:^17.4.2"
     import-local: "npm:^3.2.0"
-    yargs: "npm:^18.0.0"
+    yargs: "npm:^18.1.0"
   peerDependenciesMeta:
     "@lerna-lite/exec":
       optional: true
@@ -825,13 +835,13 @@ __metadata:
       optional: true
   bin:
     lerna: dist/cli.js
-  checksum: 10/27dc7a88281194eb17e423637fa80a21e23d4c7ae4e463a07bd5aba64fa57a842918c6e0ee58347a0200eafb7041d970d47d69bf1084fe2ec99ea3dff9c62343
+  checksum: 10/0c825f14dd226ef65ad4cf1294e402677d81fd8b51c4c5f3e71a559d96aeefbfef47ed2962ad7fec42148b557dd1933d62628290d71d80789fc3bf20d64bc354
   languageName: node
   linkType: hard
 
-"@lerna-lite/core@npm:5.4.2":
-  version: 5.4.2
-  resolution: "@lerna-lite/core@npm:5.4.2"
+"@lerna-lite/core@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@lerna-lite/core@npm:5.6.0"
   dependencies:
     "@inquirer/expand": "npm:^5.1.1"
     "@inquirer/input": "npm:^5.1.2"
@@ -842,23 +852,23 @@ __metadata:
     json5: "npm:^2.2.3"
     lilconfig: "npm:^3.1.3"
     npm-package-arg: "npm:^13.0.2"
-    semver: "npm:^7.8.5"
-    tinyexec: "npm:^1.2.4"
+    tinyexec: "npm:^1.3.0"
+    verkit: "npm:^0.4.0"
     write-file-atomic: "npm:^7.0.1"
     write-json-file: "npm:^7.0.0"
     yaml: "npm:^2.9.0"
     zeptomatch: "npm:^2.1.0"
-  checksum: 10/0c2cae3884ef3f1b1aa5b784bc024d88fee2d64f967890d0e08e2cf4bb5d23e9df3904999eecabfefabc90d788a9a103dd1c6bac76b9e217cedfa9ed965716af
+  checksum: 10/3948e9f214f225f1e0731c68103e5fffe73ae00ad9dec0e567e5a89b84de5c685b8cca4e330ffb7c5e74e177b95e26a1da99d7310f35346c181883fdfef2c80e
   languageName: node
   linkType: hard
 
-"@lerna-lite/init@npm:5.4.2":
-  version: 5.4.2
-  resolution: "@lerna-lite/init@npm:5.4.2"
+"@lerna-lite/init@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@lerna-lite/init@npm:5.6.0"
   dependencies:
-    "@lerna-lite/core": "npm:5.4.2"
+    "@lerna-lite/core": "npm:5.6.0"
     write-json-file: "npm:^7.0.0"
-  checksum: 10/faede6649d2309de28b4833b0239c6feb033d849f02279a1316012e7909c54ffa43cd84545c6ec33e0bde6f26fd1da0eb7656079be089960a0c23055040dda43
+  checksum: 10/0bfb012f9d701d8d17743a9ff2c6414eaf8336c3f348edafe90044f2e1c05e3088292f05ebe029f84d89775e9808c50d69fbd6fe5f9d89762bda6a9cdfdb87e6
   languageName: node
   linkType: hard
 
@@ -872,15 +882,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna-lite/publish@npm:^5.0.0":
-  version: 5.4.2
-  resolution: "@lerna-lite/publish@npm:5.4.2"
+"@lerna-lite/publish@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "@lerna-lite/publish@npm:5.6.0"
   dependencies:
-    "@lerna-lite/cli": "npm:5.4.2"
-    "@lerna-lite/core": "npm:5.4.2"
+    "@lerna-lite/cli": "npm:5.6.0"
+    "@lerna-lite/core": "npm:5.6.0"
     "@lerna-lite/npmlog": "npm:5.4.1"
-    "@lerna-lite/version": "npm:5.4.2"
-    "@npmcli/arborist": "npm:^9.9.0"
+    "@lerna-lite/version": "npm:5.6.0"
+    "@npmcli/arborist": "npm:^9.9.1"
     "@npmcli/package-json": "npm:^7.0.5"
     ci-info: "npm:^4.4.0"
     libnpmaccess: "npm:^10.0.3"
@@ -889,36 +899,36 @@ __metadata:
     npm-packlist: "npm:^10.0.4"
     npm-registry-fetch: "npm:^19.1.1"
     pacote: "npm:^21.5.1"
-    semver: "npm:^7.8.5"
     ssri: "npm:^13.0.1"
-    tar: "npm:^7.5.21"
-  checksum: 10/069170705e30f1fba2b4bdccee0d56b221517430640d583ca5ee352b58661af0458dc981dcb1f835cf20f0c51e6d2d813ebbb5c9e300ca2ccf18d3d2c88a6217
+    tar: "npm:^7.5.22"
+    verkit: "npm:^0.4.0"
+  checksum: 10/bc9833f6ca2f716a402a762db279b28e8a04595a5c5e11a712efa343b83177531fb5a21bdf24bba7e12ee50283ebdcbf564f790116b18cd24aba6af2cd1a0b97
   languageName: node
   linkType: hard
 
-"@lerna-lite/version@npm:5.4.2":
-  version: 5.4.2
-  resolution: "@lerna-lite/version@npm:5.4.2"
+"@lerna-lite/version@npm:5.6.0":
+  version: 5.6.0
+  resolution: "@lerna-lite/version@npm:5.6.0"
   dependencies:
-    "@conventional-changelog/git-client": "npm:^3.1.0"
-    "@conventional-changelog/template": "npm:^1.2.1"
-    "@lerna-lite/cli": "npm:5.4.2"
-    "@lerna-lite/core": "npm:5.4.2"
+    "@conventional-changelog/git-client": "npm:^3.1.2"
+    "@conventional-changelog/template": "npm:^1.3.0"
+    "@lerna-lite/cli": "npm:5.6.0"
+    "@lerna-lite/core": "npm:5.6.0"
     "@lerna-lite/npmlog": "npm:5.4.1"
     "@octokit/plugin-enterprise-rest": "npm:^6.0.1"
     "@octokit/rest": "npm:^22.0.1"
-    conventional-changelog: "npm:^8.1.0"
-    conventional-changelog-angular: "npm:^9.2.1"
-    conventional-changelog-writer: "npm:^9.2.0"
-    conventional-commits-parser: "npm:^7.1.0"
+    conventional-changelog: "npm:^8.1.3"
+    conventional-changelog-angular: "npm:^9.3.0"
+    conventional-changelog-writer: "npm:^9.2.1"
+    conventional-commits-parser: "npm:^7.1.2"
     conventional-recommended-bump: "npm:^12.1.0"
     git-url-parse: "npm:^16.1.0"
     handlebars: "npm:^4.7.9"
     npm-package-arg: "npm:^13.0.2"
-    semver: "npm:^7.8.5"
+    verkit: "npm:^0.4.0"
     write-json-file: "npm:^7.0.0"
     zeptomatch: "npm:^2.1.0"
-  checksum: 10/5b1ab96f7d2e45a32b0d634eca39638e87ab59494a0aa836c4f63961cc50bebbf64931d481e9b1e910dbfbc688a175dd2fb01048bd45afdf5bca199e6513938d
+  checksum: 10/b9318f4f966a71d6e1548157995e6a7194309b0335b9127c41226f502180940549dd331f4569c6241a5967e9781d251e093cee9b3c569e553b3558cbb9b27939
   languageName: node
   linkType: hard
 
@@ -974,9 +984,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/arborist@npm:^9.9.0":
-  version: 9.9.0
-  resolution: "@npmcli/arborist@npm:9.9.0"
+"@npmcli/arborist@npm:^9.9.1":
+  version: 9.9.1
+  resolution: "@npmcli/arborist@npm:9.9.1"
   dependencies:
     "@gar/promise-retry": "npm:^1.0.0"
     "@isaacs/string-locale-compare": "npm:^1.1.0"
@@ -1014,7 +1024,7 @@ __metadata:
     walk-up-path: "npm:^4.0.0"
   bin:
     arborist: bin/index.js
-  checksum: 10/31b02bba37abb871edb3fd027461f9227d48e51427dbeed67ed50feecd90697db35e658436bbe26a66abe3d4fe315abb01e72ca1d791d3b8b7b50faadf40e5a9
+  checksum: 10/6e0e0c42d0a678f627f31d12993b44371cc6afaf5b5a36412c5146c631e816c48774e93cff7d049d6811b9836f9418c1551859ad2fa026c5daf52d2e355c77e8
   languageName: node
   linkType: hard
 
@@ -1074,14 +1084,14 @@ __metadata:
   linkType: hard
 
 "@npmcli/map-workspaces@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "@npmcli/map-workspaces@npm:5.0.1"
+  version: 5.0.3
+  resolution: "@npmcli/map-workspaces@npm:5.0.3"
   dependencies:
     "@npmcli/name-from-folder": "npm:^4.0.0"
     "@npmcli/package-json": "npm:^7.0.0"
-    glob: "npm:^11.0.3"
+    glob: "npm:^13.0.0"
     minimatch: "npm:^10.0.3"
-  checksum: 10/014fbc8fb98c867fab1aa81ef80c1738950c9bc94a24812552d1da8a8cf127b7b052555043f32b7321f820d3a4861d57f671f5a6058c5078d434c43eec215ee2
+  checksum: 10/72c5db2c555d64ff1300b912d1c3e738818658a90b7121a1f5ac98f48db53072ce38f1856b37677fcfefbce168d0db16d1e563452bd99f56d1ba38f83201c072
   languageName: node
   linkType: hard
 
@@ -1167,21 +1177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/run-script@npm:^10.0.0":
-  version: 10.0.3
-  resolution: "@npmcli/run-script@npm:10.0.3"
-  dependencies:
-    "@npmcli/node-gyp": "npm:^5.0.0"
-    "@npmcli/package-json": "npm:^7.0.0"
-    "@npmcli/promise-spawn": "npm:^9.0.0"
-    node-gyp: "npm:^12.1.0"
-    proc-log: "npm:^6.0.0"
-    which: "npm:^6.0.0"
-  checksum: 10/3b2b6b02a40c7470a900e8d77d23e2239608c08e919d6ddee7849fc7093be0999d9eb2c9dec871988e80165a64f9d8c55430f0a699690e555ebd3e81bf1dbd35
-  languageName: node
-  linkType: hard
-
-"@npmcli/run-script@npm:^10.0.4":
+"@npmcli/run-script@npm:^10.0.0, @npmcli/run-script@npm:^10.0.4":
   version: 10.0.4
   resolution: "@npmcli/run-script@npm:10.0.4"
   dependencies:
@@ -1816,9 +1812,9 @@ __metadata:
   linkType: hard
 
 "@sigstore/protobuf-specs@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@sigstore/protobuf-specs@npm:0.5.0"
-  checksum: 10/98e84c5df1b5828e96a4c3cd39aca1ab069de53f0eaf4d0844ee50a19a15bff5707663e78eead7c27745fea3c55a37edfe5569242a1c695a146459159c104450
+  version: 0.5.1
+  resolution: "@sigstore/protobuf-specs@npm:0.5.1"
+  checksum: 10/2ca6b044ab70e6aa85cc0b67f2d67724cf8b9efc49d6f7fd65993ee9b9aea02a5e8e7a73cc2a75e1968f2aa231f79d28e4bb7e88c1f98274405214e4cb1568b2
   languageName: node
   linkType: hard
 
@@ -2489,6 +2485,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.2.2":
+  version: 6.3.0
+  resolution: "ansi-regex@npm:6.3.0"
+  checksum: 10/85e15deee80d6e52e75864897b6f7b8a8cfc5befe1868f03e3b6bf8925b9b667cf67d4aeafc6d038398f2f11c3813e7b40ad79affdd29a9c491b3585bfa125d5
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
@@ -2569,15 +2572,15 @@ __metadata:
   linkType: hard
 
 "bin-links@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "bin-links@npm:6.0.0"
+  version: 6.0.2
+  resolution: "bin-links@npm:6.0.2"
   dependencies:
     cmd-shim: "npm:^8.0.0"
     npm-normalize-package-bin: "npm:^5.0.0"
     proc-log: "npm:^6.0.0"
     read-cmd-shim: "npm:^6.0.0"
     write-file-atomic: "npm:^7.0.0"
-  checksum: 10/8baa9154777b75eb7187aacab7e5f883e649261fd00b34ba10f8dca5931ba84e35c95f41471df87bf03a0c5b835767cad0a226acf92c7e3dd1466db000bfe582
+  checksum: 10/8d28e74cb68a9ceeed83c4b039874e2754bd483cac410f2e3540fb4551009d4fcbe3528fa0ebfb8641db4afe3d7613dec715a3594984d3b722731015f2b5064c
   languageName: node
   linkType: hard
 
@@ -2638,7 +2641,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^20.0.0, cacache@npm:^20.0.1":
+"cacache@npm:^20.0.0":
+  version: 20.0.4
+  resolution: "cacache@npm:20.0.4"
+  dependencies:
+    "@npmcli/fs": "npm:^5.0.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^13.0.0"
+    lru-cache: "npm:^11.1.0"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^2.0.1"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    p-map: "npm:^7.0.2"
+    ssri: "npm:^13.0.0"
+  checksum: 10/02c1b4c57dc2473e6f4654220c9405b73ae5fcdb392f82a7cf535468a52b842690cdb3694861d13bbe4dc067d5f8abe9697b4f791ae5b65cd73d62abad1e3e54
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^20.0.1":
   version: 20.0.1
   resolution: "cacache@npm:20.0.1"
   dependencies:
@@ -2695,14 +2716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.0.0":
-  version: 4.3.1
-  resolution: "ci-info@npm:4.3.1"
-  checksum: 10/9dc952bef67e665ccde2e7a552d42d5d095529d21829ece060a00925ede2dfa136160c70ef2471ea6ed6c9b133218b47c007f56955c0f1734a2e57f240aa7445
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:^4.2.0, ci-info@npm:^4.4.0":
+"ci-info@npm:^4.0.0, ci-info@npm:^4.2.0, ci-info@npm:^4.4.0":
   version: 4.4.0
   resolution: "ci-info@npm:4.4.0"
   checksum: 10/dfded0c630267d89660c8abb988ac8395a382bdfefedcc03e3e2858523312c5207db777c239c34774e3fcff11f015477c19d2ac8a58ea58aa476614a2e64f434
@@ -2798,12 +2812,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "conventional-changelog-angular@npm:9.2.1"
+"conventional-changelog-angular@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "conventional-changelog-angular@npm:9.3.0"
   dependencies:
-    "@conventional-changelog/template": "npm:^1.2.1"
-  checksum: 10/4a7452489ab2414eacb6a14140a91fa17bafc7cc8f12e01d788aa03e31091a53a6696fe71e599f233e519a0b8605b6d058ad49cf40bb26a3783cdcea377efab1
+    "@conventional-changelog/template": "npm:^1.3.0"
+  checksum: 10/a5b6d6552752f1efd392b18d53609464a432a13563e733684f58064681d6ec5a859a9d9c167897dd6de48a72b731695f789124fb5f8bce3713275f3808ee0d5a
   languageName: node
   linkType: hard
 
@@ -2814,36 +2828,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-writer@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "conventional-changelog-writer@npm:9.2.0"
+"conventional-changelog-writer@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "conventional-changelog-writer@npm:9.2.1"
   dependencies:
-    "@conventional-changelog/template": "npm:^1.2.1"
+    "@conventional-changelog/template": "npm:^1.3.0"
     "@simple-libs/stream-utils": "npm:^2.0.0"
     argue-cli: "npm:^3.1.0"
     conventional-commits-filter: "npm:^6.0.1"
     semver: "npm:^7.5.2"
   bin:
     conventional-changelog-writer: ./dist/cli/index.js
-  checksum: 10/bb074557420a3f23392c64317ca6914d49ea548ff9c6418fb9cffa9c2cbf8878f1136bce38202af69646af896a6eade1945c87b9058a18b94adf7ed2fd72283e
+  checksum: 10/e360e8e95434ef3d7005e2c3d2daaaa234ec036d78876818e7093c7734325f67879f6bf4678e34dc0458e8add7aafd966aa8cefece6a07bbf1f53227feae992e
   languageName: node
   linkType: hard
 
-"conventional-changelog@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "conventional-changelog@npm:8.1.0"
+"conventional-changelog@npm:^8.1.3":
+  version: 8.1.3
+  resolution: "conventional-changelog@npm:8.1.3"
   dependencies:
-    "@conventional-changelog/git-client": "npm:^3.1.0"
+    "@conventional-changelog/git-client": "npm:^3.1.2"
     "@simple-libs/hosted-git-info": "npm:^2.0.0"
     "@simple-libs/normalize-package-data": "npm:^1.0.0"
     argue-cli: "npm:^3.1.0"
     conventional-changelog-preset-loader: "npm:^6.0.1"
-    conventional-changelog-writer: "npm:^9.2.0"
-    conventional-commits-parser: "npm:^7.1.0"
+    conventional-changelog-writer: "npm:^9.2.1"
+    conventional-commits-filter: "npm:^6.0.1"
+    conventional-commits-parser: "npm:^7.1.2"
     fd-package-json: "npm:^2.0.0"
   bin:
     conventional-changelog: ./dist/cli/index.js
-  checksum: 10/e2a0263db104d7ef498a968c8762ed185516552fecfab5894888b481b75a4ea3d80f4479f0de118e4a41ae4d004b35982aa7bd90b7c816a2ebf1459399241b82
+  checksum: 10/c0ab637dbcd760148e546d1e85f195fd4195739508a3a060d9a307e70ac40d61505cd1108a72632351fb277de537aef27f64c2fa320ddd4079929af52d46f383
   languageName: node
   linkType: hard
 
@@ -2863,6 +2878,18 @@ __metadata:
   bin:
     conventional-commits-parser: ./dist/cli/index.js
   checksum: 10/53ae3939469602f5767870a5417952aea6fb68cb602706e680a1df826f39ed381eaef2e99fe7e06ff9df040dc6f5ada4eb923004b3b50bb584fb8e65f749bb69
+  languageName: node
+  linkType: hard
+
+"conventional-commits-parser@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "conventional-commits-parser@npm:7.1.2"
+  dependencies:
+    "@simple-libs/stream-utils": "npm:^2.0.0"
+    argue-cli: "npm:^3.1.0"
+  bin:
+    conventional-commits-parser: ./dist/cli/index.js
+  checksum: 10/50b846af6cd494d3c7fd680f17af7dc2e762a43c45ea160c433e2bc24040337275418b401f4796be70b3de6221f41ae2471a0e5acc6e86b7a857a65e42e9d128
   languageName: node
   linkType: hard
 
@@ -3501,6 +3528,13 @@ __metadata:
   version: 1.4.0
   resolution: "get-east-asian-width@npm:1.4.0"
   checksum: 10/c9ae85bfc2feaf4cc71cdb236e60f1757ae82281964c206c6aa89a25f1987d326ddd8b0de9f9ccd56e37711b9fcd988f7f5137118b49b0b45e19df93c3be8f45
+  languageName: node
+  linkType: hard
+
+"get-east-asian-width@npm:^1.5.0":
+  version: 1.6.0
+  resolution: "get-east-asian-width@npm:1.6.0"
+  checksum: 10/3e5370b5df1f0020db711d8a3f9ee2cbfc9c7542daa99a699e9d7b9acf66e7868b89084741565a45d30d80afedf6e1218e0fb8bef7a583924a449c2816777380
   languageName: node
   linkType: hard
 
@@ -4503,7 +4537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
+"minimatch@npm:^10.0.3, minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -4512,7 +4546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.5":
+"minimatch@npm:^10.1.1, minimatch@npm:^10.2.5":
   version: 10.2.6
   resolution: "minimatch@npm:10.2.6"
   dependencies:
@@ -4846,17 +4880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-packlist@npm:^10.0.1":
-  version: 10.0.3
-  resolution: "npm-packlist@npm:10.0.3"
-  dependencies:
-    ignore-walk: "npm:^8.0.0"
-    proc-log: "npm:^6.0.0"
-  checksum: 10/2dd1d1de903e534b1468fd87be8329aca0b2c26c25a830deb936e226b0f57ed9079ccc49a279015045e3a30f85bf3eb82e92f7271179819aa263eedd7b60be3a
-  languageName: node
-  linkType: hard
-
-"npm-packlist@npm:^10.0.4":
+"npm-packlist@npm:^10.0.1, npm-packlist@npm:^10.0.4":
   version: 10.0.4
   resolution: "npm-packlist@npm:10.0.4"
   dependencies:
@@ -5184,34 +5208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pacote@npm:^21.0.0, pacote@npm:^21.0.2":
-  version: 21.0.4
-  resolution: "pacote@npm:21.0.4"
-  dependencies:
-    "@npmcli/git": "npm:^7.0.0"
-    "@npmcli/installed-package-contents": "npm:^4.0.0"
-    "@npmcli/package-json": "npm:^7.0.0"
-    "@npmcli/promise-spawn": "npm:^9.0.0"
-    "@npmcli/run-script": "npm:^10.0.0"
-    cacache: "npm:^20.0.0"
-    fs-minipass: "npm:^3.0.0"
-    minipass: "npm:^7.0.2"
-    npm-package-arg: "npm:^13.0.0"
-    npm-packlist: "npm:^10.0.1"
-    npm-pick-manifest: "npm:^11.0.1"
-    npm-registry-fetch: "npm:^19.0.0"
-    proc-log: "npm:^6.0.0"
-    promise-retry: "npm:^2.0.1"
-    sigstore: "npm:^4.0.0"
-    ssri: "npm:^13.0.0"
-    tar: "npm:^7.4.3"
-  bin:
-    pacote: bin/index.js
-  checksum: 10/1c706ee45a683b559d0c9591e820627861eb58596507072a63e122c073af3f69f170017f453e44186496a9058feb430a21a43a8531739c5651f279be5fb065f1
-  languageName: node
-  linkType: hard
-
-"pacote@npm:^21.5.1":
+"pacote@npm:^21.0.0, pacote@npm:^21.0.2, pacote@npm:^21.5.1":
   version: 21.5.1
   resolution: "pacote@npm:21.5.1"
   dependencies:
@@ -5357,12 +5354,12 @@ __metadata:
   linkType: hard
 
 "postcss-selector-parser@npm:^7.0.0":
-  version: 7.1.0
-  resolution: "postcss-selector-parser@npm:7.1.0"
+  version: 7.1.5
+  resolution: "postcss-selector-parser@npm:7.1.5"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
-  checksum: 10/2caf09e66e2be81d45538f8afdc5439298c89bea71e9943b364e69dce9443d9c5ab33f4dd8b237f1ed7d2f38530338dcc189c1219d888159e6afb5b0afe58b19
+  checksum: 10/ae66bbcb5d370a3f4b4660e23a208352a885c651f1b420f7b998faaa1034832b870066f49e295f73ee3da6a6c6312c56fea1b2039969f8d803438fa48232b307
   languageName: node
   linkType: hard
 
@@ -5513,13 +5510,6 @@ __metadata:
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
   checksum: 10/1f914879f97e7ee931ad05fe3afa629bd55270fc6cf1c1e589b6a99fab96d15daad0fa1a52a00c729ec0078045fe3e399bd4fd0c93bcc906957bdc17f89cb8e6
-  languageName: node
-  linkType: hard
-
-"retry@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "retry@npm:0.13.1"
-  checksum: 10/6125ec2e06d6e47e9201539c887defba4e47f63471db304c59e4b82fc63c8e89ca06a77e9d34939a9a42a76f00774b2f46c0d4a4cbb3e287268bd018ed69426d
   languageName: node
   linkType: hard
 
@@ -5944,6 +5934,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^8.2.1":
+  version: 8.2.2
+  resolution: "string-width@npm:8.2.2"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10/18da8c8e5247bedd8a379272b9fccebd16ec22132486344a4a5bf3bd2acf4b12fda9b2be9192eba59c5dc1484f2d36dbfb5fd5e66950fe7167fa00876078196f
+  languageName: node
+  linkType: hard
+
 "string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
@@ -5968,6 +5968,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10/db0e3f9654e519c8a33c50fc9304d07df5649388e7da06d3aabf66d29e5ad65d5e6315d8519d409c15b32fa82c1df7e11ed6f8cd50b0e4404463f0c9d77c8d0b
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.2":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10/96da3bc6d73cfba1218625a3d66cf7d37a69bf0920d8735b28f9eeaafcdb6c1fe8440e1ae9eb1ba0ca355dbe8702da872e105e2e939fa93e7851b3cb5dd7d316
   languageName: node
   linkType: hard
 
@@ -6008,20 +6017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3, tar@npm:^7.5.2":
-  version: 7.5.15
-  resolution: "tar@npm:7.5.15"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.1.0"
-    yallist: "npm:^5.0.0"
-  checksum: 10/b4cb6acd822159867f81ebda8d765c6941ec8292f1cf2f870d3713f4933c14bf0ed7bf4a92338143c31e8815ca0a1fdd62aa03ddb48a42ae187f7ef696583ffe
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.21":
+"tar@npm:^7.4.3, tar@npm:^7.5.22":
   version: 7.5.22
   resolution: "tar@npm:7.5.22"
   dependencies:
@@ -6031,6 +6027,19 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.2":
+  version: 7.5.15
+  resolution: "tar@npm:7.5.15"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10/b4cb6acd822159867f81ebda8d765c6941ec8292f1cf2f870d3713f4933c14bf0ed7bf4a92338143c31e8815ca0a1fdd62aa03ddb48a42ae187f7ef696583ffe
   languageName: node
   linkType: hard
 
@@ -6048,10 +6057,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "tinyexec@npm:1.2.4"
-  checksum: 10/f20b3e6f56f24c3ebe0129d0b6e657e561d225df2cf93c1a10362996232dd6ad4b8af8c9e81d258a64d09020e723772baf6fe0be26512dba7c61bb366d67b1f9
+"tinyexec@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10/749a8c5aac2ffe3f04220b8966f414636c6c324d4ae88895dfffb2319db61cf1c01c5d7e8f0fb8ab747389ea0be1f0f80d850a9cce88a9d96cc5ebcb345db018
   languageName: node
   linkType: hard
 
@@ -6334,6 +6343,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"verkit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "verkit@npm:0.4.0"
+  checksum: 10/1575da3123f6ed87e303569fe003764a4d8022f38dcc8c3f415bd5ff5e17b718ea532e84211401301b683797534323a4bb62889e1b0e1b7b0614d3b6ab1fdbab
+  languageName: node
+  linkType: hard
+
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.0.16
   resolution: "vite@npm:8.0.16"
@@ -6566,17 +6582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "write-file-atomic@npm:7.0.0"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10/ca8f12cc4de17756a3f35087c1985c45b5be1ac399b9dc33000ab8cdbacb210ce3adde5bc1a90acfa729fe5326d250cf4f91ef57143b25bcf342a267391f8754
-  languageName: node
-  linkType: hard
-
-"write-file-atomic@npm:^7.0.1":
+"write-file-atomic@npm:^7.0.0, write-file-atomic@npm:^7.0.1":
   version: 7.0.1
   resolution: "write-file-atomic@npm:7.0.1"
   dependencies:
@@ -6634,17 +6640,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "yargs@npm:18.0.0"
+"yargs@npm:^18.1.0":
+  version: 18.1.0
+  resolution: "yargs@npm:18.1.0"
   dependencies:
     cliui: "npm:^9.0.1"
     escalade: "npm:^3.1.1"
     get-caller-file: "npm:^2.0.5"
-    string-width: "npm:^7.2.0"
+    string-width: "npm:^8.2.1"
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^22.0.0"
-  checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
+  checksum: 10/b26d477c3f62b0a031d8f3fea16325e286375e6039e5fca5efb1ec1d64eab3cfe136edb2887e4f2e2c9a5e004d0eca735079ea0be4ca34273c6e949639c6177b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Sets up a secure, staged release pipeline for all published packages, following the same approach as mem-fs ([SBoudrias/mem-fs#71](https://github.com/SBoudrias/mem-fs/pull/71) + follow-ups, and [SBoudrias/mem-fs#80](https://github.com/SBoudrias/mem-fs/pull/80) for the lerna-lite-native staging). Originally adapted from the [Evil Martians secure-npm-package](https://github.com/evilmartians/agent-skills/blob/main/skills/secure-npm-package/SKILL.md) skill.

**No npm token exists to steal.** Publishing authenticates via GitHub OIDC → npm Trusted Publishing. Every release is *staged* by CI and goes live only after a maintainer approves it with 2FA (`npm stage approve`).

Staging is done by **`lerna publish from-git --stage`** ([lerna-lite#1399](https://github.com/lerna-lite/lerna-lite/pull/1399), v5.6.0): lerna applies the `publishConfig` manifest overrides, runs the root `prepublishOnly` build and `prepack` lifecycle (workspace devDependency strip, README utm rewrite), packs, and stages over OIDC — no custom publish scripts.

## Changes

- **`.github/workflows/publish.yml`** — runs on every push to `main`, with four jobs:
  - `guard` — checks `git tag --points-at HEAD` for release tags; the rest of the workflow is skipped on regular commits
  - `test` — `yarn install --immutable` + `yarn vitest --run packages`
  - `build` — `yarn tsc` (validation gate)
  - `publish` — `yarn lerna publish from-git --stage --yes --no-git-reset` stages every package tagged at HEAD in a single run (all tags created by `lerna version` point at the same commit). Only this job has `id-token: write`; installs are `--immutable` with dependency scripts disabled; checkout fetches tags (`fetch-depth: 0`) which `from-git` needs.
- **`.github/workflows/check-workflows.yml`** — runs `zizmor` on every PR/push to keep workflows linted.
- **`main.yml` / `codeql-analysis.yml` / `dependabot-automerge.yml`** — actions pinned by SHA, `persist-credentials: false` on every checkout. The Windows `npm install -g corepack --force` workaround (#2062) is kept with a documented zizmor exception.
- **`.github/dependabot.yml`** — 7-day cooldown on npm and github-actions updates.
- **`.yarnrc.yml`** — `enableScripts: false` (blocks third-party `postinstall`/`preinstall` scripts), `npmMinimalAgeGate: 4320` (3 days), and `npmPreapprovedPackages` for `@lerna-lite/*` + `verkit` so explicitly requested fresh lerna-lite releases bypass the gate (auto-bumps stay gated).
- **`package.json`** — git-hook setup moves from `prepare` → `postinstall` (with `enableScripts: false`, Yarn still runs **workspace** `postinstall` but not `prepare`). `@lerna-lite/*` bumped to `^5.6.0` for `--stage`. Root `prepack` sed made portable (`-i.bak` instead of BSD-only `-i ''`): lerna-lite runs the root `prepack` lifecycle during publish, and the publish job runs on Linux (GNU sed fails on `-i ''`). The script's `workspace:*` devDependency strip is still required — lerna-lite rewrites local workspace deps to version ranges (including private, unpublished ones like `@repo/tsconfig`) rather than stripping them.
- **`CONTRIBUTING.md`** — documents the new release flow, including the `--follow-tags` requirement and how to recover if tags were pushed late.

## ✅ Already done via CLI/API

- **Tag ruleset** `Tags only by admins` — tag creation/update/deletion restricted to repo admins: https://github.com/SBoudrias/Inquirer.js/rules/20921497
- **Immutable releases** enabled (`gh api -X PUT repos/SBoudrias/Inquirer.js/immutable-releases`)
- **npm Trusted Publisher configured for all 21 published packages** (GitHub Actions, `publish.yml`, stage-publish only) and publishing access set to require 2FA + disallow tokens (`npm access set mfa=publish`)

## New release flow

```sh
git checkout main && git pull
yarn lerna version          # pick bump → updates package.json + CHANGELOG, commits, tags @inquirer/x@y.z
git push origin main --follow-tags   # tags must ride along with the push
# CI runs publish.yml → lerna stages every tagged package
npm stage list
npm stage approve <stage-id>   # your 2FA → live w/ provenance
```

## Verification

- `zizmor` clean (0 findings across all workflows)
- 388/388 unit tests pass (`yarn vitest --run packages`), integration tests pass (`turbo test`)
- `yarn oxlint . && yarn oxfmt --check . && yarn eslint .` green
- `yarn tsc` green (22/22 packages)
- `enableScripts: false` confirmed: install works, workspace `postinstall` runs
- `yarn lerna publish --help` shows `--stage`; `yarn install --immutable` passes with the age gate + `npmPreapprovedPackages` active
- `yarn prepack` verified portable (workspace devDeps stripped, no `.bak` leftovers)
- Guard logic tested locally both ways (tag at HEAD / no tag)
- Verified against lerna-lite 5.6.0 source: `from-git` in independent mode reads `git tag --points-at HEAD` and stages manifest versions; empty tag set is a no-op

## Test plan

- [x] Enable Immutable Releases + tag ruleset on github.com
- [x] Configure npm Trusted Publishers for all published packages
- [x] Set publishing access to require 2FA + disallow tokens on all published packages
- [ ] Cut a patch release as an end-to-end test of the version → stage → approve flow

Co-Authored-By: Oz <oz-agent@warp.dev>
