### PR TITLE
feat(@inquirer/password): add ctrl+space toggle to reveal password

### DIFF
--- a/packages/i18n/src/create.ts
+++ b/packages/i18n/src/create.ts
@@ -148,6 +148,15 @@ export function createLocalizedPrompts(locale: Locale) {
       const theme = makeTheme(config.theme, {
         style: {
           maskedText: locale.password.maskedText,
+          keysHelpTip: (keys: Array<[string, string]>) => {
+            const localizedKeys = keys.map(([key, label]): [string, string] => {
+              if (label === 'toggle visibility') return [key, locale.password.helpToggle];
+              return [key, label];
+            });
+            return localizedKeys
+              .map(([k, l]) => `${styleText('bold', k)} ${styleText('dim', l)}`)
+              .join(styleText('dim', ' • '));
+          },
         },
       });
 

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -27,6 +27,7 @@ export const locale: Locale = {
   },
   password: {
     maskedText: '[entrada oculta]',
+    helpToggle: 'alternar visibilidad',
   },
 };
 

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -28,6 +28,7 @@ export const locale: Locale = {
   },
   password: {
     maskedText: '[saisie masquée]',
+    helpToggle: 'afficher/masquer',
   },
 };
 

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -28,6 +28,7 @@ export const locale: Locale = {
   },
   password: {
     maskedText: '[entrada mascarada]',
+    helpToggle: 'alternar visibilidade',
   },
 };
 

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -27,6 +27,7 @@ export const locale: Locale = {
   },
   password: {
     maskedText: '[输入已隐藏]',
+    helpToggle: '切换可见性',
   },
 };
 

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -60,6 +60,8 @@ export interface EditorStrings {
 export interface PasswordStrings {
   /** Text shown instead of typed input to indicate it is hidden */
   maskedText: string;
+  /** Help text for the key that toggles mask visibility */
+  helpToggle: string;
 }
 
 /**

--- a/packages/i18n/test/auto-detect.test.ts
+++ b/packages/i18n/test/auto-detect.test.ts
@@ -160,7 +160,10 @@ describe('auto locale detection', () => {
           loadingMessage: () => 'Überprüfung...',
           waitingMessage: (key) => `Drücken Sie ${key} um Ihren Editor zu öffnen.`,
         },
-        password: { maskedText: '[Eingabe verborgen]' },
+        password: {
+          maskedText: '[Eingabe verborgen]',
+          helpToggle: 'Sichtbarkeit umschalten',
+        },
       }),
     );
 

--- a/packages/i18n/test/password.test.ts
+++ b/packages/i18n/test/password.test.ts
@@ -7,7 +7,10 @@ import { password } from '@inquirer/i18n/zh';
 describe('password (zh)', () => {
   it('idle state shows Chinese masked text', async () => {
     const answer = password({ message: '请输入密码' });
-    expect(screen.getScreen()).toMatchInlineSnapshot(`"? 请输入密码 [输入已隐藏]"`);
+    expect(screen.getScreen()).toMatchInlineSnapshot(`
+      "? 请输入密码 [输入已隐藏]
+      ctrl+t 切换可见性"
+    `);
 
     screen.type('secret');
     screen.keypress('enter');
@@ -17,7 +20,10 @@ describe('password (zh)', () => {
   it('after typing still shows masked text', async () => {
     const answer = password({ message: '请输入密码' });
     screen.type('secret');
-    expect(screen.getScreen()).toMatchInlineSnapshot(`"? 请输入密码 [输入已隐藏]"`);
+    expect(screen.getScreen()).toMatchInlineSnapshot(`
+      "? 请输入密码 [输入已隐藏]
+      ctrl+t 切换可见性"
+    `);
 
     screen.keypress('enter');
     await answer;

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -60,12 +60,13 @@ const answer = await password({ message: 'Enter your name' });
 
 ## Options
 
-| Property | Type                                                        | Required | Description                                                                                                                                                                                                             |
-| -------- | ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| message  | `string`                                                    | yes      | The question to ask                                                                                                                                                                                                     |
-| mask     | `boolean`                                                   | no       | Show a `*` mask over the input or keep it transparent                                                                                                                                                                   |
-| validate | `string => boolean \| string \| Promise<boolean \| string>` | no       | On submit, validate the filtered answered content. When returning a string, it'll be used as the error message displayed to the user. Note: returning a rejected promise, we'll assume a code error happened and crash. |
-| theme    | [See Theming](#Theming)                                     | no       | Customize look of the prompt.                                                                                                                                                                                           |
+| Property   | Type                                                        | Required | Description                                                                                                                                                                                                             |
+| ---------- | ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| message    | `string`                                                    | yes      | The question to ask                                                                                                                                                                                                     |
+| mask       | `boolean \| string`                                         | no       | Show a `*` mask over the input, use a custom mask character, or keep it transparent.                                                                                                                                    |
+| toggleMask | `boolean`                                                   | no       | Allow the user to press `ctrl+t` to temporarily reveal the typed value. Defaults to `true`; set to `false` to disable both the shortcut and its help line.                                                              |
+| validate   | `string => boolean \| string \| Promise<boolean \| string>` | no       | On submit, validate the filtered answered content. When returning a string, it'll be used as the error message displayed to the user. Note: returning a rejected promise, we'll assume a code error happened and crash. |
+| theme      | [See Theming](#Theming)                                     | no       | Customize look of the prompt.                                                                                                                                                                                           |
 
 ## Theming
 
@@ -83,8 +84,25 @@ type Theme = {
     message: (text: string, status: 'idle' | 'done' | 'loading') => string;
     error: (text: string) => string;
     help: (text: string) => string;
+    maskedText: string;
+    keysHelpTip: (keys: [key: string, action: string][]) => string | undefined;
   };
 };
+```
+
+`maskedText` is the inline tip shown when `mask` is off and the value is hidden (default: `[input is masked]`).
+
+### `theme.style.keysHelpTip`
+
+This function customizes the keyboard shortcut help displayed on the line below the prompt. It receives `[['ctrl+t', 'toggle visibility']]` while the value is hidden. Use it to change the formatting or localize the action, or return `undefined` to hide the help line entirely.
+
+```js
+theme: {
+  style: {
+    keysHelpTip: (keys) =>
+      keys.map(([key, action]) => `${key}: ${action}`).join(' | '),
+  },
+}
 ```
 
 # License

--- a/packages/password/password.test.ts
+++ b/packages/password/password.test.ts
@@ -8,16 +8,17 @@ describe('password prompt', () => {
       message: 'Enter your password',
     });
 
-    expect(getScreen()).toMatchInlineSnapshot(
-      '"? Enter your password [input is masked]"',
-    );
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password [input is masked]
+      ctrl+t toggle visibility"
+    `);
 
-    events.type('J');
-    expect(getScreen()).toMatchInlineSnapshot(
-      '"? Enter your password [input is masked]"',
-    );
+    events.type('John');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password [input is masked]
+      ctrl+t toggle visibility"
+    `);
 
-    events.type('ohn');
     events.keypress('enter');
 
     await expect(answer).resolves.toEqual('John');
@@ -30,10 +31,16 @@ describe('password prompt', () => {
       mask: true,
     });
 
-    expect(getScreen()).toMatchInlineSnapshot('"? Enter your password"');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password
+      ctrl+t toggle visibility"
+    `);
 
     events.type('J');
-    expect(getScreen()).toMatchInlineSnapshot('"? Enter your password *"');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password *
+      ctrl+t toggle visibility"
+    `);
 
     events.type('ohn');
     events.keypress('enter');
@@ -48,12 +55,12 @@ describe('password prompt', () => {
       mask: '%',
     });
 
-    expect(getScreen()).toMatchInlineSnapshot('"? Enter your password"');
+    events.type('John');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password %%%%
+      ctrl+t toggle visibility"
+    `);
 
-    events.type('J');
-    expect(getScreen()).toMatchInlineSnapshot('"? Enter your password %"');
-
-    events.type('ohn');
     events.keypress('enter');
 
     await expect(answer).resolves.toEqual('John');
@@ -67,22 +74,196 @@ describe('password prompt', () => {
       validate: (value: string) => value.length >= 8,
     });
 
-    expect(getScreen()).toMatchInlineSnapshot(`"? Enter your password"`);
-
     events.type('1');
-    expect(getScreen()).toMatchInlineSnapshot(`"? Enter your password *"`);
-
     events.keypress('enter');
     await nextRender();
     expect(getScreen()).toMatchInlineSnapshot(`
       "? Enter your password *
-      > You must provide a valid value"
+      > You must provide a valid value
+      ctrl+t toggle visibility"
     `);
 
     events.type('2345678');
-    expect(getScreen()).toMatchInlineSnapshot(`"? Enter your password ********"`);
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password ********
+      ctrl+t toggle visibility"
+    `);
 
     events.keypress('enter');
     await expect(answer).resolves.toEqual('12345678');
+  });
+
+  it('disables reveal and its help line with toggleMask false (mask: true)', async () => {
+    const { answer, events, getScreen } = await render(password, {
+      message: 'Enter your password',
+      mask: true,
+      toggleMask: false,
+    });
+
+    events.type('John');
+    expect(getScreen()).toMatchInlineSnapshot('"? Enter your password ****"');
+
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot('"? Enter your password ****"');
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('John');
+  });
+
+  it('disables reveal and its help line with toggleMask false (no mask)', async () => {
+    const { answer, events, getScreen } = await render(password, {
+      message: 'Enter your password',
+      toggleMask: false,
+    });
+
+    events.type('John');
+    expect(getScreen()).toMatchInlineSnapshot(
+      '"? Enter your password [input is masked]"',
+    );
+
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot(
+      '"? Enter your password [input is masked]"',
+    );
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('John');
+  });
+
+  it('reveals by default and toggles on ctrl+t (mask: true)', async () => {
+    const { answer, events, getScreen } = await render(password, {
+      message: 'Enter your password',
+      mask: true,
+    });
+
+    events.type('John');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password ****
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password John
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password ****
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('John');
+  });
+
+  it('reveals by default and toggles on ctrl+t (no mask)', async () => {
+    const { answer, events, getScreen } = await render(password, {
+      message: 'Enter your password',
+    });
+
+    events.type('John');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password [input is masked]
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password John
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password [input is masked]
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('John');
+  });
+
+  it('does not leak the revealed value or help past submission', async () => {
+    const { answer, events, getScreen } = await render(password, {
+      message: 'Enter your password',
+      mask: true,
+    });
+
+    events.type('John');
+    events.keypress({ name: 't', ctrl: true });
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password John
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('John');
+    expect(getScreen()).toMatchInlineSnapshot('"✔ Enter your password ****"');
+  });
+
+  it('preserves reveal state and input through failed validation', async () => {
+    const { answer, events, getScreen, nextRender } = await render(password, {
+      message: 'Enter your password',
+      mask: true,
+      validate: (value: string) => value.length >= 8,
+    });
+
+    events.type('123');
+    events.keypress({ name: 't', ctrl: true });
+    events.keypress('enter');
+    await nextRender();
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password 123
+      > You must provide a valid value
+      ctrl+t toggle visibility"
+    `);
+
+    events.type('45678');
+    expect(getScreen()).toMatchInlineSnapshot(`
+      "? Enter your password 12345678
+      ctrl+t toggle visibility"
+    `);
+
+    events.keypress('enter');
+    await expect(answer).resolves.toEqual('12345678');
+  });
+
+  it('supports customizing or hiding the keyboard help line', async () => {
+    const keys: [string, string][][] = [];
+    const custom = await render(password, {
+      message: 'Enter your password',
+      mask: true,
+      theme: {
+        style: {
+          keysHelpTip: (shortcuts: [string, string][]) => {
+            keys.push(shortcuts);
+            return shortcuts.map(([key, action]) => `${key}: ${action}`).join(' | ');
+          },
+        },
+      },
+    });
+
+    expect(custom.getScreen()).toContain('ctrl+t: toggle visibility');
+    custom.events.keypress({ name: 't', ctrl: true });
+    expect(custom.getScreen()).toContain('ctrl+t: toggle visibility');
+    expect(keys).toContainEqual([['ctrl+t', 'toggle visibility']]);
+
+    custom.events.type('John');
+    custom.events.keypress('enter');
+    await expect(custom.answer).resolves.toEqual('John');
+
+    const hidden = await render(password, {
+      message: 'Enter your password',
+      theme: { style: { keysHelpTip: () => undefined } },
+    });
+    expect(hidden.getScreen()).toMatchInlineSnapshot(
+      '"? Enter your password [input is masked]"',
+    );
+
+    hidden.events.type('John');
+    hidden.events.keypress('enter');
+    await expect(hidden.answer).resolves.toEqual('John');
   });
 });

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -10,33 +10,41 @@ import {
 } from '@inquirer/core';
 import { cursorHide } from '@inquirer/ansi';
 import type { PartialDeep } from '@inquirer/type';
+import { styleText } from 'node:util';
 
 type PasswordTheme = {
   style: {
     maskedText: string;
+    keysHelpTip: (keys: [key: string, action: string][]) => string | undefined;
   };
 };
 
 const passwordTheme: PasswordTheme = {
   style: {
     maskedText: '[input is masked]',
+    keysHelpTip: (keys: [string, string][]) =>
+      keys
+        .map(([key, action]) => `${styleText('bold', key)} ${styleText('dim', action)}`)
+        .join(styleText('dim', ' • ')),
   },
 };
 
 type PasswordConfig = {
   message: string;
   mask?: boolean | string;
+  toggleMask?: boolean;
   validate?: (value: string) => boolean | string | Promise<string | boolean>;
   theme?: PartialDeep<Theme<PasswordTheme>>;
 };
 
 export default createPrompt<string, PasswordConfig>((config, done) => {
-  const { validate = () => true } = config;
+  const { toggleMask = true, validate = () => true } = config;
   const theme = makeTheme<PasswordTheme>(passwordTheme, config.theme);
 
   const [status, setStatus] = useState<Status>('idle');
   const [errorMsg, setError] = useState<string>();
   const [value, setValue] = useState<string>('');
+  const [revealed, setRevealed] = useState(false);
 
   const prefix = usePrefix({ status, theme });
 
@@ -61,6 +69,8 @@ export default createPrompt<string, PasswordConfig>((config, done) => {
         setError(isValid || 'You must provide a valid value');
         setStatus('idle');
       }
+    } else if (toggleMask && key.ctrl && key.name === 't') {
+      setRevealed((prev) => !prev);
     } else {
       setValue(rl.line);
       setError(undefined);
@@ -69,23 +79,33 @@ export default createPrompt<string, PasswordConfig>((config, done) => {
 
   const message = theme.style.message(config.message, status);
 
+  const showPlaintext = toggleMask && revealed && status === 'idle';
+
   let formattedValue = '';
-  let helpTip;
-  if (config.mask) {
+  if (showPlaintext) {
+    formattedValue = value;
+  } else if (config.mask) {
     const maskChar = typeof config.mask === 'string' ? config.mask : '*';
     formattedValue = maskChar.repeat(value.length);
   } else if (status !== 'done') {
-    helpTip = `${theme.style.help(theme.style.maskedText)}${cursorHide}`;
+    formattedValue = theme.style.help(theme.style.maskedText);
   }
 
   if (status === 'done') {
     formattedValue = theme.style.answer(formattedValue);
+  } else if (!config.mask) {
+    formattedValue += cursorHide;
   }
 
-  let error = '';
-  if (errorMsg) {
-    error = theme.style.error(errorMsg);
-  }
+  const content = [prefix, message, formattedValue].filter(Boolean).join(' ');
+  const bottomContent = [
+    errorMsg ? theme.style.error(errorMsg) : '',
+    toggleMask && status === 'idle'
+      ? theme.style.keysHelpTip([['ctrl+t', 'toggle visibility']])
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
 
-  return [[prefix, message, config.mask ? formattedValue : helpTip].join(' '), error];
+  return [content, bottomContent];
 });


### PR DESCRIPTION
Closes #1330. Supersedes #1334 (stalled/outdated — different codebase since then, so this is a fresh implementation rather than a rebase of it).

## What this does

Adds an opt-in `allowShowPassword` config option to `@inquirer/password`. When enabled, pressing `ctrl+space` temporarily reveals the typed value in plaintext; pressing it again re-masks it. A themed help tip (`(ctrl+space to show)` / `(ctrl+space to hide)`) is appended to the prompt so the shortcut is discoverable without reading docs. Default is `false`, so existing behavior/snapshots are unchanged for everyone who doesn't opt in.

## Addressing the three concerns from the issue thread

1. **Discoverability** — reuses the existing help-tip mechanism (the same one that already renders `[input is masked]`) to show a live, state-aware hint (`show` vs `hide`) next to the prompt whenever the feature is enabled.
2. **Common/standard shortcut** — I looked for prior art before picking one: GUI password fields (browsers, password managers, OS credential prompts) universally use a mouse-driven eye icon, not a keyboard shortcut; TUI/CLI prompt libraries I checked (bubbletea/huh, survey, promptui, gocui) don't expose a runtime reveal toggle at all — echo mode is fixed at construction. So there doesn't appear to be an existing convention to defer to. I went with `ctrl+space` because it's mnemonic (space already means "toggle" elsewhere, e.g. checkbox), doesn't collide with the shell's `ctrl+r` reverse-search or the emacs-keybinding set this repo already supports, and matches what #1334 originally proposed — happy to bikeshed this further if you have a preference.
3. **Opt-in** — off by default via `allowShowPassword`; when unset, the keypress handler doesn't register the toggle at all and no hint is rendered, so behavior for existing consumers is 100% unchanged.

## Caveat worth flagging

Some terminal emulators/OSes intercept `ctrl+space` for IME/input-source switching (notably on macOS and some Linux DEs) before it reaches the process. This is documented in the README as a best-effort limitation — masking still works normally, the reveal shortcut just won't fire in that terminal.

## What changed

- `packages/password/src/index.ts` — `allowShowPassword` config, `revealed` state, `ctrl+space` handling via `@inquirer/core`'s `isSpaceKey`, render changes for both the `mask` and no-`mask` paths, no plaintext/tip leak once the prompt is `done`.
- `packages/password/README.md` — documents the new option, the theming hook (`showHideTip`), and the terminal-compatibility caveat.
- `packages/password/password.test.ts` — new cases: off-by-default no-op, reveal/hide toggling for both `mask: true` and no-`mask`, no leak past submission, and no interference with the existing `validate` flow.

## Test plan

- [x] `yarn vitest --run packages/password` — 10/10 passing
- [x] `yarn pretest` (tsc + oxlint + oxfmt + eslint) — clean
- [x] `yarn test` (full unit + integration suite) — 394 passing / 1 skipped, 0 failing
- [ ] Manual verification of `ctrl+space` delivery across real terminals (xterm, iTerm2/Terminal.app, Windows Terminal) — not yet done on my end; flagging in case you or another reviewer can confirm on a platform I don't have handy.