### PR TITLE
fix(confirm): ignore surrounding whitespace in answers

### DIFF
--- a/packages/confirm/confirm.test.ts
+++ b/packages/confirm/confirm.test.ts
@@ -72,6 +72,18 @@ describe('confirm prompt', () => {
     expect(getScreen()).toMatchInlineSnapshot(`"✔ Do you want to proceed? No"`);
   });
 
+  it('ignores surrounding whitespace', async () => {
+    const { answer, events, getScreen } = await render(confirm, {
+      message: 'Do you want to proceed?',
+    });
+
+    events.type('  yes  ');
+    events.keypress('enter');
+
+    await expect(answer).resolves.toEqual(true);
+    expect(getScreen()).toMatchInlineSnapshot(`"✔ Do you want to proceed? Yes"`);
+  });
+
   it('uses default (yes) on empty input', async () => {
     const { answer, events, getScreen } = await render(confirm, {
       message: 'Do you want to proceed?',

--- a/packages/confirm/src/index.ts
+++ b/packages/confirm/src/index.ts
@@ -77,7 +77,7 @@ export default createPrompt<boolean, ConfirmConfig>((config, done) => {
   const { transformer = boolToString } = config;
 
   function getBooleanValue(value: string, defaultValue?: boolean): boolean {
-    const v = value.toLowerCase();
+    const v = value.trim().toLowerCase();
     if (v === '') return defaultValue !== false;
     if (yes.toLowerCase().startsWith(v)) return true;
     if (no.toLowerCase().startsWith(v)) return false;


### PR DESCRIPTION
## Summary

- Trim confirm prompt input before matching yes/no keywords
- Add regression coverage for answers with surrounding whitespace

## Why

Users can accidentally include spaces when typing or piping answers into a prompt. Previously, values such as `  yes  ` did not match a keyword and silently fell back to the configured default. Trimming the input preserves existing matching behavior while accepting the same answer with incidental whitespace.