### PR TITLE
feat: prettify prompt and theme types for better IDE display

### DIFF
--- a/packages/core/src/lib/create-prompt.ts
+++ b/packages/core/src/lib/create-prompt.ts
@@ -1,6 +1,6 @@
 import * as readline from 'node:readline';
 import { AsyncResource } from 'node:async_hooks';
-import { type Prompt, type Prettify } from '@inquirer/type';
+import { type Prompt } from '@inquirer/type';
 import MuteStream from 'mute-stream';
 import { onExit as onSignalExit } from 'signal-exit';
 import ScreenManager from './screen-manager.ts';
@@ -15,9 +15,15 @@ import path from 'node:path';
 const nativeSetImmediate = globalThis.setImmediate;
 
 type ViewFunction<Value, Config> = (
-  config: Prettify<Config>,
+  config: Config,
   done: (value: Value) => void,
 ) => string | [string, string | undefined];
+
+/**
+ * Expand the top-level keys of a type for better IDE display, without
+ * recursing into nested fields (so generic values stay compatible).
+ */
+type ShallowPrettify<T> = { [K in keyof T]: T[K] } & {};
 
 function getCallSites() {
   // oxlint-disable-next-line typescript/unbound-method
@@ -42,10 +48,13 @@ function getCallSites() {
 
 export function createPrompt<Value, Config>(
   view: ViewFunction<Value, Config>,
-): Prompt<Value, Config> {
+): Prompt<Value, ShallowPrettify<Config> & Config> {
   const callSites = getCallSites();
 
-  const prompt: Prompt<Value, Config> = (config, context = {}) => {
+  const prompt: Prompt<Value, ShallowPrettify<Config> & Config> = (
+    config,
+    context = {},
+  ) => {
     // Default `input` to stdin
     const { input = process.stdin, signal } = context;
     const cleanups = new Set<() => void>();

--- a/packages/core/src/lib/make-theme.ts
+++ b/packages/core/src/lib/make-theme.ts
@@ -38,5 +38,6 @@ export function makeTheme<SpecificTheme extends object>(
     getDefaultTheme(),
     ...themes.filter((theme) => theme != null),
   ] as Theme<SpecificTheme>[];
-  return deepMerge(...themesToMerge);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return deepMerge(...themesToMerge) as Prettify<Theme<SpecificTheme>>;
 }

--- a/packages/core/src/lib/pagination/use-pagination.ts
+++ b/packages/core/src/lib/pagination/use-pagination.ts
@@ -1,4 +1,3 @@
-import type { Prettify } from '@inquirer/type';
 import { useRef } from '../use-ref.ts';
 import { readlineWidth, breakLines } from '../utils.ts';
 
@@ -103,13 +102,7 @@ export function usePagination<T>({
   /** The index of the active item. */
   active: number;
   /** Renders an item as part of a page. */
-  renderItem: (
-    layout: Prettify<{
-      item: T;
-      index: number;
-      isActive: boolean;
-    }>,
-  ) => string;
+  renderItem: (layout: { item: T; index: number; isActive: boolean }) => string;
   /** The size of the page. */
   pageSize: number;
   /** Allows creating an infinitely looping list. `true` if unspecified. */

--- a/packages/core/src/lib/theme.ts
+++ b/packages/core/src/lib/theme.ts
@@ -175,7 +175,7 @@ type DefaultTheme = {
   };
 };
 
-export type Theme<Extension extends object = object> = Prettify<Extension & DefaultTheme>;
+export type Theme<Extension extends object = object> = Extension & DefaultTheme;
 
 export const defaultTheme: DefaultTheme = {
   prefix: {

--- a/packages/inquirer/src/index.ts
+++ b/packages/inquirer/src/index.ts
@@ -16,7 +16,6 @@ import {
   search,
   Separator,
 } from '@inquirer/prompts';
-import type { Prettify } from '@inquirer/type';
 import PromptsRunner from './ui/prompt.ts';
 import type { PromptCollection, LegacyPromptConstructor, PromptFn } from './ui/prompt.ts';
 import type {
@@ -93,8 +92,8 @@ const builtInPrompts: PromptCollection = {
   search,
 };
 
-type PromptReturnType<T> = Promise<Prettify<T>> & {
-  ui: PromptsRunner<Prettify<T>>;
+type PromptReturnType<T extends Answers> = Promise<T> & {
+  ui: PromptsRunner<T>;
 };
 
 /**

--- a/packages/inquirer/src/types.ts
+++ b/packages/inquirer/src/types.ts
@@ -86,7 +86,7 @@ export type AsyncGetterFunction<T, A extends Answers> = (
       ...args: [error: null | undefined, value: T] | [error: Error, value: undefined]
     ) => void;
   },
-  answers: NoInfer<Prettify<Partial<A>>>,
+  answers: NoInfer<Partial<A>>,
 ) => void | T | Promise<T>;
 
 type MaybeAsyncValue<T, A extends Answers> = T | AsyncGetterFunction<T, A>;
@@ -179,11 +179,9 @@ export type PromptModuleNamedQuestion<
   A extends Answers,
   Prompts extends Record<string, Record<string, any>> = never,
   Flat extends Answers = A,
-> = Prettify<
-  PromptModuleSpecificQuestion<A, Prompts> & {
-    name: Extract<keyof Flat, string>;
-  }
->;
+> = PromptModuleSpecificQuestion<A, Prompts> & {
+  name: Extract<keyof Flat, string>;
+};
 
 export type DistinctQuestion<A extends Answers = Answers> = PromptModuleNamedQuestion<A>;
 

--- a/packages/type/src/utils.ts
+++ b/packages/type/src/utils.ts
@@ -2,9 +2,22 @@
 
 type Key = string | number | symbol;
 
-export type Prettify<T> = {
-  [K in keyof T]: T[K];
-} & {};
+/**
+ * Recursively expand intersections and mapped types for better IDE display,
+ * while preserving functions, arrays, primitives, and types with a string
+ * index signature (e.g. `Record<string, ...>`) as-is.
+ */
+export type Prettify<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends ReadonlyArray<unknown>
+    ? T
+    : T extends string | number | boolean | symbol | bigint | null | undefined
+      ? T
+      : T extends object
+        ? string extends keyof T
+          ? T
+          : { [K in keyof T]: Prettify<T[K]> } & {}
+        : T;
 
 export type PartialDeep<T> = T extends object
   ? {


### PR DESCRIPTION
## Summary

Expand the types surfaced by prompts and themes so the IDE shows readable object shapes instead of opaque generic references.

### `makeTheme` — theme type is now fully flattened

Before:
```ts
const theme = makeTheme<SelectTheme>();
// style: { disabled: (text: string) => string } & { answer: ...; message: ...; ... }
```

After:
```ts
const theme = makeTheme<SelectTheme>();
// style: { disabled: ...; answer: ...; message: ...; ... }  // flattened
// prefix: string | Omit<Record<Status, string>, "loading">
```

### Prompts — config keys are expanded in the IDE

Before:
```ts
<const Value>(config: SelectConfig<Value>, context?: Context | undefined) => Promise<Value>
```

After:
```ts
<const Value>(config: {
  message: string;
  choices: readonly (Separator | Value | Choice<Value>)[];
  pageSize?: number | undefined;
  loop?: boolean | undefined;
  default?: NoInfer<Value> | undefined;
  theme?: {...} | undefined;
} & SelectConfig<Value>, context?: Context | undefined) => Promise<Value>
```

## Approach

- **`Prettify` is now recursive** (deep): it expands intersections and mapped types while preserving functions, arrays, primitives, and string-indexed records. `makeTheme` returns `Prettify<Theme<SpecificTheme>>`, flattening nested intersections like the `style` merge.
- **`createPrompt` returns `Prompt<Value, ShallowPrettify<Config> & Config>`**: a shallow prettify (top-level keys only) intersected with the original config expands the config for display while staying assignable to `Config` — no internal cast, and consumers like `i18n` that extract config types stay compatible.
- **Removed `Prettify` from generic usages** where a recursive conditional on a generic type parameter is deferred and breaks assignability: `create-prompt` view, `use-pagination` layout, `Theme`, and `inquirer`'s `PromptReturnType` / `AsyncGetterFunction` / `PromptModuleNamedQuestion`.

## Why shallow + `& Config` for prompts (not deep)?

A deep `Prettify<Config> & Config` double-wraps nested generic fields (e.g. `number`'s `required?: Required` becomes `Prettify<Prettify<Required> & Required>`), which breaks `i18n` when it re-passes config objects. The shallow version expands only the top-level keys and leaves nested generics untouched.

## Commands run

- `yarn tsc`
- `yarn vitest --run packages`
- `yarn oxfmt --check .`
- `yarn oxlint .`
- `yarn eslint .`
