### PR TITLE
fix(@inquirer/testing): keep keypress simulation working under TERM=dumb

### DIFF
--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import input from '@inquirer/input';
+import { render } from './index.ts';
+
+// Restore the original environment between tests.
+let savedTerm: string | undefined;
+afterEach(() => {
+  if (savedTerm === undefined) delete process.env['TERM'];
+  else process.env['TERM'] = savedTerm;
+});
+
+describe('render()', () => {
+  it('keeps keypress simulation working under TERM=dumb', async () => {
+    // Node's readline disables line editing when TERM=dumb. `render()` must
+    // not inherit that degraded mode, or backspace/arrow keypresses become
+    // no-ops and the prompt state never updates.
+    // @see https://github.com/SBoudrias/Inquirer.js/issues/2180
+    savedTerm = process.env['TERM'];
+    process.env['TERM'] = 'dumb';
+
+    const { answer, events } = await render(input, { message: 'Question?' });
+    expect(process.env['TERM']).toBe('dumb');
+
+    events.type('12');
+    events.keypress('backspace');
+    events.type('3');
+    events.keypress('enter');
+
+    expect(await answer).toBe('13'); // backspace deleted the '2'
+  });
+});

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -29,7 +29,21 @@ export async function render<Value, const Config>(
   const output = new BufferedStream();
   const firstRender = new Promise<void>((resolve) => output.once('render', resolve));
 
-  const answer = prompt(config, { ...options, input, output });
+  // Node's readline disables line editing (backspace, arrows, etc.) when
+  // `TERM=dumb` is set, regardless of whether the input is a real terminal.
+  // Environments like GitLab CI or Emacs shells set `TERM=dumb`, which would
+  // silently break the keypress simulation below. The check only happens when
+  // the readline interface is created (synchronously inside `prompt()`), so
+  // overriding `TERM` for the prompt construction alone is sufficient.
+  // @see https://github.com/SBoudrias/Inquirer.js/issues/2180
+  const savedTerm = process.env['TERM'];
+  if (savedTerm === 'dumb') process.env['TERM'] = 'xterm-256color';
+  let answer: Promise<Value>;
+  try {
+    answer = prompt(config, { ...options, input, output });
+  } finally {
+    if (savedTerm === 'dumb') process.env['TERM'] = 'dumb';
+  }
 
   // The first render is synchronous. If our BufferedStream received a write, we're ready.
   if (output.writeCount === 0) {


### PR DESCRIPTION
## Description

Fixes #2180.

When `TERM=dumb` is set in the environment (GitLab CI shells, Emacs shell buffers, some IDE test runners), Node's readline swaps `_ttyWrite` for `_ttyWriteDumb`, which disables all line editing — backspace, arrows, home/end become no-ops, and raw sequences get inserted as characters. This silently breaks `events.keypress('backspace')` & co. in `@inquirer/testing`, regardless of Node version.

**Not a Node regression**: `_ttyWriteDumb` has shipped since Node 12; the issue's exact failure set (number: 8, input: 6, rawlist: 1) reproduces on Node 24 with `TERM=dumb` and passes on 25.9/26.8 with a normal `TERM`. No runtime impact for real CLI users — this only affects test environments.

Since the `TERM` check only runs once (when the readline interface is created synchronously inside `prompt()`), `render()` now temporarily overrides `TERM` during prompt construction and restores it immediately after.

## Commands run

- `TERM=dumb yarn vitest run packages/testing packages/number packages/input packages/rawlist` → 59 passed (previously 15 failures)
- `yarn vitest run packages` → 418 passed | 1 skipped
- `yarn tsc --noEmit -p packages/testing` → clean
- `npx oxlint packages/testing && npx eslint packages/testing` → clean
- `npx oxfmt --check packages/testing/src/` → clean