### PR TITLE
fix: pin @inquirer/type to exact versions in published manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,9 @@ The push to `main` triggers `.github/workflows/publish.yml`. A `guard` job check
 2. **build** — `yarn tsc`
 3. **publish** — `yarn lerna publish from-git --stage --yes --no-git-reset`
 
-`lerna publish from-git` stages every package tagged at HEAD (all tags created by `lerna version` point at the same commit). lerna-lite applies the `publishConfig` manifest overrides (main/types/exports) natively, runs the `prepublishOnly` build and the root `prepack` (workspace devDependency strip, README utm rewrite), and stages each package via OIDC Trusted Publishing. The packages are now **staged**, not live.
+`lerna publish from-git` stages every package tagged at HEAD (all tags created by `lerna version` point at the same commit). lerna-lite applies the `publishConfig` manifest overrides (main/types/exports) natively, runs the `prepublishOnly` build and the root `prepack` (README utm rewrite, `package normalize` manifest fixups, exact `@inquirer/type` pin), and stages each package via OIDC Trusted Publishing. The packages are now **staged**, not live.
+
+The `@inquirer/type` dependency is pinned to an exact version in published manifests (`package pin @inquirer/type` runs at `prepack` time). TypeScript type definitions leak into consumers' `tsc` runs, so a semver range on a types package can break downstream builds without any change to the Inquirer.js source (see [#2244](https://github.com/SBoudrias/Inquirer.js/issues/2244)).
 
 Forgot `--follow-tags`? Push the tags afterwards (`git push origin <tag>...`), then re-run the publish workflow on the release commit from the Actions tab — `from-git` reads the tags at that commit, so it will pick them up on the re-run.
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dev": "turbo watch tsc",
     "postinstall": "git config --local include.path ../.gitconfig || true",
     "prepublishOnly": "yarn tsc",
-    "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i.bak -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1 -type f -name 'README*.bak' -delete && find packages/* -maxdepth 1  -type f -name package.json -exec sh -c 'jq \".devDependencies |= with_entries(select(.value != \\\"workspace:*\\\"))\" \"$1\" > \"$1.tmp\" && mv \"$1.tmp\" \"$1\"' _ {} \\;",
+    "prepack": "find packages/* -maxdepth 1 -type f -name 'README*' -exec sed -i.bak -e 's/utm_source=github/utm_source=npmjs/g' {} + && find packages/* -maxdepth 1 -type f -name 'README*.bak' -delete && package normalize && package pin @inquirer/type",
     "postpack": "git -c hook.auto-install.event= restore packages/*/README.md",
     "setup": "setup-packages && package lint && oxfmt . --no-error-on-unmatched-pattern",
     "pretest": "yarn tsc && oxlint . && oxfmt --check . && eslint .",

--- a/tools/package/README.md
+++ b/tools/package/README.md
@@ -43,7 +43,17 @@ bun add @sboudrias/package --dev
 </tr>
 </table>
 
-# Usage
+# Commands
+
+| Command                                               | Description                                                   |
+| ----------------------------------------------------- | ------------------------------------------------------------- |
+| [`package lint`](#package-lint)                       | Validate and fix package metadata.                            |
+| [`package normalize`](#package-normalize)             | Fix workspace manifests so they are valid for npm publishing. |
+| [`package pin <dependency>`](#package-pin-dependency) | Pin exact versions of a workspace dependency.                 |
+
+All commands operate on public workspace packages (see [Workspace Discovery](#workspace-discovery)) and write manifests in place.
+
+## package lint
 
 ```bash
 package lint
@@ -57,15 +67,13 @@ package lint --check
 
 `package lint --check` runs the same validation without writing files. It exits non-zero when any package needs a fix or has a manual conflict.
 
-# Lint Rules
-
-## Valid Peer Dependencies
+### Valid Peer Dependencies
 
 Runtime dependencies can declare their own peer dependencies. `package lint` makes those peer requirements visible on the package that uses the runtime dependency.
 
 It adds missing peers to `peerDependencies` and copies matching `peerDependenciesMeta` entries so optional peers stay optional.
 
-## Matching engines
+### Matching engines
 
 Packages should only advertise Node.js support that their runtime dependencies can also support.
 
@@ -73,16 +81,40 @@ Packages should only advertise Node.js support that their runtime dependencies c
 
 That failure is intentional. Bumping a dependency can raise the minimum supported Node.js version and break dependants that still install the package under the previous `engines.node` range. In that case, manually narrow the package engine range or choose a compatible dependency version.
 
-## Ensure package.json is exposed
+### Ensure package.json is exposed
 
 Packages should expose their manifest for tools that inspect package metadata at runtime.
 
 `package lint` ensures public packages expose `"./package.json": "./package.json"` in `exports`.
 
+## package normalize
+
+```bash
+package normalize
+```
+
+`package normalize` applies every manifest fixup required to make public workspace packages valid for npm publishing, in place.
+
+Currently it removes dev dependencies declared with the `workspace:*` protocol: those specs only resolve inside the workspace and are invalid once the package is published, so they must be stripped from the manifest before it is packed. Dev dependencies with other specs are left untouched.
+
+As new npm-validity issues are identified, their fixups join this command instead of the calling pipeline. The Inquirer.js release pipeline runs it at `prepack` time, right before packing the tarballs.
+
+## package pin <dependency>
+
+```bash
+package pin <dependency>
+```
+
+`package pin <dependency>` rewrites semver ranges (`^1.2.3`, `~1.2.3`) of the given dependency to exact versions (`1.2.3`) across all public workspace packages, in place.
+
+Exact specs, `workspace:` protocols, and dev dependencies are left untouched. It exits non-zero when a range cannot be resolved to a single exact version (e.g. `>=1.0.0`, `1.x`); such ranges must be fixed manually.
+
+The Inquirer.js release pipeline uses this at `prepack` time to pin `@inquirer/type` exactly in published manifests: type-only dependencies leak into consumers' `.d.ts` compilation, so an uncontrolled range can break downstream TypeScript builds even when the runtime behavior is unchanged.
+
 # Workspace Discovery
 
 The CLI discovers workspaces from `package.json` `workspaces` fields and `pnpm-workspace.yaml` files.
 
-If no workspaces are configured, the root `package.json` is linted as a single-package project.
+If no workspaces are configured, the root `package.json` is treated as a single-package project.
 
 Private packages are ignored by default.

--- a/tools/package/src/bin.ts
+++ b/tools/package/src/bin.ts
@@ -1,42 +1,10 @@
 #!/usr/bin/env node
-import { Builtins, Cli, Command, Option } from 'clipanion';
-import { lintPackages } from './lint.ts';
+import { Builtins, Cli } from 'clipanion';
+import { LintCommand } from './lint/command.ts';
+import { NormalizeCommand } from './normalize/command.ts';
+import { PinCommand } from './pin/command.ts';
 
-class LintCommand extends Command {
-  static override paths = [['lint']];
-
-  static override usage = Command.Usage({
-    description: 'Validate and fix package metadata.',
-    examples: [
-      ['Fix package metadata', '$0 lint'],
-      ['Validate package metadata without writing files', '$0 lint --check'],
-    ],
-  });
-
-  check = Option.Boolean('--check', false, {
-    description: 'Validate package metadata without writing files.',
-  });
-
-  override async execute() {
-    try {
-      const result = await lintPackages({ check: this.check });
-      for (const issue of result.issues) {
-        this.context.stderr.write(
-          `[${issue.status}] ${issue.message} (${issue.packagePath})\n`,
-        );
-      }
-
-      return result.hasFailures ? 1 : 0;
-    } catch (error: unknown) {
-      this.context.stderr.write(
-        `${error instanceof Error ? error.message : String(error)}\n`,
-      );
-      return 1;
-    }
-  }
-}
-
-const cli = Cli.from([LintCommand, Builtins.HelpCommand], {
+const cli = Cli.from([LintCommand, NormalizeCommand, PinCommand, Builtins.HelpCommand], {
   binaryLabel: 'Package',
   binaryName: 'package',
   enableCapture: false,

--- a/tools/package/src/index.ts
+++ b/tools/package/src/index.ts
@@ -1,1 +1,3 @@
-export { lintPackages } from './lint.ts';
+export { lintPackages } from './lint/index.ts';
+export { normalizeManifests } from './normalize/index.ts';
+export { pinDependencies } from './pin/index.ts';

--- a/tools/package/src/lint/command.ts
+++ b/tools/package/src/lint/command.ts
@@ -1,0 +1,36 @@
+import { Command, Option } from 'clipanion';
+import { lintPackages } from './index.ts';
+
+export class LintCommand extends Command {
+  static override paths = [['lint']];
+
+  static override usage = Command.Usage({
+    description: 'Validate and fix package metadata.',
+    examples: [
+      ['Fix package metadata', '$0 lint'],
+      ['Validate package metadata without writing files', '$0 lint --check'],
+    ],
+  });
+
+  check = Option.Boolean('--check', false, {
+    description: 'Validate package metadata without writing files.',
+  });
+
+  override async execute() {
+    try {
+      const result = await lintPackages({ check: this.check });
+      for (const issue of result.issues) {
+        this.context.stderr.write(
+          `[${issue.status}] ${issue.message} (${issue.packagePath})\n`,
+        );
+      }
+
+      return result.hasFailures ? 1 : 0;
+    } catch (error: unknown) {
+      this.context.stderr.write(
+        `${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return 1;
+    }
+  }
+}

--- a/tools/package/src/lint/index.test.ts
+++ b/tools/package/src/lint/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { lintPackages } from './lint.ts';
+import { lintPackages } from './index.ts';
 
 const tempDirs: string[] = [];
 

--- a/tools/package/src/lint/index.ts
+++ b/tools/package/src/lint/index.ts
@@ -4,9 +4,9 @@ import type { PackageJson } from 'type-fest';
 import {
   applyPeerDependencyHoists,
   getPeerDependencyHoists,
-} from './peer-dependencies.ts';
-import { resolveDependencyPackageJson, writePackageJsonFile } from './package-json.ts';
-import { readWorkspaceProject } from './workspaces.ts';
+} from '../peer-dependencies.ts';
+import { resolveDependencyPackageJson, writePackageJsonFile } from '../package-json.ts';
+import { readWorkspaceProject } from '../workspaces.ts';
 
 function nodeEngine(pkg: PackageJson) {
   const node = pkg.engines?.['node'];

--- a/tools/package/src/normalize/command.ts
+++ b/tools/package/src/normalize/command.ts
@@ -1,0 +1,30 @@
+import { Command } from 'clipanion';
+import { normalizeManifests } from './index.ts';
+
+export class NormalizeCommand extends Command {
+  static override paths = [['normalize']];
+
+  static override usage = Command.Usage({
+    description: 'Fix workspace manifests so they are valid for npm publishing.',
+    examples: [['Fix manifests before packing tarballs', '$0 normalize']],
+  });
+
+  override async execute() {
+    try {
+      const fixups = await normalizeManifests();
+
+      for (const fixup of fixups) {
+        this.context.stdout.write(
+          `[fixed] ${fixup.name}: removed workspace dev dependency ${fixup.dependencyName}.\n`,
+        );
+      }
+
+      return 0;
+    } catch (error: unknown) {
+      this.context.stderr.write(
+        `${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return 1;
+    }
+  }
+}

--- a/tools/package/src/normalize/index.test.ts
+++ b/tools/package/src/normalize/index.test.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { normalizeManifests } from './index.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+async function makeTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'package-prepublish-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJson(filepath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filepath), { recursive: true });
+  await fs.writeFile(filepath, JSON.stringify(value, null, 2) + '\n');
+}
+
+async function readJson(filepath: string) {
+  return JSON.parse(await fs.readFile(filepath, 'utf8')) as unknown;
+}
+
+async function writeRootPackage(cwd: string) {
+  await writeJson(path.join(cwd, 'package.json'), {
+    name: 'root',
+    private: true,
+    workspaces: ['packages/*'],
+  });
+}
+
+describe('normalizeManifests', () => {
+  it('removes workspace-protocol dev dependencies from public packages', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/app/package.json');
+    await writeJson(packagePath, {
+      name: 'app',
+      version: '1.0.0',
+      dependencies: {
+        chalk: '^5.3.0',
+      },
+      devDependencies: {
+        '@repo/tsconfig': 'workspace:*',
+        '@inquirer/testing': 'workspace:*',
+        typescript: '^5.8.2',
+        '@repo/custom-config': 'workspace:^1.0.0',
+      },
+    });
+
+    const result = await normalizeManifests({ cwd });
+
+    expect(result).toEqual([
+      {
+        kind: 'remove-workspace-dev-dependency',
+        packagePath: 'packages/app/package.json',
+        name: 'app',
+        dependencyName: '@repo/tsconfig',
+      },
+      {
+        kind: 'remove-workspace-dev-dependency',
+        packagePath: 'packages/app/package.json',
+        name: 'app',
+        dependencyName: '@inquirer/testing',
+      },
+    ]);
+    expect(await readJson(packagePath)).toMatchObject({
+      dependencies: { chalk: '^5.3.0' },
+      devDependencies: {
+        typescript: '^5.8.2',
+        '@repo/custom-config': 'workspace:^1.0.0',
+      },
+    });
+  });
+
+  it('empties the devDependencies field when every entry uses the workspace protocol', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/app/package.json');
+    await writeJson(packagePath, {
+      name: 'app',
+      version: '1.0.0',
+      devDependencies: {
+        '@repo/tsconfig': 'workspace:*',
+      },
+    });
+
+    await normalizeManifests({ cwd });
+
+    expect(await readJson(packagePath)).toMatchObject({
+      devDependencies: {},
+    });
+  });
+
+  it('ignores private packages and packages without dev dependencies', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const privatePath = path.join(cwd, 'packages/private/package.json');
+    const cleanPath = path.join(cwd, 'packages/clean/package.json');
+    await writeJson(privatePath, {
+      name: 'private-package',
+      private: true,
+      version: '1.0.0',
+      devDependencies: {
+        '@repo/tsconfig': 'workspace:*',
+      },
+    });
+    await writeJson(cleanPath, {
+      name: 'clean',
+      version: '1.0.0',
+    });
+
+    const result = await normalizeManifests({ cwd });
+
+    expect(result).toEqual([]);
+    expect(await readJson(privatePath)).toMatchObject({
+      devDependencies: { '@repo/tsconfig': 'workspace:*' },
+    });
+  });
+
+  it('is a no-op when there is nothing to fix', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/app/package.json');
+    const original = {
+      name: 'app',
+      version: '1.0.0',
+      devDependencies: {
+        typescript: '^5.8.2',
+      },
+    };
+    await writeJson(packagePath, original);
+
+    const result = await normalizeManifests({ cwd });
+
+    expect(result).toEqual([]);
+    expect(await readJson(packagePath)).toEqual(original);
+  });
+});

--- a/tools/package/src/normalize/index.ts
+++ b/tools/package/src/normalize/index.ts
@@ -1,0 +1,72 @@
+import path from 'node:path';
+import { writePackageJsonFile } from '../package-json.ts';
+import { readWorkspaceProject, type WorkspacePackage } from '../workspaces.ts';
+
+export type ManifestFixup = {
+  kind: 'remove-workspace-dev-dependency';
+  packagePath: string;
+  name: string;
+  dependencyName: string;
+};
+
+type PackageFixup = (pkg: WorkspacePackage) => ManifestFixup[];
+
+/**
+ * Removes dev dependencies declared with the `workspace:*` protocol. Those
+ * specs only resolve inside the workspace and are invalid once the package is
+ * published, so they must be stripped from the manifest before it is packed
+ * into the tarball. Dev dependencies with other specs are left untouched.
+ */
+function fixWorkspaceDevDependencies(pkg: WorkspacePackage): ManifestFixup[] {
+  const { packageJson, packagePath } = pkg;
+  if (packageJson.private === true) return [];
+
+  const name = packageJson.name ?? packagePath;
+  const devDependencies = packageJson.devDependencies;
+  if (devDependencies == null) return [];
+
+  const entries = Object.entries(devDependencies);
+  const kept = entries.filter(([, spec]) => spec !== 'workspace:*');
+  if (kept.length === entries.length) return [];
+
+  packageJson.devDependencies = Object.fromEntries(kept);
+
+  return entries.flatMap(([dependencyName, spec]) =>
+    spec === 'workspace:*'
+      ? [
+          {
+            kind: 'remove-workspace-dev-dependency' as const,
+            packagePath,
+            name,
+            dependencyName,
+          },
+        ]
+      : [],
+  );
+}
+
+const FIXUPS: PackageFixup[] = [fixWorkspaceDevDependencies];
+
+/**
+ * Applies every manifest fixup required to make public workspace packages
+ * valid for npm publishing. Run before packing tarballs.
+ */
+export async function normalizeManifests(
+  options: { cwd?: string } = {},
+): Promise<ManifestFixup[]> {
+  const cwd = options.cwd ?? process.cwd();
+  const { packages } = await readWorkspaceProject(cwd);
+
+  const fixups = packages.flatMap((pkg) => FIXUPS.flatMap((fixup) => fixup(pkg)));
+
+  const changedPackagePaths = new Set(fixups.map((fixup) => fixup.packagePath));
+  await Promise.all(
+    packages
+      .filter(({ packagePath }) => changedPackagePaths.has(packagePath))
+      .map(({ packageJson, packagePath }) =>
+        writePackageJsonFile(path.join(cwd, packagePath), packageJson),
+      ),
+  );
+
+  return fixups;
+}

--- a/tools/package/src/pin/command.ts
+++ b/tools/package/src/pin/command.ts
@@ -1,0 +1,39 @@
+import { Command, Option } from 'clipanion';
+import { pinDependencies } from './index.ts';
+
+export class PinCommand extends Command {
+  static override paths = [['pin']];
+
+  static override usage = Command.Usage({
+    description: 'Pin exact versions of workspace dependencies.',
+    examples: [['Pin a dependency across all public packages', '$0 pin @inquirer/type']],
+  });
+
+  dependencyName = Option.String({ required: true });
+
+  override async execute() {
+    try {
+      const result = await pinDependencies({
+        dependencyNames: [this.dependencyName],
+      });
+
+      for (const pin of result.pinned) {
+        this.context.stdout.write(
+          `[fixed] ${pin.name}: pinned ${pin.dependencyName} from "${pin.range}" to "${pin.exact}".\n`,
+        );
+      }
+      for (const unpinnable of result.unpinnable) {
+        this.context.stderr.write(
+          `[error] ${unpinnable.name} declares ${unpinnable.dependencyName} with an unsupported range "${unpinnable.range}" (${unpinnable.packagePath})\n`,
+        );
+      }
+
+      return result.unpinnable.length > 0 ? 1 : 0;
+    } catch (error: unknown) {
+      this.context.stderr.write(
+        `${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      return 1;
+    }
+  }
+}

--- a/tools/package/src/pin/index.test.ts
+++ b/tools/package/src/pin/index.test.ts
@@ -1,0 +1,190 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { pinDependencies } from './index.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+async function makeTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'package-pin-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJson(filepath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filepath), { recursive: true });
+  await fs.writeFile(filepath, JSON.stringify(value, null, 2) + '\n');
+}
+
+async function readJson(filepath: string) {
+  return JSON.parse(await fs.readFile(filepath, 'utf8')) as unknown;
+}
+
+async function writeRootPackage(cwd: string) {
+  await writeJson(path.join(cwd, 'package.json'), {
+    name: 'root',
+    private: true,
+    workspaces: ['packages/*'],
+  });
+}
+
+describe('pinDependencies', () => {
+  it('pins caret and tilde ranges to exact versions', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/app/package.json');
+    await writeJson(packagePath, {
+      name: 'app',
+      version: '1.0.0',
+      dependencies: {
+        '@inquirer/type': '^4.1.0',
+        chalk: '~5.3.0',
+        lodash: '^4.17.21',
+      },
+    });
+
+    const result = await pinDependencies({
+      cwd,
+      dependencyNames: ['@inquirer/type', 'chalk'],
+    });
+
+    expect(result.unpinnable).toEqual([]);
+    expect(await readJson(packagePath)).toMatchObject({
+      dependencies: {
+        '@inquirer/type': '4.1.0',
+        chalk: '5.3.0',
+        lodash: '^4.17.21',
+      },
+    });
+    expect(result.pinned).toEqual([
+      {
+        packagePath: 'packages/app/package.json',
+        name: 'app',
+        dependencyName: '@inquirer/type',
+        range: '^4.1.0',
+        exact: '4.1.0',
+      },
+      {
+        packagePath: 'packages/app/package.json',
+        name: 'app',
+        dependencyName: 'chalk',
+        range: '~5.3.0',
+        exact: '5.3.0',
+      },
+    ]);
+  });
+
+  it('pins optional dependencies and leaves dev dependencies alone', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/app/package.json');
+    await writeJson(packagePath, {
+      name: 'app',
+      version: '1.0.0',
+      dependencies: {},
+      optionalDependencies: {
+        '@inquirer/type': '^4.1.0',
+      },
+      devDependencies: {
+        '@inquirer/type': '^4.1.0',
+      },
+    });
+
+    const result = await pinDependencies({ cwd, dependencyNames: ['@inquirer/type'] });
+
+    expect(result.pinned.map((pin) => pin.exact)).toEqual(['4.1.0']);
+    expect(await readJson(packagePath)).toMatchObject({
+      optionalDependencies: { '@inquirer/type': '4.1.0' },
+      devDependencies: { '@inquirer/type': '^4.1.0' },
+    });
+  });
+
+  it('is a no-op for exact specs, workspace protocols, and untouched packages', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const pinnedPath = path.join(cwd, 'packages/pinned/package.json');
+    const untouchedPath = path.join(cwd, 'packages/untouched/package.json');
+    const originalPinned = {
+      name: 'pinned',
+      version: '1.0.0',
+      dependencies: {
+        '@inquirer/type': '4.1.0',
+      },
+    };
+    await writeJson(pinnedPath, originalPinned);
+    await writeJson(untouchedPath, {
+      name: 'untouched',
+      version: '1.0.0',
+      dependencies: {
+        chalk: '^5.3.0',
+      },
+      devDependencies: {
+        '@inquirer/type': 'workspace:^4.1.0',
+      },
+    });
+
+    const result = await pinDependencies({ cwd, dependencyNames: ['@inquirer/type'] });
+
+    expect(result.pinned).toEqual([]);
+    expect(result.unpinnable).toEqual([]);
+    expect(await readJson(pinnedPath)).toEqual(originalPinned);
+    expect(await readJson(untouchedPath)).toMatchObject({
+      dependencies: { chalk: '^5.3.0' },
+    });
+  });
+
+  it('reports ranges that cannot be pinned to an exact version', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/app/package.json');
+    await writeJson(packagePath, {
+      name: 'app',
+      version: '1.0.0',
+      dependencies: {
+        '@inquirer/type': '>=4.0.0',
+      },
+    });
+
+    const result = await pinDependencies({ cwd, dependencyNames: ['@inquirer/type'] });
+
+    expect(result.pinned).toEqual([]);
+    expect(result.unpinnable).toEqual([
+      {
+        packagePath: 'packages/app/package.json',
+        name: 'app',
+        dependencyName: '@inquirer/type',
+        range: '>=4.0.0',
+      },
+    ]);
+    expect(await readJson(packagePath)).toMatchObject({
+      dependencies: { '@inquirer/type': '>=4.0.0' },
+    });
+  });
+
+  it('ignores private workspace packages', async () => {
+    const cwd = await makeTempDir();
+    await writeRootPackage(cwd);
+    const packagePath = path.join(cwd, 'packages/private/package.json');
+    await writeJson(packagePath, {
+      name: 'private-package',
+      private: true,
+      version: '1.0.0',
+      dependencies: {
+        '@inquirer/type': '^4.1.0',
+      },
+    });
+
+    const result = await pinDependencies({ cwd, dependencyNames: ['@inquirer/type'] });
+
+    expect(result.pinned).toEqual([]);
+    expect(await readJson(packagePath)).toMatchObject({
+      dependencies: { '@inquirer/type': '^4.1.0' },
+    });
+  });
+});

--- a/tools/package/src/pin/index.ts
+++ b/tools/package/src/pin/index.ts
@@ -1,0 +1,90 @@
+import path from 'node:path';
+import { valid as validVersion } from 'semver';
+import { writePackageJsonFile } from '../package-json.ts';
+import { readWorkspaceProject } from '../workspaces.ts';
+
+const DEPENDENCY_FIELDS = ['dependencies', 'optionalDependencies'] as const;
+
+export type PinnedDependency = {
+  packagePath: string;
+  name: string;
+  dependencyName: string;
+  range: string;
+  exact: string;
+};
+
+export type UnpinnableDependency = {
+  packagePath: string;
+  name: string;
+  dependencyName: string;
+  range: string;
+};
+
+export type PinDependenciesResult = {
+  pinned: PinnedDependency[];
+  unpinnable: UnpinnableDependency[];
+};
+
+/**
+ * Rewrites semver ranges (`^1.2.3`, `~1.2.3`) of the given dependencies to
+ * exact versions (`1.2.3`) across all public workspace packages.
+ *
+ * Exact specs and `workspace:` protocols are left untouched. Ranges that
+ * cannot be resolved to a single exact version (e.g. `>=1.0.0`, `1.x`) are
+ * reported as unpinnable and must be fixed manually.
+ */
+export async function pinDependencies(options: {
+  cwd?: string;
+  dependencyNames: string[];
+}): Promise<PinDependenciesResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const dependencyNames = [...new Set(options.dependencyNames)];
+  const { packages } = await readWorkspaceProject(cwd);
+
+  const pinned: PinnedDependency[] = [];
+  const unpinnable: UnpinnableDependency[] = [];
+
+  for (const { packageJson, packagePath } of packages) {
+    if (packageJson.private === true) continue;
+    const name = packageJson.name ?? packagePath;
+
+    for (const field of DEPENDENCY_FIELDS) {
+      const dependencies = packageJson[field];
+      if (dependencies == null) continue;
+
+      for (const dependencyName of dependencyNames) {
+        const range = dependencies[dependencyName];
+        if (typeof range !== 'string' || range.startsWith('workspace:')) {
+          continue;
+        }
+
+        if (!/^[~^]/.test(range)) {
+          if (validVersion(range) == null) {
+            unpinnable.push({ packagePath, name, dependencyName, range });
+          }
+          continue;
+        }
+
+        const exact = range.slice(1);
+        if (validVersion(exact) == null) {
+          unpinnable.push({ packagePath, name, dependencyName, range });
+          continue;
+        }
+
+        dependencies[dependencyName] = exact;
+        pinned.push({ packagePath, name, dependencyName, range, exact });
+      }
+    }
+  }
+
+  const changedPackagePaths = new Set(pinned.map((pin) => pin.packagePath));
+  await Promise.all(
+    packages
+      .filter(({ packagePath }) => changedPackagePaths.has(packagePath))
+      .map(({ packageJson, packagePath }) =>
+        writePackageJsonFile(path.join(cwd, packagePath), packageJson),
+      ),
+  );
+
+  return { pinned, unpinnable };
+}


### PR DESCRIPTION
## What & why

Fixes the class of breakage reported in #2244: `@inquirer/type@4.1.0` changed `Prettify<T>` to a recursive conditional type, which broke `tsc` (with `skipLibCheck: false`) for users of the *already published* `inquirer@13`, because its manifest declares `"@inquirer/type": "^4.0.5"` and a fresh install resolved `4.1.0`.

Type-only dependencies leak into consumers' `.d.ts` compilation, so a semver range on them can break downstream builds without any change to the Inquirer.js source. This PR guarantees every package published from now on ships an **exact** `@inquirer/type` version.

## Why not lerna's `exact` option

- `exact: true` is all-or-nothing: it pins **every** internal dependency (`@inquirer/core`, `figures`, `ansi`, ...), not just `@inquirer/type`.
- Hand-pinning in git manifests doesn't survive either: lerna-lite's `updateLocalDependency()` rewrites any spec to `${savePrefix}${version}` (`^x.y.z`) the next time the dependency is versioned, so an exact spec would be clobbered back to a range at the next release.

## Implementation

Pinning happens at **`prepack` time**, which already rewrites manifests right before the tarballs are staged (same hook that rewrites README utm params today). All manifest fixups now live in `@sboudrias/package` so they share one implementation, workspace discovery, and test coverage:

- **`package normalize`** — applies every manifest fixup required to make public workspace packages valid for npm publishing. Today that means replacing the inline `jq` prepack step: removing `workspace:*` dev dependencies from public workspace packages before packing. Verified to produce **byte-identical manifests** to the old jq step, and it now also covers the published `tools/*` packages, which the jq glob (`packages/*` only) never touched. Future npm-validity fixups join this command instead of the release pipeline.
- **`package pin <dependency>`** — rewrites `^x.y.z` / `~x.y.z` specs to `x.y.z` across public workspace packages (`dependencies` / `optionalDependencies`). Idempotent; skips dev dependencies, `workspace:` protocols, and already-exact specs. Exits non-zero on ranges it cannot pin (e.g. `>=4.0.0`, `4.x`) so bad specs surface at release time.
- Root `prepack` now reads: README utm rewrite → `package normalize` → `package pin @inquirer/type`.
- Refactor: each command lives in its own module under `tools/package/src/<command>/` with an `index.ts` (implementation) and a `command.ts` (CLI class), tests colocated; `bin.ts` only assembles the CLI. The manifest-fixup command is named `normalize` (it runs during the `prepack` phase, so npm lifecycle names like `prepublish` would be misleading).
- Git manifests keep caret ranges — `lerna version` and yarn workspace resolution are untouched; only the **published** manifests change.

## Commands run

- `yarn pretest` (tsc + oxlint + oxfmt + eslint) — passes
- `yarn test` (vitest + integration suites) — passes; 21 unit tests for `@sboudrias/package` (4 new for `pin`, 4 new for `normalize`)
- `package normalize` + `package pin @inquirer/type` dry-run against a copy of the real manifests: all 13 runtime `@inquirer/type` specs pinned to `4.1.0` (only `@inquirer/prompts`' inert devDependency stays ranged) and normalize output identical to the previous jq behavior.

## Caveat

This does not fix the already-published packages (`inquirer@13`'s `^4.0.5` is immutable); #2244 still needs its patch release. This change prevents recurrence from the next release onward. If we want the same protection for `@inquirer/core` (its types also surface in consumers' `.d.ts`), it's one more `package pin @inquirer/core` call in `prepack`.

Closes #2244
