### PR TITLE
fix(@inquirer/i18n): mock Intl in auto-detect test to fix Windows flake

### DIFF
--- a/packages/i18n/test/auto-detect.test.ts
+++ b/packages/i18n/test/auto-detect.test.ts
@@ -90,12 +90,22 @@ describe('auto locale detection', () => {
 
   it('falls back to English for unsupported locale', async () => {
     process.env['LANG'] = 'de_DE.UTF-8';
+    // Mock the Intl API so the test is deterministic across platforms. On
+    // Windows + Node 22 the real Intl.DateTimeFormat() locale resolution is
+    // pathologically slow (seconds) when an unsupported LANG is set, which
+    // made this test flaky (timing out at the 5s default).
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion, typescript/no-unnecessary-type-assertion
+    vi.spyOn(Intl, 'DateTimeFormat').mockImplementation((() => ({
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      resolvedOptions: () => ({ locale: 'en-US' }) as Intl.ResolvedDateTimeFormatOptions,
+    })) as typeof Intl.DateTimeFormat);
     const { confirm } = await import('../src/index.ts');
 
     const answer = confirm({ message: 'Continue?' });
     expect(screen.getScreen()).toMatchInlineSnapshot(`"? Continue? (Y/n)"`);
     screen.keypress('enter');
     await answer;
+    vi.restoreAllMocks();
   });
 
   it('falls back to English when Intl returns unsupported locale', async () => {


### PR DESCRIPTION
## Problem

The `falls back to English for unsupported locale` test in `packages/i18n/test/auto-detect.test.ts` is flaky on CI, timing out on **Windows + Node 22**:

```
Error: Test timed out in 5000ms.
 ❯ packages/i18n/test/auto-detect.test.ts:91:3
```

Example failure: https://github.com/SBoudrias/Inquirer.js/actions/runs/32068410950/job/95505766013

## Root cause

The test sets `LANG=de_DE.UTF-8` (an unsupported locale) and relies on the **real** `Intl.DateTimeFormat().resolvedOptions().locale` call inside `detectLocale()` to fall back to English. On Windows + Node 22, resolving the ICU locale with an unsupported `LANG` set is pathologically slow (the test took ~12.4s, well past the 5s default `testTimeout`).

The other Intl-based tests in the file already mock `Intl.DateTimeFormat` (test 8 took 17ms vs test 7's 12.4s in the same run), confirming the real Intl call is the slow path.

## Fix

Mock `Intl.DateTimeFormat` to return `en-US` in this test, matching the pattern already used by the other Intl-based tests. The test remains deterministic and fast on all platforms while still verifying the intended behavior (unsupported `LANG` env var falls back to English).

## Verification

- `yarn vitest --run --coverage packages/i18n` — 42 tests pass
- `yarn vitest --run packages/i18n/test/auto-detect.test.ts` — 10 tests pass, ~200ms (vs 12.4s before on Windows)
- `yarn tsc` — clean
- `yarn oxlint` / `yarn oxfmt --check` / `yarn eslint` — clean
