### PR TITLE
docs: add inquirer-grouped-checkbox to community prompts

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -581,6 +581,22 @@ Navigate a tree of choices, expanding and collapsing branches with the arrow key
 ----------------
 ```
 
+[**Grouped Checkbox Prompt**](https://github.com/patik/inquirer-grouped-checkbox)<br/>
+Checkboxes organized into labeled groups. Selecting a group header toggles every item in that group, each group shows its own running total, and typing filters across all the groups at once.
+
+```
+? Which languages do you work in? (3/6)
+❯ ◉ 🖥️ Frontend (3/3)
+    ◉ TypeScript
+    ◉ JavaScript
+    ◉ CSS
+  ◯ ⚙️ Backend (0/3)
+    ◯ Go
+    ◯ Python
+    ◯ Rust
+(Select: space • Toggle all: a • Invert: i)
+```
+
 # License
 
 Copyright (c) 2023 Simon Boudrias (twitter: [@vaxilart](https://twitter.com/Vaxilart))<br/>


### PR DESCRIPTION
Adds [inquirer-grouped-checkbox](https://github.com/patik/inquirer-grouped-checkbox) to the community prompts list.

It is a checkbox prompt whose choices are organized into labeled groups. The group headers are navigable and selectable, so pressing space on one toggles every item in that group, and each header carries its own running total. If you turn on `searchable`, typing filters across all of the groups at once.

The package is built on `@inquirer/core` v12, is published to npm, and ships types for both ESM and CJS. The sample output in the diff is copied from an actual run rather than written by hand.